### PR TITLE
Fixes ZEN-15032

### DIFF
--- a/Products/ZenUI3/browser/resources/css/zenoss.css
+++ b/Products/ZenUI3/browser/resources/css/zenoss.css
@@ -2020,3 +2020,11 @@ span.syntax-text  {
   margin: 0 0 4px;
   width: 16px;
 }
+
+.compatibilityModeAlert .x-window-body{
+  background: transparent;
+}
+
+.compatibilityModeAlert .x-window-header-body{
+  background: #000000;
+}

--- a/Products/ZenUI3/browser/resources/js/zenoss/zenoss.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/zenoss.js
@@ -2,12 +2,16 @@
 /**
  * Check compatibilty mode turned on
  */
-Ext.onReady(function(){
-    if(navigator.userAgent.indexOf("Trident") > -1 && navigator.userAgent.indexOf("MSIE 7.0") > -1){i
-        Ext.Msg.alert(_t("Compatibility Mode Unsupported"), _t("Zenoss does not support running in IE Compatibility Mode."));
-    }
-});
-
+if(navigator.userAgent.indexOf("Trident") > -1 && navigator.userAgent.indexOf("MSIE 7.0") > -1){
+    Ext.onReady(function(){
+        Ext.Msg.show({
+		title: _t("Compatibility Mode Unsupported"), 
+		msg: _t("Zenoss does not support running in IE Compatibility Mode."),
+		buttons: Ext.Msg.OK,
+		cls: "compatibilityModeAlert"
+	});
+    });
+}
 /**
  * Global Ext settings.
  */


### PR DESCRIPTION
Reverse if statement so that the alert will show even with broken JS.
Add CSS styling so that the alert uses Zenoss style even with broken JS.
