### PR TITLE
replace old cli:[/serviced proxy] with new cli:[serviced service proxy]

### DIFF
--- a/bin/zenfunctions
+++ b/bin/zenfunctions
@@ -205,7 +205,7 @@ debug() {
         echo "Sending SIGUSR1 to $PID"
         kill -s USR1 $PID 2>/dev/null || $PS | grep -q "^ *$PID$"
         return $?
-    elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
+    elif pgrep -fla -- '/serviced service proxy' >/dev/null 2>&1; then
         PIDS=`pgrep -f -- "py --configfile $CFGFILE"`
         if [ "$PIDS" ]; then
                 echo "Sending SIGUSR1 to PIDS: " $PIDS
@@ -226,7 +226,7 @@ stats() {
         echo "Sending SIGUSR2 to $PID"
         kill -s USR2 $PID 2>/dev/null || $PS | grep -q "^ *$PID$"
         return $?
-    elif pgrep -fla -- '/serviced proxy' >/dev/null 2>&1; then
+    elif pgrep -fla -- '/serviced service proxy' >/dev/null 2>&1; then
         PIDS=`pgrep -f -- "py --configfile $CFGFILE"`
         if [ "$PIDS" ]; then
                 echo "Sending SIGUSR2 to PIDS: " $PIDS


### PR DESCRIPTION
ISSUE:

```
# plu@plu-9: serviced service action zenhub debug
Unable to find process to send SIGUSR1 signal
# plu@plu-9: 
```

due to:
  https://github.com/zenoss/serviced/blob/develop/agent.go#L808-L810

```
# plu@plu-9: serviced service attach zenhub pgrep -fla 'zenhub'
1 /serviced/serviced service proxy ca301e80-d17a-bce1-0b8e-2d9a96004472 su - zenoss -c "/opt/zenoss/bin/zenhub run --duallog"
18 su - zenoss -c /opt/zenoss/bin/zenhub run --duallog
19 /opt/zenoss/bin/python /opt/zenoss/Products/ZenHub/zenhub.py --configfile /opt/zenoss/etc/zenhub.conf --duallog
53 /opt/zenoss/bin/python /opt/zenoss/Products/ZenHub/zenhubworker.py --configfile /opt/zenoss/etc/zenhubworker.conf -C /opt/zenoss/var/zenhub/localhost_worker.conf
54 /opt/zenoss/bin/python /opt/zenoss/Products/ZenHub/zenhubworker.py --configfile /opt/zenoss/etc/zenhubworker.conf -C /opt/zenoss/var/zenhub/localhost_worker.conf
~/src/europa/src/golang/src/github.com/zenoss/serviced
# plu@plu-9: serviced service action zenhub debug
Sending SIGUSR1 to PIDS:  19
```
