### PR TITLE
fixes ZEN-12760: add new addnote api method that does not force indexing

### DIFF
--- a/Products/Zuul/facades/zepfacade.py
+++ b/Products/Zuul/facades/zepfacade.py
@@ -312,6 +312,11 @@ class ZepFacade(ZuulFacade):
 
         self.client.addNote(uuid, message, userUuid, userName)
 
+    def addNoteBulkAsync(self, uuids, message, userName, userUuid=None):
+        if userName and not userUuid:
+            userUuid = self._getUserUuid(userName)
+
+        self.client.addNoteBulkAsync(uuids, message, userUuid, userName)
 
     def postNote(self, uuid, note):
         self.client.postNote(uuid, from_dict(EventNote, note))


### PR DESCRIPTION
DEMO:
  https://jira.zenoss.com/secure/attachment/18466/fix-for-ZEN-12760.png

port of:
  https://jira.zenoss.com/browse/ZEN-12761
  https://github.com/zenoss/pm-resmgr-4.2.4/pull/568

fixes:
  https://github.com/zenoss/zenoss-zep/pull/28
  https://github.com/zenoss/zenoss-protocols/pull/9
  https://github.com/zenoss/zenoss-prodbin/pull/249
