### PR TITLE
ZEN-14173: smartly sanitize event details, links and images tags are still usable

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
@@ -72,25 +72,6 @@ Ext.onReady(function() {
         '</table>'];
 
     /**
-     * The template used for additional event properties.
-     * Escapes HTML to prevent XSS
-     */
-    Zenoss.eventdetail.additional_detail_data_template = ['<table class="proptable" width="100%">',
-        '<tpl for="properties">',
-        '<tr class=\'{[xindex % 2 === 0 ? "even" : "odd"]}\'>',
-        '<td class="proptable_key">{key:htmlEncode}</td>',
-        '<td class="proptable_value">',
-        '<tpl switch="key">',
-            '<tpl case="eventClassMapping">',
-                '{value}',
-            '<tpl default>',
-                '{value:htmlEncode}',
-        '</tpl>',
-        '</td></tr>',
-        '</tpl>',
-        '</table>'];
-
-    /**
      * Template for log messages.
      * WAS: Zenoss.eventdetail.log_table_template
      */
@@ -487,7 +468,7 @@ Ext.onReady(function() {
             var eventDetailsSection = new Zenoss.eventdetail.DetailsSection({
                 id: 'event_detail_details_section',
                 title: _t('Event Details'),
-                template: Zenoss.eventdetail.additional_detail_data_template
+                template: Zenoss.eventdetail.detail_data_template
             });
             this.addSection(eventDetailsSection);
 

--- a/Products/Zuul/infos/event.py
+++ b/Products/Zuul/infos/event.py
@@ -18,6 +18,7 @@ from Products.ZenEvents.events2.proxy import EventProxy
 from Products.Zuul.interfaces import ICatalogTool
 from Products.ZenUtils.guid.interfaces import IGUIDManager
 from Products.Zuul.interfaces import IMarshallable
+from lxml.html.clean import clean_html
 
 
 _status_name = ProtobufEnum(EventSummary,'status').getPrettyName
@@ -358,7 +359,7 @@ class EventCompatDetailInfo(EventCompatInfo):
                     values = list(values)
                 for value in (v for v in values if v):
                     if not detail['name'].startswith('__meta__'):
-                        d.append(dict(key=detail['name'], value=value))
+                        d.append(dict(key=clean_html(detail['name']), value=clean_html(value)))
         return d
 
     @property


### PR DESCRIPTION
port from 425 that was reviewed by Joseph Hanson
