### PR TITLE
* fixes ZEN-14460, disable creation of zenpack via the ui, add via CLI

### DIFF
--- a/Products/ZenModel/ZenPack.py
+++ b/Products/ZenModel/ZenPack.py
@@ -1217,8 +1217,7 @@ registerDirectory("skins", globals())
         cpClient = ControlPlaneClient(**getConnectionSettings())
         serviceTree = ServiceTree(cpClient.queryServices("*"))
         tenant = serviceTree.matchServicePath(self.currentServiceId, '/')[0]
-        context = tenant._data.get('Context','null')
-        context = json.loads(context) if context != 'null' else {}
+        context = tenant._data.get('Context', {})
 
         # Determine template parameters
         templateParams = defaultdict(lambda:'')

--- a/Products/ZenModel/ZenPackManager.py
+++ b/Products/ZenModel/ZenPackManager.py
@@ -105,7 +105,7 @@ class ZenPackManager(ZenModelRM):
 
 
     security.declareProtected(ZEN_MANAGE_DMD, 'manage_addZenPack')
-    def manage_addZenPack(self, packId, REQUEST=None):
+    def manage_addZenPack(self, packId, REQUEST=None, devDir=''):
         """
         Create a new zenpack on the filesystem with the given info.
         Install the pack.  If REQUEST then render the REQUEST otherwise
@@ -136,7 +136,7 @@ class ZenPackManager(ZenModelRM):
             raise ZenPackException(msgOrId)
 
         # Create it
-        zpDir = ZenPackCmd.CreateZenPack(packId)
+        zpDir = ZenPackCmd.CreateZenPack(packId, devDir=devDir)
 
         # Install it
         zenPacks = ZenPackCmd.InstallEggAndZenPack(self.dmd, zpDir, link=True,

--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -56,7 +56,7 @@ ZENPACK_ENTRY_POINT = 'zenoss.zenpacks'
 #   ZenPack Creation
 ########################################
 
-def CreateZenPack(zpId, prevZenPackName=''):
+def CreateZenPack(zpId, prevZenPackName='', devDir=None):
     """
     Create the zenpack in the filesystem.
     The zenpack is not installed in Zenoss, it is simply created in
@@ -69,7 +69,8 @@ def CreateZenPack(zpId, prevZenPackName=''):
     
     # Copy template to $ZENHOME/ZenPacks
     srcDir = zenPath('Products', 'ZenModel', 'ZenPackTemplate')
-    devDir = zenPath('ZenPacks')
+    if not devDir:
+        devDir = zenPath('ZenPacks')
     if not os.path.exists(devDir):
         os.mkdir(devDir, 0750)
     destDir = os.path.join(devDir, zpId)

--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -116,7 +116,7 @@ class ZenPackCmd(ZenScriptBase):
     def run(self):
         """Execute the user's request"""
         if self.args:
-            print "Require one of --install, --remove, --export, or --list flags."
+            print "Require one of --install, --remove, --export, --create, or --list flags."
             self.parser.print_help()
             return
 
@@ -128,6 +128,19 @@ class ZenPackCmd(ZenScriptBase):
             audit('Shell.ZenPack.Export', zenpack=self.options.exportPack)
         elif self.options.removePackName:
             audit('Shell.ZenPack.Remove', zenpack=self.options.removePackName)
