### PR TITLE
Fix traceback on publish of unicode metrics.

### DIFF
--- a/Products/ZenHub/metricpublisher/utils.py
+++ b/Products/ZenHub/metricpublisher/utils.py
@@ -7,6 +7,9 @@
 #
 ##############################################################################
 
+import logging
+log = logging.getLogger("zen.publisher")
+
 from functools import wraps
 
 import eventlet
@@ -92,11 +95,22 @@ def sanitized_float(unsanitized):
     99.9
     >>> sanitized_float('123 V')
     123.0
+    >>> sanitized_float('not-applicable') is None
+    True
 
     """
-    if isinstance(unsanitized, basestring):
-        return float(unsanitized.translate(None, NON_NUMERIC_CHARS))
-    elif isinstance(unsanitized, float):
-        return unsanitized
-    else:
-        return float(unsanitized)
+    try:
+        if isinstance(unsanitized, float):
+            return unsanitized
+
+        if isinstance(unsanitized, (int, long)):
+            return float(unsanitized)
+
+        if isinstance(unsanitized, str):
+            return float(unsanitized.translate(None, NON_NUMERIC_CHARS))
+
+        if isinstance(unsanitized, unicode):
+            return float(str(unsanitized).translate(None, NON_NUMERIC_CHARS))
+
+    except Exception:
+        log.warn("failed converting %r to float", unsanitized)

--- a/Products/ZenHub/tests/testMetricPublisher.py
+++ b/Products/ZenHub/tests/testMetricPublisher.py
@@ -12,6 +12,8 @@ import unittest
 import ujson as json
 
 from Products.ZenHub.metricpublisher.publisher import RedisListPublisher, HttpPostPublisher, BasePublisher
+from Products.ZenHub.metricpublisher.utils import sanitized_float
+
 
 class BasePublisherTestCase(unittest.TestCase):
     def testBuildMetric(self):
@@ -49,9 +51,51 @@ class RedisPublisherTestCase(unittest.TestCase):
                 json.dumps({"metric":"m","value":0.0,"timestamp":1,"tags":{}}),
                 publisher._mq.pop())
 
+
+class UtilsTestCase(unittest.TestCase):
+    def test_sanitized_float(self):
+        # The result of float() and sanitized_float() should match for
+        # these.
+        float_inputs = [
+            100, '100', u'100',
+            -100, '-100', u'-100',
+            100.1, '100.1', u'100.1',
+            -100.1, '-100.1', u'-100.1',
+            1e9, '1e9', u'1e9',
+            -1e9, '-1e9', u'-1e9',
+            1.1e9, '1.1e9', u'1.1e9',
+            -1.1e9, '-1.1e9', u'-1.1e9',
+            ]
+
+        for value in float_inputs:
+            self.assertEquals(sanitized_float(value), float(value))
+
+        # First item in tuple should be normalized to second item.
+        normalized_inputs = [
+            ('100%', 100.0),
+            ('-100%', -100.0),
+            ('100.1%', 100.1),
+            ('-100.1%', -100.1),
+            ('123 V', 123.0),
+            ('F123', 123.0),
+            ]
+
+        for value, expected_output in normalized_inputs:
+            self.assertEquals(sanitized_float(value), expected_output)
+
+        # Bad inputs should result in None.
+        bad_inputs = [
+            'not-applicable',
+            ]
+
+        for value in bad_inputs:
+            self.assertEquals(sanitized_float(value), None)
+
+
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(BasePublisherTestCase))
     suite.addTest(unittest.makeSuite(HttpPostPublisherTestCase))
     suite.addTest(unittest.makeSuite(RedisPublisherTestCase))
+    suite.addTest(unittest.makeSuite(UtilsTestCase))
     return suite


### PR DESCRIPTION
This bug was introduced by 0910b99 to fix ZEN-14618. Take more care to sanitize
metrics. Include unit test.

Fixes ZEN-14650.
