### PR TITLE
Feature/zen 15681

### DIFF
--- a/bin/zenrun
+++ b/bin/zenrun
@@ -59,8 +59,6 @@ shift
 if ${NOCOMMIT:-false}; then
   if [[ -r $RUNPATH/$PROGRAM ]]; then
     source $RUNPATH/$PROGRAM
-  elif [[ -r $PROGRAM ]]; then
-    source $PROGRAM
   else
     $(which $PROGRAM) "$@"
     exit 1

--- a/bin/zenrun.d/percona.sh
+++ b/bin/zenrun.d/percona.sh
@@ -13,15 +13,17 @@ install(){
     ZVAR="/var/zenoss"
     PERCONADIR="${ZVAR}/percona"
     URL="http://www.percona.com/downloads/percona-toolkit/2.2.12/tarball/percona-toolkit-2.2.12.tar.gz"
-    if [ ! -d ${ZVAR} ]; then
+    if [[ ! -d ${ZVAR} ]]; then
       echo "No such directory: ${ZVAR}"
       return 1
     fi
 
+    echo "Installing percona to  ${PERCONADIR}"
+
     mkdir -p "${PERCONADIR}" || return "$?"
 
     echo "Downloading percona toolkit: ${URL}"
-    curl -L ${URL} |tar -xzv  --strip-components=1 -C ${PERCONADIR}
+    curl -L "${URL}" |tar -xzv  --strip-components=1 -C "${PERCONADIR}"
     RC=$?
     if [[ $RC != 0 ]]; then
         echo "Error downloading percona!"


### PR DESCRIPTION
serviced service run zope install-percona
I1219 16:55:13.243775 15195 server.go:341] Connected to the control center at port 10.87.110.177:4979
I1219 16:55:13.496783 15195 server.go:435] Acquiring image from the dfs...
I1219 16:55:13.497795 15195 server.go:437] Acquired!  Starting shell
2014/12/19 22:55:13 publisher init
2014/12/19 22:55:13
            {
                "network": {
                    "servers": [ "127.0.0.1:5043" ],
                    "ssl certificate": "/usr/local/serviced/resources/logstash/logstash-forwarder.crt",
                    "ssl key": "/usr/local/serviced/resources/logstash/logstash-forwarder.key",
                    "ssl ca": "/usr/local/serviced/resources/logstash/logstash-forwarder.crt",
                    "timeout": 15
                },
                "files": [

```
    {
        "paths": [ "/opt/zenoss/log/event.log" ],
        "fields": {"instance":"0","service":"abljo0ouao0vg8sjcgk0scxzv","type":"zope_eventlog"}
    },
            {
                "paths": [ "/opt/zenoss/log/Z2.log" ],
                "fields": {"instance":"0","service":"abljo0ouao0vg8sjcgk0scxzv","type":"zope_access_logs"}
            },
            {
                "paths": [ "/opt/zenoss/log/audit.log" ],
                "fields": {"instance":"0","service":"abljo0ouao0vg8sjcgk0scxzv","type":"zenossaudit"}
            }
            ]
        }
```

2014/12/19 22:55:13.845333 Launching harvester on new file: /opt/zenoss/log/event.log
2014/12/19 22:55:13.845415 Launching harvester on new file: /opt/zenoss/log/Z2.log
2014/12/19 22:55:13.845479 Loading client ssl certificate: /usr/local/serviced/resources/logstash/logstash-forwarder.crt and /usr/local/serviced/resources/logstash/logstash-forwarder.key
2014/12/19 22:55:13.848594 Starting harvester: /opt/zenoss/log/event.log
2014/12/19 22:55:13.848658 Current file offset: 750
2014/12/19 22:55:13.848697 Starting harvester: /opt/zenoss/log/Z2.log
2014/12/19 22:55:13.848775 Current file offset: 920
2014/12/19 22:55:14.034018 Setting trusted CA from file: /usr/local/serviced/resources/logstash/logstash-forwarder.crt
2014/12/19 22:55:14.034318 Connecting to 127.0.0.1:5043 (127.0.0.1)
2014/12/19 22:55:14.100594 Connected to 127.0.0.1
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
Downloading percona toolkit: http://www.percona.com/downloads/percona-toolkit/2.2.12/tarball/percona-toolkit-2.2.12.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0 1360k    0  5229    0     0  19090      0  0:01:12 --:--:--  0:01:12 19083percona-toolkit-2.2.12/README
percona-toolkit-2.2.12/MANIFEST
percona-toolkit-2.2.12/Makefile.PL
percona-toolkit-2.2.12/INSTALL
percona-toolkit-2.2.12/COPYING
percona-toolkit-2.2.12/Changelog
percona-toolkit-2.2.12/lib/
percona-toolkit-2.2.12/docs/
percona-toolkit-2.2.12/docs/percona-toolkit.pod
percona-toolkit-2.2.12/bin/
percona-toolkit-2.2.12/bin/pt-visual-explain
percona-toolkit-2.2.12/bin/pt-variable-advisor
percona-toolkit-2.2.12/bin/pt-upgrade
percona-toolkit-2.2.12/bin/pt-table-usage
percona-toolkit-2.2.12/bin/pt-table-sync
percona-toolkit-2.2.12/bin/pt-table-checksum
percona-toolkit-2.2.12/bin/pt-summary
percona-toolkit-2.2.12/bin/pt-stalk
percona-toolkit-2.2.12/bin/pt-slave-restart
percona-toolkit-2.2.12/bin/pt-slave-find
percona-toolkit-2.2.12/bin/pt-slave-delay
percona-toolkit-2.2.12/bin/pt-sift
percona-toolkit-2.2.12/bin/pt-show-grants
percona-toolkit-2.2.12/bin/pt-query-digest
percona-toolkit-2.2.12/bin/pt-pmp
percona-toolkit-2.2.12/bin/pt-online-schema-change
percona-toolkit-2.2.12/bin/pt-mysql-summary
percona-toolkit-2.2.12/bin/pt-mext
percona-toolkit-2.2.12/bin/pt-kill
percona-toolkit-2.2.12/bin/pt-ioprofile
percona-toolkit-2.2.12/bin/pt-index-usage
percona-toolkit-2.2.12/bin/pt-heartbeat
percona-toolkit-2.2.12/bin/pt-fk-error-logger
percona-toolkit-2.2.12/bin/pt-fingerprint
percona-toolkit-2.2.12/bin/pt-find
percona-toolkit-2.2.12/bin/pt-fifo-split
percona-toolkit-2.2.12/bin/pt-duplicate-key-checker
percona-toolkit-2.2.12/bin/pt-diskstats
percona-toolkit-2.2.12/bin/pt-deadlock-logger
percona-toolkit-2.2.12/bin/pt-config-diff
percona-toolkit-2.2.12/bin/pt-archiver
100 1360k  100 1360k    0     0  1935k      0 --:--:-- --:--:-- --:--:-- 1934k
percona-toolkit-2.2.12/bin/pt-align
Command returned non-zero exit code 1.  Container not commited.
