### PR TITLE
debug and stats should only signal the python program and avoid the java...

### DIFF
--- a/bin/zenfunctions
+++ b/bin/zenfunctions
@@ -208,7 +208,7 @@ debug() {
     elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
         PIDS=`pgrep -f -- "py --configfile $CFGFILE"`
         if [ "$PIDS" ]; then
-                echo "Sending SIGUSR1 to PIDS: $PIDS"
+                echo "Sending SIGUSR1 to PIDS: " $PIDS
                 kill -s USR1 $PIDS 2>/dev/null || ps -p $PIDS
         else
                 echo "Unable to find process to send SIGUSR1 signal"
@@ -229,7 +229,7 @@ stats() {
     elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
         PIDS=`pgrep -f -- "py --configfile $CFGFILE"`
         if [ "$PIDS" ]; then
-                echo "Sending SIGUSR2 to PIDS: $PIDS"
+                echo "Sending SIGUSR2 to PIDS: " $PIDS
                 kill -s USR2 $PIDS 2>/dev/null || ps -p $PIDS
         else
                 echo "Unable to find process to send SIGUSR2 signal"


### PR DESCRIPTION
... program

ISSUE - java process is signaled (causing it to restart) in addition to python process which manages the java process:

```
# plu@plu-ubuntu: serviced attach -pattern zenjmx ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  0 09:58 ?        00:00:00 /serviced/serviced proxy 3b20821c-244f-a44d-bab0-11cf4ad53009 su - zenoss -c "/opt/zenoss/bin/zenjmx run -c --duallog "
root        15     1  0 09:58 ?        00:00:02 /usr/local/serviced/resources/logstash/logstash-forwarder -old-files-hours=26280 -config /etc/logstash-forwarder.conf
root       103     1  0 10:00 ?        00:00:00 su - zenoss -c /opt/zenoss/bin/zenjmx run -c --duallog 
zenoss     104   103  3 10:00 ?        00:00:07 /opt/zenoss/bin/python /opt/zenoss/ZenPacks/ZenPacks.zenoss.ZenJMX-3.11.0-py2.7.egg/ZenPacks/zenoss/ZenJMX/zenjmx.py --configfile /opt/zenoss/etc/zenjmx.conf -c --duallog
zenoss     238     1  0 10:04 ?        00:00:00 [expr] <defunct>
zenoss     243   104  3 10:04 ?        00:00:01 java -server -Xmx512m -cp ./*:/opt/zenoss/zenjmx-libs/*: com.zenoss.zenpacks.zenjmx.ZenJmxMain --configfile /opt/zenoss/etc/zenjmx.conf -zenjmxjavaport 9988 --configfile /opt/zenoss/etc/zenjmx.conf -v 20
root       279     0  0 10:04 ?        00:00:00 ps -wwef


# plu@plu-ubuntu: serviced action zenjmx debug
Sending SIGUSR1 to PIDS:  104 243

```

DEMO:

```
# plu@plu-ubuntu: serviced action zenjmx debug
Sending SIGUSR1 to PIDS:  104
```
