### PR TITLE
fixes ZEN-10145: added smart safe cookies for servers set to SSL

### DIFF
--- a/Products/ZenUtils/Security.py
+++ b/Products/ZenUtils/Security.py
@@ -312,5 +312,11 @@ def migratePAS(context):
 @component.adapter(ZPublisher.interfaces.IPubEnd)
 def secureSessionCookie(event):
     """Zope session cookie should only accesible from the server side"""
-    if '_ZopeId' in event.request.response.cookies and 'http_only' not in event.request.response.cookies['_ZopeId']:
-        event.request.response.cookies['_ZopeId']['http_only'] = True
+    if '_ZopeId' in event.request.response.cookies:
+        if 'http_only' not in event.request.response.cookies['_ZopeId']:
+            event.request.response.cookies['_ZopeId']['http_only'] = True
+        if 'HTTP_X_FORWARDED_PROTO' in event.request.environ \
+                and event.request.environ['HTTP_X_FORWARDED_PROTO'] == 'https' \
+                and 'secure' not in event.request.response.cookies['_ZopeId']:
+            event.request.response.cookies['_ZopeId']['secure'] = True
+


### PR DESCRIPTION
port of https://dev.zenoss.com/tracint/changeset/79960
fixing https://jira.zenoss.com/browse/ZEN-10146

notice that 4.x checks for HTTP_X_URL_SCHEME=https, but 5.x checks for HTTP_X_FORWARDED_PROTO =https due to all browser requests going through zproxy

ZEN-10145 jira ticket has demo screenshots for firefox and chrome 
