### PR TITLE
Move default service definition location

### DIFF
--- a/Products/ZenModel/ZenPack.py
+++ b/Products/ZenModel/ZenPack.py
@@ -1119,7 +1119,7 @@ registerDirectory("skins", globals())
         :returns: absolute file paths
         :rtype: list of strings
         """
-        return glob.glob(self.path('controlplane', '*.json'))
+        return glob.glob(self.path('service_definition', '*.json'))
 
 
     def installServicesFromFiles(self, serviceFileNames, tag):


### PR DESCRIPTION
Use "service_definition" instead of "controlplane" as controlplane is
  no longer the name of the product
