### PR TITLE
return UTC timezone correctly for fedora

### DIFF
--- a/Products/ZenUtils/Time.py
+++ b/Products/ZenUtils/Time.py
@@ -59,6 +59,9 @@ def getServerTimeZone():
         # some timezones like UTC are only one word so the directory will show up
         if tz.startswith("zoneinfo/"):
             tz = tz.replace("zoneinfo/", "")
+        # fedora timezones like UTC look like /etc/localtime -> /usr/share/zoneinfo/Etc/UTC
+        if tz.startswith("Etc/"):
+            tz = tz.replace("Etc/", "")
         SERVER_TIMEZONE = tz        
         return SERVER_TIMEZONE
     tzfile_digest = None


### PR DESCRIPTION
SERVER_TIMEZONE was being incorrectly set as "Etc/UTC" on fedora due to:
# root@6786fcf49555: ls -l /etc/localtime

lrwxrwxrwx 1 root root 27 Dec 17 12:36 /etc/localtime -> /usr/share/zoneinfo/Etc/UTC
