### PR TITLE
Feature/graph refresh fix2

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -378,8 +378,6 @@
             this.graphEl.setStyle({'cursor': cls});
         },
         updateGraph: function(params) {
-            console.log("params", params);
-
             var gp = Ext.apply({}, params, this.graph_params);
             gp.start = params.start || gp.start;
             if (gp.start < 0) {


### PR DESCRIPTION
Fixes graph auto update and refresh button not respecting date ranges set by the user in the date range selector.

Fixes https://jira.zenoss.com/browse/ZEN-9417

Also fixes https://jira.zenoss.com/browse/ZEN-12153 where the date placed in the "Start" field is later than the date in the "end" field.
