### PR TITLE
Fixes ZEN-9972 (reviewed by epowell): Always show the process class name...

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/process.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/process.js
@@ -942,7 +942,8 @@ Ext.define("Zenoss.MatchProcessStore", {
     		        includeRegex: Ext.getCmp('regexIncludeTextField').getValue(),
 		        	excludeRegex: Ext.getCmp('regexExcludeTextField').getValue(),
 		        	replaceRegex: Ext.getCmp('regexReplaceTextField').getValue(),
-	        		replacement: Ext.getCmp('replacementTextField').getValue()
+	        		replacement: Ext.getCmp('replacementTextField').getValue(),
+	        		name: Ext.getCmp('nameTextField2').getValue()
     			});
     		}
     		this.setBaseParam("uids", uids);

--- a/Products/Zuul/facades/processfacade.py
+++ b/Products/Zuul/facades/processfacade.py
@@ -144,10 +144,7 @@ class ProcessFacade(TreeFacade):
                 for line in matchedLines:
                     i += 1
                     ii = str(i)
-                    if isinstance(processClass, OSProcessClassDataMatcher):
-                        name = processClass.includeRegex
-                    else:
-                        name = processClass.name
+                    name = processClass.name
                     yield {
                         'uid': ii,
                         'matched': True,


### PR DESCRIPTION
... instead of the include regex expression when testing a specific process class
