### PR TITLE
Don't double-HTMLencode device/component links

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
@@ -364,7 +364,7 @@ Ext.onReady(function() {
                             sourceData.device_url,
                             sourceData.device_title);
                     }
-                    return Ext.htmlEncode(val);
+                    return val;
                 },
                 component: function(value, sourceData) {
                     var val = sourceData.component_title;
@@ -373,7 +373,7 @@ Ext.onReady(function() {
                             sourceData.component_url,
                             sourceData.component_title);
                     }
-                    return Ext.htmlEncode(val);
+                    return val;
                 },
                 eventClass: function(value, sourceData) {
                     return  Zenoss.render.EventClass(


### PR DESCRIPTION
The actual underlying issue of the ticket (ZEN-5505) was fixed a while back, but this was blocking it being verified. A new ticket should have been opened instead.
