### PR TITLE
ZEN-12650 Interfaces cannot be deleted from /Server/Ssh/Linux devices

### DIFF
--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -205,12 +205,15 @@ class IpInterface(OSComponent, Layer2Linkable):
         for ip in self.ipaddresses():
             ip.index_object()
 
-        macs = self.device().getMacAddressCache()
-        try: 
-            macs.remove(self.macaddress)
-            notify(IndexingEvent(self.device(), idxs=('macAddresses',), update_metadata=False))
-        except KeyError:
-            pass
+        device = self.device()
+
+        if device:
+            macs = device.getMacAddressCache()
+            try: 
+                macs.remove(self.macaddress)
+                notify(IndexingEvent(self.device(), idxs=('macAddresses',), update_metadata=False))
+            except KeyError:
+                pass
             
     def manage_deleteComponent(self, REQUEST=None):
         """

--- a/Products/ZenModel/subscribers.py
+++ b/Products/ZenModel/subscribers.py
@@ -37,9 +37,11 @@ def onInterfaceRemoved(ob, event):
     """
 
     if not IObjectWillBeAddedEvent.providedBy(event):
-        macs = ob.device().getMacAddressCache()
-        if ob.macaddress in macs:
-            macs.remove(ob.macaddress)
+        device = ob.device()
+        if device:
+            macs = device.getMacAddressCache()
+            if ob.macaddress in macs:
+                macs.remove(ob.macaddress)
 
 
 @adapter(IpInterface, IObjectAddedEvent)
@@ -49,5 +51,7 @@ def onInterfaceAdded(ob, event):
     """
 
     if ob.macaddress:
-        ob.device().getMacAddressCache().add(ob.macaddress)
+        device = ob.device()
+        if device:
+            device.getMacAddressCache().add(ob.macaddress)
 


### PR DESCRIPTION
- Check if the device exists on the interface before trying to add/remove attributes to the mac address cache
  
  Port ZEN-9115 to RM 5.0.0