+        elif self.options.createPackName:
+            audit('Shell.ZenPack.Create', zenpack=self.options.createPackName)
+
+
+        if self.options.createPackName:
+            devDir, packName = os.path.split(self.options.createPackName)
+            try:
+                self.connect()
+                self.dmd.ZenPackManager.manage_addZenPack(packName, devDir=devDir)
+            except Exception as ex:
+                self.log.fatal("could not create zenpack: %s", ex)
+                sys.exit(1)
+            sys.exit(0)
 
         if self.options.installPackName:
             eggInstall = (self.options.installPackName.lower().endswith('.egg')
@@ -464,6 +477,10 @@ class ZenPackCmd(ZenScriptBase):
 
 
     def buildOptions(self):
+        self.parser.add_option('--create',
+                               dest='createPackName',
+                               default=None,
+                               help="Zenpack name or path to full destination path, eg /home/zenoss/src/ZenPacks.example.TestPack")
         self.parser.add_option('--install',
                                dest='installPackName',
                                default=None,

--- a/Products/ZenWidgets/skins/zenui/dialog_addZenPack.pt
+++ b/Products/ZenWidgets/skins/zenui/dialog_addZenPack.pt
@@ -4,40 +4,17 @@
 <table>
     <tr>
         <td colspan="2">
-            ZenPack names are a sequence of three or more package names 
-            separated by
-            periods.  The first package is always named ZenPacks.  The second 
-            package usually identifies the person or organization responsible 
-            for 
-            the ZenPack.  The last package name usually identifies the function 
-            of 
-            the ZenPack.  Examples:
-            <ul style="margin:3px 0 0 12px">
-                <li>ZenPacks.WidgetCorp.WidgetWatcher</li>
-                <li>ZenPacks.JohnDoe.networking.RouterGraphs</li>
-            </ul>
-        </td>
-    </tr>
-    <tr>
-        <td>
-            <span id="new_id_label">Name&nbsp;</span>:
-        </td>
-        <td>
-            <input id="new_id" name="packId" value="ZenPacks.">
-            <input type="hidden" id="checkValidIdPath" 
-                    tal:attributes="value here/absolute_url_path">
+            ZenPacks can no longer be added via the UI. Please use the CLI
+	    to add the zenpack. For example:
+            <code>>
+               serviced service run zope zenpack create ZenPacks.awesome.Extension
+            </code>  
         </td>
     </tr>
 </table>
 </div>
 <br>
 <div align="center">
-<input tal:attributes="id string:dialog_submit;
-        type string:submit;
-        value string:OK;
-        onclick string:return $$('dialog').submit_form_and_check(
-                                                '${here/absolute_url_path}')"
-                name="manage_addZenPack:method" />
 <input tal:attributes="id string:dialog_cancel;
                         type string:button;
                         value string:Cancel;

--- a/bin/zenpack
+++ b/bin/zenpack
@@ -29,6 +29,6 @@ else
         echo "INFO: Bypassing normal processing while in upgrade mode." 1>&2
     else
         . $ZENHOME/bin/zenfunctions
-        $PYTHON $ZENHOME/Products/ZenUtils/zenpack.py "$CMD" $*
+        exec $PYTHON $ZENHOME/Products/ZenUtils/zenpack.py "$CMD" $*
     fi
 fi

--- a/bin/zenrun.d/zenpack.sh
+++ b/bin/zenrun.d/zenpack.sh
@@ -34,11 +34,24 @@ help() {
     echo "usage:"
     echo "   zenpack help"
     echo "   zenpack install <zenpack_egg_relpath>"
+    echo "   zenpack link <zenpack_egg_relpath>"
+    echo "   zenpack create <zenpack_name>"
     echo "   zenpack list"
     echo "   zenpack uninstall <zenpack_name>"
     return 1
 }
 
+
+create() {
+    zenpack --create "$@"
+    return $?
+}
+
+
+link() {
+  zenpack --link --install "$@"
+  return $?
+}
 
 install() {
     # Map host path to container path


### PR DESCRIPTION
This disables zenpack creation via the UI. It is problematic because of the non-sticky sessions in Europa. Zenpacks can be created via the CLI with the create command. Existing zenpacks can be install on the CLI in linked mode as well.

```
Creating a new zenpack (installs in link mode)
dgarcia@dgarcia-desktop:~/src/europa/src/golang/src/github.com/control-center/serviced⟫ ./serviced service run zope zenpack create /home/zenoss/ZenPacks.zenoss.FML
I0930 11:26:21.866995 20263 server.go:341] Connected to the control center at port 10.87.120.128:4979
....
INFO:zen.ZenPackCMD:installing zenpack ZenPacks.zenoss.FML; launching process
2014/09/30 16:26:46.652290 Registrar received 1 events
2014-09-30 16:26:48,226 INFO zen.ZPLoader: Loading /home/zenoss/ZenPacks.zenoss.FML/ZenPacks/zenoss/FML/objects/objects.xml
2014-09-30 16:26:48,227 INFO zen.AddToPack: End loading objects
2014-09-30 16:26:48,227 INFO zen.AddToPack: Processing links
2014-09-30 16:26:48,319 INFO zen.AddToPack: Loaded 0 objects into the ZODB database
2014-09-30 16:26:48,354 INFO zen.HookReportLoader: Loading reports from /home/zenoss/ZenPacks.zenoss.FML/ZenPacks/zenoss/FML/reports
2014/09/30 16:26:48.561769 Registrar received 2 events
2014/09/30 16:26:50.647265 Registrar received 1 events
I0930 11:26:55.394324 20263 shell.go:207] Committing container
```
