### PR TITLE
fix wizard step 2 closing entire window

### DIFF
--- a/Products/ZenWidgets/browser/quickstart/templates/quickstart_macros.pt
+++ b/Products/ZenWidgets/browser/quickstart/templates/quickstart_macros.pt
@@ -163,7 +163,8 @@ Ext.onReady(function() {
     }    
     var closeWindowIfPopup = function(form, action) {
         // opener is defined as the window that opened the popup
-        if (!Ext.isEmpty(opener)) {
+        // if this popup is part of quick start step 2, dont close.
+        if (!Ext.isEmpty(opener) || !~window.location.href.indexOf("qs-step2")) {
             window.close();
         }
     };


### PR DESCRIPTION
relying on `opener` to determine if this is a popup window isnt too reliable, so heres an even uglier workaround
