### PR TITLE
Only calculate excludeFilter if necessary

### DIFF
--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -619,10 +619,11 @@ class EventsRouter(DirectRouter):
         if excludeIds or len(exclude_params) > 0:
             if excludeIds is None:
                 excludeIds = {}
-
-        # make sure the exclude filter doesn't include the context otherwise all
-        # event actions wont have an effect.
-        excludeFilter = self._buildFilter(None, exclude_params, specificEventUuids=excludeIds.keys(), includeContextInUid=False)
+            # make sure the exclude filter doesn't include the context
+            # otherwise all event actions wont have an effect.
+            excludeFilter = self._buildFilter(None, exclude_params,
+                                              specificEventUuids=excludeIds.keys(),
+                                              includeContextInUid=False)
 
         log.debug('The exclude filter:' + str(excludeFilter))
         log.debug('Finished building request filters.')


### PR DESCRIPTION
Prevents calling keys() on excludeIds when it is None
Fixes https://jira.zenoss.com/browse/ZEN-15541

This fixes a logic error introduced in https://github.com/zenoss/zenoss-prodbin/commit/bcb4a0982c1efe9748743c853b0d4533aac9d31a
