### PR TITLE
fixes ZEN-14592, ZEN-14126: allow fake remote service methods to take keyword args also

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -128,7 +128,7 @@ class HubDown(Exception): pass
 
 
 class FakeRemote:
-    def callRemote(self, *unused):
+    def callRemote(self, *args, **kwargs):
         ex = HubDown("ZenHub is down")
         return defer.fail(ex)
 


### PR DESCRIPTION
...
