### PR TITLE
added ability for bin/quiesce-*.sh to take env vars as args

### DIFF
--- a/bin/quiesce-mysql.sh
+++ b/bin/quiesce-mysql.sh
@@ -12,7 +12,7 @@
 function help()
 {
     cat <<CAT_EOF >&2
-Usage: $0 { status | pause | resume | help }
+Usage: $0 { status | pause | resume | help } [PAUSE_CHECK_TIMEOUT=120] [LOCK_HOLD_DURATION=600]
 
     PAUSE_CHECK_TIMEOUT env var may be overridden from default of 60 seconds
         amount of time to look for locked=true after calling pause
@@ -193,6 +193,17 @@ function do_resume()
     done
 }
 
+function parseEnvs()
+{
+    while (( $# > 0 )); do
+        case "$1" in
+            *=*)
+                eval export $1
+            ;;
+        esac
+        shift
+    done
+}
 
 function main()
 {
@@ -259,6 +270,7 @@ if [[ "$(basename $0)" == "quiesce-mysql.sh" ]]; then
     export CFGDIR=$ZENHOME/etc
     CMD="$1"
     shift
+    parseEnvs "$@"
     # END OF HACK
 
     main "$@"

--- a/bin/quiesce-rabbitmq.sh
+++ b/bin/quiesce-rabbitmq.sh
@@ -13,7 +13,7 @@
 function help()
 {
     cat <<CAT_EOF >&2
-Usage: $0 { status | pause | resume | help }
+Usage: $0 { status | pause | resume | help } [PAUSE_CHECK_TIMEOUT=120]
 
     PAUSE_CHECK_TIMEOUT env var may be overridden from default of 60 seconds
         amount of time to look for locked=true after calling pause
@@ -175,6 +175,17 @@ function do_resume()
     rabbitmqctl set_vm_memory_high_watermark $vm_memory_high_watermark
 }
 
+function parseEnvs()
+{
+    while (( $# > 0 )); do
+        case "$1" in
+            *=*)
+                eval export $1
+            ;;
+        esac
+        shift
+    done
+}
 
 function main()
 {
@@ -186,6 +197,7 @@ function main()
 
     CMD="$1"
     shift
+    parseEnvs "$@"
     case "$CMD" in
         status)
             do_status


### PR DESCRIPTION
related:
  https://github.com/zenoss/serviced/pull/548
  https://github.com/zenoss/platform-build/pull/141
  https://github.com/zenoss/platform-build/pull/142
  https://github.com/zenoss/zenoss-prodbin/pull/180
  https://github.com/zenoss/zenoss-prodbin/pull/181
