### PR TITLE
fixes ZEN-15230: zenpack install detects if it is running in control center container

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -582,7 +582,7 @@ class ZenPackCmd(ZenScriptBase):
                                help="Do not install the zenpack if the version is unchanged")
         self.parser.add_option('--service-id',
                                dest='serviceId',
-                               default='',
+                               default=os.getenv('CONTROLPLANE_SERVICED_ID', ''),
                                help=optparse.SUPPRESS_HELP)
 
         self.parser.prog = "zenpack"


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-15230

DEMO:

```
# plu@plu-9: serviced service status
NAME            ID              STATUS      UPTIME          HOST    IN_SYNC     DOCKER_ID
└─Zenoss.core.full  chclmwanhzquemv0j3jrkfc2j   Stopped                             
  ├─zenactiond      233r23bkckruhumwiw6um4k1e   Stopped                             
  ├─Zauth       2xhcx8j8yaxtg68de0tz3uwqz   Stopped                             
  ├─zeneventserver  32s2lz6mmpsc2uo8v06tn7tes   Running     2m28.812872229s     plu-9   Y       7a1b93d18538
  ├─redis       3sda7y57s71ubiqhdlp9ul01u   Running     3m2.361134956s      plu-9   Y       93c43d12184d
  ├─zeneventd       4e5vm9vjhur6k3bu5vl27s9r4   Stopped                             
  ├─MetricShipper   543xdzh6gnfqdu9cegourttja   Stopped                             
  ├─zenjobs     5n93prripfuhcczocq9p2uo2u   Stopped                             
  ├─RabbitMQ        822e5hbjnjwvspeq6tt18l4lo   Running     2m35.668989997s     plu-9   Y       19f0bea5abce
  ├─CentralQuery    8nbq28po8peu7pwj4w60ydx56   Stopped                             
  ├─MySQL       a2kgjssgk1e6wku6hu286hmki   Running     2m56.556768983s     plu-9   Y       02318b534423
  ├─Zope/0      admo64i3ao5t2299iipz4yrok/0 Running     2m41.245931885s     plu-9   Y       8ea8c021cde1
  ├─Zope/1      admo64i3ao5t2299iipz4yrok/1 Running     2m13.810006714s     plu-9   Y       3722faba1bf3
  ├─memcached       bxxsuo930rpbapcjz52ie44jg   Stopped                             
  ├─localhost       c0sn5yor16ktzonva1rmrf1nv                                   
  │ ├─localhost       d0e5pdwi7ett49ju9jh70qj28                                   
  │ │ ├─zencommand  1a242e0gh0c7gcekojo10wvhu   Stopped                             
  │ │ ├─zentrap     1zqjyicue3zsmsucbtnmddsua   Stopped                             
  │ │ ├─collectorredis  38huruvinedmrizgs3rfe1xss   Stopped                             
  │ │ ├─zenmodeler  3iarnkod8eq1m48i8xqtt476t   Stopped                             
  │ │ ├─zenstatus   51x0gfhda261ft9yor5ntwaym   Stopped                             
  │ │ ├─zenperfsnmp 6yzfvcrjswk7cko5c71wmlg9w   Stopped                             
  │ │ ├─zenjmx      8xrrldz6q8fenbag6fny9wac1   Stopped                             
  │ │ ├─zenpython   9e2pnpic662bvy1oz9l25r3oq   Stopped                             
  │ │ ├─zminion     aacpu664tv23hs1ftj69qw8m8   Stopped                             
  │ │ ├─zensyslog   ctnvhlmgdebfcl71uy118i6k9   Stopped                             
  │ │ ├─zenping     dbwjpsmoa7q7dki4l6tedjam4   Stopped                             
  │ │ ├─MetricShipper   dumw3kz8wld5dzmqd2f7dc7ir   Stopped                             
  │ │ └─zenprocess  ehhvy9stysstt34c1wad4bw9f   Stopped                             
  │ └─zenhub      dfagz55vo4825b70d4e2uk3ck   Stopped                             
  ├─opentsdb        ctqhtb6pn9c2ttv0q562jq2lm                                   
  │ ├─reader      8ww3cif57ec2kddge6sox05lk   Stopped                             
  │ └─writer      dyyx6j8lb5bydiknb7is06582   Stopped                             
  ├─HBase       eqswzj3tz1a5co9mu43o21n77                                   
  │ ├─RegionServer    3y4to1nj42jpg05e1765wb2ie   Stopped                             
  │ ├─ZooKeeper       5egdmp4lq2sm4qclmvs6ueo50   Stopped                             
  │ └─HMaster     8b2ggtwd4oesidd72m32sorpc   Stopped                             
  └─MetricConsumer  et8fen5fcbvaivemqgigwqfi2   Stopped                             

# plu@plu-9: zendev devshell
I1106 10:27:27.062307 00546 server.go:341] Connected to the control center at port 10.87.110.39:4979
I1106 10:27:27.272516 00546 server.go:435] Acquiring image from the dfs...
I1106 10:27:27.273576 00546 server.go:437] Acquired!  Starting shell
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
Last login: Thu Nov  6 16:27:28 UTC 2014
(zenoss)[zenoss@056f666035f6 ~]$ zenpack --link --install /mnt/src/enterprise_zenpacks/ZenPacks.zenoss.vSphere
'module' object has no attribute 'StrictRedis'
WARNING:ZenUtils.ZopeRequestLogger:ERROR connecting to redis. redis URL: redis://localhost:6379/0
WARNING:ZenUtils.ZopeRequestLogger:Please check the redis-url value in global.conf
2014-11-06 16:28:09,398 INFO zen.ZPLoader: Loading /mnt/src/enterprise_zenpacks/ZenPacks.zenoss.vSphere/ZenPacks/zenoss/vSphere/objects/objects.xml
2014-11-06 16:28:10,342 INFO zen.AddToPack: End loading objects
2014-11-06 16:28:10,342 INFO zen.AddToPack: Processing links
2014-11-06 16:28:10,507 INFO zen.AddToPack: Loaded 174 objects into the ZODB database
2014-11-06 16:28:10,543 INFO zen.HookReportLoader: Loading reports from /mnt/src/enterprise_zenpacks/ZenPacks.zenoss.vSphere/ZenPacks/zenoss/vSphere/reports
2014-11-06 16:28:10,557 INFO zen.HookReportLoader: loading: /vSphere/Hosts
2014-11-06 16:28:10,563 INFO zen.HookReportLoader: loading: /vSphere/Datastores
2014-11-06 16:28:10,566 INFO zen.HookReportLoader: loading: /vSphere/VMs
2014-11-06 16:28:10,569 INFO zen.HookReportLoader: loading: /vSphere/VMware Utilization
2014-11-06 16:28:10,614 INFO zen.HookReportLoader: loading: /vSphere/Clusters
2014-11-06 16:28:10,617 INFO zen.HookReportLoader: loading: /Enterprise Reports/VM to Datastore
2014-11-06 16:28:31,564 INFO zen.controlplane.client: Deploying service
2014-11-06 16:28:31,837 INFO zen.vsphere: Creating vNIC catalog
2014-11-06 16:28:31,839 INFO zen.vsphere: Reindexing all vNICs
2014-11-06 16:28:32,027 INFO zen.vsphere: Creating LUN catalog
2014-11-06 16:28:32,028 INFO zen.vsphere: Reindexing all LUNs
2014-11-06 16:28:32,031 INFO zen.vsphere: Reindexing all LUNs
2014-11-06 16:28:32,033 INFO zen.vSphere: Initializing vSphere performance counter info
(zenoss)[zenoss@056f666035f6 ~]$ logout

# plu@plu-9: serviced service status vsphere
NAME            ID              STATUS      UPTIME  HOST    IN_SYNC     DOCKER_ID
└─Zenoss.core.full  chclmwanhzquemv0j3jrkfc2j   Stopped                     
  └─localhost       c0sn5yor16ktzonva1rmrf1nv                           
    └─localhost     d0e5pdwi7ett49ju9jh70qj28                           
      └─zenvsphere  687c6yrguzmz5m6eiqxch4d5m   Stopped                     

# plu@plu-9: 
```
