### PR TITLE
Reverting bad port

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/ComponentPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/ComponentPanel.js
@@ -592,18 +592,15 @@ Ext.define("Zenoss.component.ComponentGridPanel", {
                 fields: config.fields
             });
         config.sortInfo = config.sortInfo || {};
-        var store = new ZC.BaseComponentStore({
+	config = Ext.applyIf(config, {
+	    autoExpandColumn: 'name',
+	    bbar: {},
+	    store: new ZC.BaseComponentStore({
                 model: modelId,
                 initialSortColumn: config.sortInfo.field || 'name',
                 initialSortDirection: config.sortInfo.direction || 'ASC',
                 directFn:config.directFn || Zenoss.remote.DeviceRouter.getComponents
-            });
-
-        store.buffered = Zenoss.settings.enableInfiniteGridForEvents;
-
-        config = Ext.applyIf(config, {
-            autoExpandColumn: 'name',  
-            store: store,
+	    }),
             columns: [{
                 id: 'component_severity',
                 dataIndex: 'severity',
@@ -640,8 +637,6 @@ Ext.define("Zenoss.component.ComponentGridPanel", {
                 }
             })
         });
-        if (Zenoss.settings.enableInfiniteGridForEvents)
-             config.bbar = {};
         ZC.ComponentGridPanel.superclass.constructor.call(this, config);
         this.relayEvents(this.getSelectionModel(), ['rangeselect']);
         this.store.proxy.on('load',
@@ -740,6 +735,7 @@ Ext.define("Zenoss.component.ComponentGridPanel", {
 });
 
 
+
 Ext.define("Zenoss.component.BaseComponentStore", {
     extend:"Zenoss.DirectStore",
     constructor: function(config) {
@@ -755,10 +751,9 @@ Ext.define("Zenoss.component.BaseComponentStore", {
         });
         ZC.BaseComponentStore.superclass.constructor.call(this, config);
         this.on('guaranteedrange', function(){this.loaded = true;}, this);
-        // paginated grid fires load instead of guaranteedrange
-        this.on('load', function(){this.loaded = true; this.fireEvent('guaranteedrange', this)}, this);
     }
 });
+
 
 Ext.define("Zenoss.component.IpInterfacePanel", {
     alias:['widget.IpInterfacePanel'],


### PR DESCRIPTION
https://github.com/zenoss/zenoss-prodbin/commit/5960f4bfb6abd9a08c55589ffa8dbe9d79bfbc09 is the change in question.

This was made in order to port https://jira.zenoss.com/browse/ZEN-13045 to Europa, but it ended up causing https://jira.zenoss.com/browse/ZEN-13474. Will reopen ZEN-13045; perhaps it's missing other code?
