### PR TITLE
Forward serviceId to sub processes

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -415,6 +415,8 @@ def InstallDistAsZenPack(dmd, dist, eggPath, link=False, filesOnly=False,
                     cmd += ['--previousversion', upgradingFrom]
                 if fromUI:
                     cmd += ["--fromui"]
+                if serviceId:
+                    cmd += ['--service-id', serviceId]
 
                 cmdStr = " ".join(cmd)
                 log.debug("launching sub process command: %s" % cmdStr)


### PR DESCRIPTION
Allows zenpack subprocess to know that they are running in a controlplane
  managed environment and that they need to install services.  This
  allows updating of zenpacks to work properly.
