### PR TITLE
Feature/graph zoom fix

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -384,7 +384,7 @@
             if (Ext.isNumber(gp.start)) {
                 delta = this.convertEndToAbsolute(gp.end) - gp.start;
             } else {
-                /*JsDbg*/debugger;delta = rangeToMilliseconds(gp.start);
+                delta = rangeToMilliseconds(gp.start);
             }
             changes.downsample = '1m-avg';
             Ext.Array.each(DOWNSAMPLE, function(v) {


### PR DESCRIPTION
fixes: https://jira.zenoss.com/browse/ZEN-10657

Instead of zoom buttons toggling zoom mode for mouse clicks, zoom buttons now immediately zoom graph in and out. This prevents graphPanel from needing to listen to mouse clicks, which means mouse clicks are now entirely handled by the graphing library (instead of the ext panel).

end result: you can toggle series' on and off!

note: the graph panel interactions are all less than ideal, so this fix is just to get things working. the graph panel really needs an overhaul.
