### PR TITLE
* fixes ZEN-14445: make getDefaultZopeUrl return localhost all the time ...

### DIFF
--- a/Products/ZenUtils/Utils.py
+++ b/Products/ZenUtils/Utils.py
@@ -1691,7 +1691,7 @@ def getDefaultZopeUrl():
     """
     Returns the default Zope URL.
     """
-    return 'http://%s:%d' % (socket.getfqdn(), 8080)
+    return 'http://localhost:8080'
 
 
 def swallowExceptions(log, msg=None, showTraceback=True, returnValue=None):


### PR DESCRIPTION
...since we run in containers
