### PR TITLE
fixes ZEN-8911: Improve logging and data point capture of ApplyDataMap p...

### DIFF
--- a/Products/DataCollector/tests/testApplyDataMap.py
+++ b/Products/DataCollector/tests/testApplyDataMap.py
@@ -82,6 +82,8 @@ class ApplyDataMapTest(BaseTestCase):
 
             def getObjByPath(self, path):
                 return reduce(getattr, path.split("/"), self)
+            def getId(self):
+                return "testDevice"
 
             class a:
                 class b:

--- a/Products/ZenHub/services/ModelerService.py
+++ b/Products/ZenHub/services/ModelerService.py
@@ -17,7 +17,7 @@ from PerformanceConfig import PerformanceConfig
 from Products.ZenHub.PBDaemon import translateError
 from Products.DataCollector.DeviceProxy import DeviceProxy
 from Products.DataCollector.Plugins import loadPlugins
-
+import time
 import logging
 log = logging.getLogger('zen.ModelerService')
 
@@ -121,7 +121,16 @@ class ModelerService(PerformanceConfig):
         adm.setDeviceClass(device, devclass)
         def inner(map):
             def action():
-                return bool(adm._applyDataMap(device, map))
+                start_time = time.time()
+                completed= bool(adm._applyDataMap(device, map))
+                end_time=time.time()-start_time
+                if hasattr(map, "relname"):
+                    log.debug("Time in _applyDataMap for Device %s with relmap %s objects: %.2f", device.getId(),map.relname,end_time)
+                elif hasattr(map,"modname"):
+                    log.debug("Time in _applyDataMap for Device %s with objectmap, size of %d attrs: %.2f",device.getId(),len(map.items()),end_time)
+                else:
+                    log.debug("Time in _applyDataMap for Device %s: %.2f . Could not find if relmap or objmap",device.getId(),end_time)
+                return completed
             return self._do_with_retries(action)
 
         changed = False


### PR DESCRIPTION
...rocessing

DEMO:

```
# plu@plu-9: serviced service action zenhub debug

# plu@plu-9: serviced service attach zenhub tail -F /opt/zenoss/log/zenhub.log |grep _apply
2014-09-15 22:01:22,910 DEBUG zen.ApplyDataMap: Started _applyDataMap for device test-rhel54.zenoss.loc
2014-09-15 22:01:22,912 INFO zen.ZenHub: Worker (22555) reports 2014-09-15 22:01:22,912 DEBUG zen.ApplyDataMap: _applyDataMap for Device test-rhel54.zenoss.loc will modify 0 objects for processes
2014-09-15 22:01:22,913 INFO zen.ZenHub: Worker (22555) reports 2014-09-15 22:01:22,913 DEBUG zen.ModelerService: Time in _applyDataMap for Device test-rhel54.zenoss.loc with relmap processes objects: 0.00
2014-09-15 22:01:22,913 INFO zen.ZenHub: Worker (22555) reports 2014-09-15 22:01:22,913 DEBUG zen.ApplyDataMap: Started _applyDataMap for device test-rhel54.zenoss.loc
2014-09-15 22:01:23,038 INFO zen.ZenHub: Worker (22555) reports 2014-09-15 22:01:23,037 DEBUG zen.ApplyDataMap: _applyDataMap for Device test-rhel54.zenoss.loc will modify 1 objects for cpus
2014-09-15 22:01:23,179 INFO zen.ZenHub: Worker (22555) reports 2014-09-15 22:01:23,178 DEBUG zen.ModelerService: Time in _applyDataMap for Device test-rhel54.zenoss.loc with relmap cpus objects: 0.27
```
