### PR TITLE
Get the signature of RelationshipMap back to what's expected

### DIFF
--- a/Products/DataCollector/plugins/DataMaps.py
+++ b/Products/DataCollector/plugins/DataMaps.py
@@ -21,7 +21,8 @@ class RelationshipMap(PBSafe):
     relname = ""
     compname = ""
 
-    def __init__(self, parentId="", relname="", compname="", modname="", objmaps=[]):
+    def __init__(self, relname="", compname="", modname="", objmaps=[],
+            parentId=""):
         self.parentId = parentId
         self.relname = relname
         self.compname = compname


### PR DESCRIPTION
This fixes a bug introduced by porting a fix from 4.x, here:

https://github.com/zenoss/zenoss-prodbin/commit/a3c9f1d5cefeb656e1a25954d9f0ceb205c95cc3
