### PR TITLE
fixes CC-532: set zenoss as default user for zenrun; allow override with DESIRED_USER

### DIFF
--- a/bin/zenrun
+++ b/bin/zenrun
@@ -46,6 +46,11 @@ if [[ $# -lt 1 ]]; then
     exit 255
 fi
 
+DESIRED_USER=${DESIRED_USER:-"zenoss"}
+if [[ "$(whoami)" != "$DESIRED_USER" ]]; then
+    exec su - "$DESIRED_USER" -c "DESIRED_USER=$DESIRED_USER $0 $*"
+fi
+
 RUNPATH=${RUNPATH:-$(dirname $0)/zenrun.d}
 PROGRAM=$1
 shift

--- a/bin/zenrun.d/help.sh
+++ b/bin/zenrun.d/help.sh
@@ -39,3 +39,8 @@ testdiscard() {
     echo -e "signaling host to discard the container ..."
     exit 1
 }
+
+testid() {
+    id
+    exit 1
+}


### PR DESCRIPTION
hardcoding su - zenoss was removed per:
  https://github.com/control-center/serviced/pull/1350
zenrun now becomes zenoss user if it is run as non-zenoss

DEMO1 - show zenpack list still works:

```
# plu@plu-9: serviced -v=1 service run -i zope zenpack list
...
I1203 15:29:22.588035 21036 server.go:439] command: docker [run ... su - root -c '${ZENHOME:-/opt/zenoss}/bin/zenrun zenpack.sh --service-id=bb87y4o5ur7kc3z6lmag07wr9 list']


...
ZenPacks.zenoss.ApacheMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.ApacheMonitor-2.1.4-py2.7.egg)
ZenPacks.zenoss.Dashboard (/opt/zenoss/ZenPacks/ZenPacks.zenoss.Dashboard-1.0.0-py2.7.egg)
ZenPacks.zenoss.DellMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.DellMonitor-2.2.0-py2.7.egg)
ZenPacks.zenoss.DeviceSearch (/opt/zenoss/ZenPacks/ZenPacks.zenoss.DeviceSearch-1.2.0-py2.7.egg)
ZenPacks.zenoss.DigMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.DigMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.DnsMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.DnsMonitor-2.1.0-py2.7.egg)
ZenPacks.zenoss.FtpMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.FtpMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.HPMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.HPMonitor-2.1.0-py2.7.egg)
ZenPacks.zenoss.HttpMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.HttpMonitor-2.1.0-py2.7.egg)
ZenPacks.zenoss.IRCDMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.IRCDMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.JabberMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.JabberMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.LDAPMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.LDAPMonitor-1.4.1-py2.7.egg)
ZenPacks.zenoss.LinuxMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.LinuxMonitor-1.3.0-py2.7.egg)
ZenPacks.zenoss.Microsoft.Windows (/opt/zenoss/ZenPacks/ZenPacks.zenoss.Microsoft.Windows-2.1.3-py2.7.egg)
ZenPacks.zenoss.MySqlMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.MySqlMonitor-3.0.3-py2.7.egg)
ZenPacks.zenoss.NNTPMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.NNTPMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.NtpMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.NtpMonitor-2.2.1-py2.7.egg)
ZenPacks.zenoss.PythonCollector (/opt/zenoss/ZenPacks/ZenPacks.zenoss.PythonCollector-1.6.0-py2.7.egg)
ZenPacks.zenoss.XenMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.XenMonitor-1.1.0-py2.7.egg)
ZenPacks.zenoss.ZenJMX (/opt/zenoss/ZenPacks/ZenPacks.zenoss.ZenJMX-3.11.0-py2.7.egg)
ZenPacks.zenoss.ZenossVirtualHostMonitor (/opt/zenoss/ZenPacks/ZenPacks.zenoss.ZenossVirtualHostMonitor-2.4.0-py2.7.egg)
I1203 15:29:35.168033 21036 shell.go:231] Command returned non-zero exit code 1.  Container not commited.
# plu@plu-9: 
```

DEMO2 - help testid shows zenoss:

```
# plu@plu-9: serviced -v=1 service run -i zope help testid
...
I1203 15:28:55.126462 20573 server.go:439] command: docker [run ... su - root -c '${ZENHOME:-/opt/zenoss}/bin/zenrun help.sh testid']
...


    This is an example template for a 'serviced run ...' command.  
    Each custom script must include a function '__DEFAULT__', which 
    defines the default action to be performed by the host when the 
    command completes and functions for each custom command that 
    requires a specific action from the host.

    Defined Commands:
        testcommit    testdiscard


uid=1337(zenoss) gid=1000(zenoss) groups=1000(zenoss)
I1203 15:29:01.771923 20573 shell.go:231] Command returned non-zero exit code 1.  Container not commited.
# plu@plu-9: 
```
