### PR TITLE
return empty string for None members in array

### DIFF
--- a/Products/ZenUtils/ProcessQueue.py
+++ b/Products/ZenUtils/ProcessQueue.py
@@ -164,7 +164,7 @@ class _ProcessQueueProtocol(ProcessProtocol):
 
     def __str__(self):
         if self._args:
-            return"process %s" % " ".join(self._args)
+            return "process %s" % " ".join([x or 'None' for x in self._args])
         else:
             return "process %s" % self._executable 
 


### PR DESCRIPTION
ISSUE:

```
2014-10-07 16:08:25,058 ERROR zen.zenactiond: sequence item 2: expected string, NoneType found
Traceback (most recent call last):
  File "/opt/zenoss/Products/ZenEvents/zenactiond.py", line 120, in processSignal
    action.execute(notification, signal)
  File "/opt/zenoss/Products/ZenModel/actions.py", line 667, in execute
    self._execute(notification, signal)
  File "/opt/zenoss/Products/ZenModel/actions.py", line 722, in _execute
    timeout_callback=_protocol.timedOut
  File "/opt/zenoss/Products/ZenUtils/ProcessQueue.py", line 75, in queueProcess
    log.debug("Adding process %s to queue" % processQProtocol)
  File "/opt/zenoss/Products/ZenUtils/ProcessQueue.py", line 167, in __str__
    return"process %s" % " ".join(self._args)
TypeError: sequence item 2: expected string, NoneType found
```

self._args must have a member of None - similar to this example:

```
>>> args=("foo", "bar", None, "baz")
>>> if args: "process %s" % " ".join(args)
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: sequence item 2: expected string, NoneType found
```

fix offending line similar to this:

```
>>> args=("foo", "bar", None, "baz")
>>> if args: "process %s" % " ".join([x or '' for x in args])
... 
'process foo bar  baz'
```
