### PR TITLE
ZEN-6475: show device description for deferred object internal error

### DIFF
--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -173,9 +173,9 @@ class MySshClient(SshClient):
         # member variable for zenmodeler
         d = self.command_defers.pop(command, None)
         if d is None:
-            log.error("Internal error where deferred object not in dictionary." \
+            log.error("Internal error where deferred object not in dictionary for %s." \
                       " Command = '%s' Data = '%s' Code = '%s' Stderr = '%s'",
-                      command.split()[0], data, code, stderr)
+                      self.description, command.split()[0], data, code, stderr)
         elif not d.called:
             d.callback((data, code, stderr))
 


### PR DESCRIPTION
DEMO - snippet from zencommand log:

```
2014-10-21 18:25:23,656 ERROR zen.zencommand: Testing Internal error where deferred object not in dictionary for root:*****@10.175.210.226:22. Command = '/usr/bin/uptime' Data = ' 09:11:13 up 74 days, 22:01,  0 users,  load average: 0.00, 0.00, 0.00
' Code = '0' Stderr = ''
```
