### PR TITLE
for CP daemons, find daemon pid with pgrep if pidfile does not exist

### DIFF
--- a/bin/zenfunctions
+++ b/bin/zenfunctions
@@ -205,6 +205,14 @@ debug() {
         echo "Sending SIGUSR1 to $PID"
         kill -s USR1 $PID 2>/dev/null || $PS | grep -q "^ *$PID$"
         return $?
+    elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
+        PIDS=`pgrep -f -- "--configfile $CFGFILE"`
+        if [ "$PIDS" ]; then
+                echo "Sending SIGUSR1 to PIDS: $PIDS"
+                kill -s USR1 $PIDS 2>/dev/null || ps -p $PIDS
+        else
+                echo "Unable to find process to send SIGUSR1 signal"
+        fi
     else
         echo "Unable to find process to send SIGUSR1 signal"
     fi
@@ -218,6 +226,14 @@ stats() {
         echo "Sending SIGUSR2 to $PID"
         kill -s USR2 $PID 2>/dev/null || $PS | grep -q "^ *$PID$"
         return $?
+    elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
+        PIDS=`pgrep -f -- "--configfile $CFGFILE"`
+        if [ "$PIDS" ]; then
+                echo "Sending SIGUSR2 to PIDS: $PIDS"
+                kill -s USR2 $PIDS 2>/dev/null || ps -p $PIDS
+        else
+                echo "Unable to find process to send SIGUSR2 signal"
+        fi
     else
         echo "Unable to find process to send SIGUSR2 signal"
     fi


### PR DESCRIPTION
DEMO:

```
[zenoss@f6233ee4d912 bin]$ ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 15:56 ?        00:00:02 /serviced/serviced proxy c3d98059-cc01-1c7b-818f-16a80f770730 su - zenoss -c "/opt/zenoss/bin/zenperfsnmp run -c --duallog "
root        18     1  0 15:56 ?        00:00:04 /usr/local/serviced/resources/logstash/logstash-forwarder -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root        22     1  0 15:56 ?        00:00:00 su - zenoss -c /opt/zenoss/bin/zenperfsnmp run -c --duallog 
zenoss      23    22  0 15:56 ?        00:00:14 /opt/zenoss/bin/python /opt/zenoss/Products/ZenRRD/zenperfsnmp.py --configfile /opt/zenoss/etc/zenperfsnmp.conf -c --duallog
root        57     0  0 16:27 ?        00:00:00 bash
root        58    57  0 16:27 ?        00:00:00 su - zenoss
zenoss      59    58  0 16:27 ?        00:00:00 -bash
root       164     0  0 16:48 ?        00:00:00 tail -F /opt/zenoss/log/zenperfsnmp.log
zenoss     296    59  0 17:42 ?        00:00:00 ps -wwef
[zenoss@f6233ee4d912 bin]$ grep CFGFILE /opt/zenoss/bin/zenperfsnmp 
CFGFILE=$CFGDIR/zenperfsnmp.conf
[zenoss@f6233ee4d912 bin]$ CFGFILE=$CFGDIR/zenperfsnmp.conf
[zenoss@f6233ee4d912 bin]$ pgrep -fla -- "--configfile.*$CFGFILE"
23 /opt/zenoss/bin/python /opt/zenoss/Products/ZenRRD/zenperfsnmp.py --configfile /opt/zenoss/etc/zenperfsnmp.conf -c --duallog

[zenoss@f6233ee4d912 bin]$ zenperfsnmp debug                                             
Sending SIGUSR1 to PIDS: 23
[zenoss@f6233ee4d912 bin]$ grep 'logging level' /opt/zenoss/log/zenperfsnmp.log | tail -1
2014-04-16 17:48:05,287 INFO zen: Setting logging level to DEBUG
[zenoss@f6233ee4d912 bin]$ zenperfsnmp debug                                             
Sending SIGUSR1 to PIDS: 23
[zenoss@f6233ee4d912 bin]$ grep 'logging level' /opt/zenoss/log/zenperfsnmp.log | tail -1
2014-04-16 17:48:13,612 INFO zen: Restoring logging level back to INFO (20)

```
