### PR TITLE
remove jobs older than 24 hours

### DIFF
--- a/Products/Jobber/manager.py
+++ b/Products/Jobber/manager.py
@@ -382,12 +382,12 @@ class JobManager(ZenModelRM):
         for b in self.getCatalog()()[:]:
             try:
                 ob = b.getObject()
+                if ob.finished != None and ob.finished < untiltime:
+                    self.deleteJob(ob.getId())
+                elif ob.status == states.ABORTED and ob.started < untiltime:
+                    self.deleteJob(ob.getID())
             except ConflictError:
                 pass
-            if ob.finished != None and ob.finished < untiltime:
-                self.deleteJob(ob.getId())
-            elif ob.status == states.ABORTED and ob.started < untiltime:
-                self.deleteJob(ob.getID())
 
     def clearJobs(self):
         """


### PR DESCRIPTION
The root cause of https://jira.zenoss.com/browse/ZEN-11014 was that the jobs list grew too large and became too expensive to query/update. This PR removes jobs older than 24 hours whenever a new job or job chain is added.
