### PR TITLE
fixes ZEN-14020: split snmp communities in js before making router call,...

### DIFF
--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -677,7 +677,7 @@ class AutoDiscoveryJob(SubprocessJob):
             '', '/Discovered', collector, 1000
             )
         # strip out the device option since we are discovering for a network
-        cmd = [c for c in cmd if c != '-d']
+        cmd = [c.replace(" -d ", "") for c in cmd if c != '-d']
         cmd.extend([
                 '--parallel', '8',
                 '--job', self.request.id

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AutoDiscoveryController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AutoDiscoveryController.js
@@ -92,6 +92,9 @@
                     zProperties[key] = values[key];
                 }
             }
+            if ('zSnmpCommunities' in zProperties) {
+                zProperties['zSnmpCommunities'] = zProperties['zSnmpCommunities'].split("\n");
+            }
             params = {
                 networks: ranges,
                 zProperties: zProperties,

--- a/Products/Zuul/facades/networkfacade.py
+++ b/Products/Zuul/facades/networkfacade.py
@@ -229,7 +229,7 @@ class NetworkFacade(TreeFacade):
             for net in nets:
                 # Make the network if it doesn't exist, so zendisc has
                 # something to discover
-                self._.dmd.Networks.createNet(net)
+                self._dmd.Networks.createNet(net)
 
             netdesc = ("network %s" % nets[0] if len(nets)==1
                     else "%s networks" % len(nets))


### PR DESCRIPTION
- split snmp communities in js before making router call
- fix dmd reference in network facade
- look for -d inside of command args for AutoDiscovery jobs

This uses update zminion that passes all args to subprocess
https://github.com/zenoss/platform-build/commit/5e1da71ac8f0dc0a404880f0b3f3cffc51b88398
https://github.com/zenoss/zminion/commit/15c612564e6298cc6fda4577250ce055a304cc63
