### PR TITLE
fixes ZEN-13552, filter device updates using configFilter

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -13,6 +13,7 @@ import time
 import logging
 import json
 import zope.interface
+from zope.component import getUtilitiesFor
 from twisted.internet import defer,  reactor, task
 from twisted.python.failure import Failure
 from optparse import SUPPRESS_HELP
@@ -20,6 +21,7 @@ from Products.ZenCollector.interfaces import ICollector,\
                                              ICollectorPreferences,\
                                              IDataService,\
                                              IEventService,\
+                                             IConfigurationDispatchingFilter,\
                                              IFrameworkFactory,\
                                              ITaskSplitter,\
                                              IConfigurationListener,\
@@ -295,6 +297,15 @@ class CollectorDaemon(RRDDaemon):
         super(CollectorDaemon, self).parseOptions()
         self.preferences.options = self.options
 
+        options = self.options.__dict__
+        dispatchFilterName = options.get('configDispatch', '') if options else ''
+        filterFactories = dict(getUtilitiesFor(IConfigurationDispatchingFilter))
+        filterFactory = filterFactories.get(dispatchFilterName, None) or \
+                        filterFactories.get('', None)
+        if filterFactory:
+            self.preferences.configFilter = filterFactory.getFilter(options)
+            log.debug("Filter configured: %s:%s", filterFactory, self.preferences.configFilter)
+
     def connected(self):
         """
         Method called by PBDaemon after a connection to ZenHub is established.
@@ -450,10 +461,13 @@ class CollectorDaemon(RRDDaemon):
         # guard against parsing updates during a disconnect
         if config is None:
             return
-        self.log.debug("Device %s updated", config.configId)
-        if not self.options.device or self.options.device in (config.id, config.configId):
+        configFilter = getattr(self.preferences, "configFilter", lambda x: True)
+        if (not self.options.device and configFilter(config)) or self.options.device in (config.id, config.configId):
+            self.log.debug("Device %s updated", config.configId)
             self._updateConfig(config)
             self._configProxy.updateConfigProxy(self.preferences, config)
+        else:
+            self.log.debug("Device %s config filtered", config.configId)
 
     def remote_updateDeviceConfigs(self, configs):
         """


### PR DESCRIPTION
During invalidation processing, new configurations are pushed down to the collectors. When collectors have a worker strategy, the configurations must be filtered as they are during configuration fetching.
