### PR TITLE
fixes ZEN-12866: add convenience function to set_trace with rpdb in a co...

### DIFF
--- a/Products/ZenUtils/debugtools.py
+++ b/Products/ZenUtils/debugtools.py
@@ -48,3 +48,20 @@ def profile(f):
         p.print_stats()
         return result
     return inner
+
+
+def rpdb_set_trace(log=None):
+    """
+    convenience function to set_trace with rpdb in a control center container
+    """
+    import rpdb
+    import subprocess
+
+    ip=subprocess.check_output(["hostname", "-i"]).strip()
+    port=4444
+    print "connect to rpdb remotely with: nc %s %d  # Control-C to exit nc" % (ip, port)
+    if log:
+        log.warn("connect to rpdb remotely with: nc %s %d  # Control-C to exit nc" % (ip, port))
+    debugger = rpdb.Rpdb(ip, port)
+    debugger.set_trace()
+


### PR DESCRIPTION
...ntrol center container

depends on https://github.com/zenoss/platform-build/pull/280

DEMO:

```
# plu@plu-9: serviced service attach zenperfsnmp
/
# root@f07b650a617d: cp -p /opt/zenoss/Products/ZenRRD/zenperfsnmp.py /opt/zenoss/Products/ZenRRD/zenperfsnmp.py.old
/
# root@f07b650a617d: vi /opt/zenoss/Products/ZenRRD/zenperfsnmp.py
/
# root@f07b650a617d: diff -Nurp /opt/zenoss/Products/ZenRRD/zenperfsnmp.py.old /opt/zenoss/Products/ZenRRD/zenperfsnmp.py
--- /opt/zenoss/Products/ZenRRD/zenperfsnmp.py.old  2014-08-14 15:56:55.917353176 +0100
+++ /opt/zenoss/Products/ZenRRD/zenperfsnmp.py  2014-08-14 15:53:05.421365288 +0100
@@ -99,6 +99,7 @@ class SnmpPerformanceCollectionPreferenc
                           default=3,
                           type='int',
                           help="How many consecutive time outs per cycle before stopping attempts to collect")
+        from Products.ZenUtils.debugtools import rpdb_set_trace; rpdb_set_trace(log)


     def postStartup(self):
/
# root@f07b650a617d: ps -wwef
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  1 15:53 ?        00:00:06 /serviced/serviced service proxy 8q7f1p297ln6bpz61p7svifaf 0 su - zenoss -c "/opt/zenoss/bin/zenperfsnmp run -c --duallog --monitor localhost "
root        21     1  0 15:53 ?        00:00:00 su - zenoss -c /opt/zenoss/bin/zenperfsnmp run -c --duallog --monitor localhost 
zenoss      22    21  0 15:53 ?        00:00:05 /opt/zenoss/bin/python /opt/zenoss/Products/ZenRRD/zenperfsnmp.py --configfile /opt/zenoss/etc/zenperfsnmp.conf -c --duallog --monitor localhost
...
/
# root@f07b650a617d: pkill -f 'python.*zenperfsnmp.py'
/
# root@f07b650a617d: date; ps -wwef
Thu Aug 14 16:03:15 BST 2014
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  1 15:53 ?        00:00:06 /serviced/serviced service proxy 8q7f1p297ln6bpz61p7svifaf 0 su - zenoss -c "/opt/zenoss/bin/zenperfsnmp run -c --duallog --monitor localhost "
...
/
# root@f07b650a617d: date; ps -wwef
Thu Aug 14 16:03:27 BST 2014
UID        PID  PPID  C STIME TTY          TIME CMD
root         1     0  1 15:53 ?        00:00:06 /serviced/serviced service proxy 8q7f1p297ln6bpz61p7svifaf 0 su - zenoss -c "/opt/zenoss/bin/zenperfsnmp run -c --duallog --monitor localhost "
root      7902     1  0 16:03 ?        00:00:00 su - zenoss -c /opt/zenoss/bin/zenperfsnmp run -c --duallog --monitor localhost 
zenoss    7903  7902 52 16:03 ?        00:00:04 /opt/zenoss/bin/python /opt/zenoss/Products/ZenRRD/zenperfsnmp.py --configfile /opt/zenoss/etc/zenperfsnmp.conf -c --duallog --monitor localhost
...
/
# root@f07b650a617d: hostname -i
172.17.3.97
/
# root@f07b650a617d: exit
~/src/europa/src
# plu@plu-9: nc 172.17.3.97 4444
--Return--
> /opt/zenoss/Products/ZenUtils/debugtools.py(66)rpdb_set_trace()->None
-> debugger.set_trace()
(Pdb) where
  /opt/zenoss/Products/ZenRRD/zenperfsnmp.py(609)<module>()
-> daemon = CollectorDaemon(myPreferences, myTaskSplitter)
  /opt/zenoss/Products/ZenCollector/daemon.py(201)__init__()
-> super(CollectorDaemon, self).__init__(name=self.preferences.collectorName)
  /opt/zenoss/Products/ZenRRD/RRDDaemon.py(61)__init__()
-> PBDaemon.__init__(self, noopts, name=name)
  /opt/zenoss/Products/ZenHub/PBDaemon.py(549)__init__()
-> ZenDaemon.__init__(self, noopts, keeproot)
  /opt/zenoss/Products/ZenUtils/ZenDaemon.py(57)__init__()
-> super(ZenDaemon, self).__init__(noopts)
  /opt/zenoss/Products/ZenUtils/CmdBase.py(125)__init__()
-> self.buildOptions()
  /opt/zenoss/Products/ZenCollector/daemon.py(292)buildOptions()
-> self.preferences.buildOptions(self.parser)
  /opt/zenoss/Products/ZenRRD/zenperfsnmp.py(102)buildOptions()
-> from Products.ZenUtils.debugtools import rpdb_set_trace; rpdb_set_trace(log)
> /opt/zenoss/Products/ZenUtils/debugtools.py(66)rpdb_set_trace()->None
-> debugger.set_trace()
(Pdb) ^C
~/src/europa/src
# plu@plu-9: 
```
