### PR TITLE
downgrade log.error to log.debug of zenhub health check warning for zenjobs success

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -994,7 +994,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
                 d.addErrback(errback)
                 return d
             else:
-                self.log.error('ZenHub health check: ZenHub may be down.')
+                self.log.debug('ZenHub health check: ZenHub may be down.')
                 self._signalZenHubAnswering(False)
         except pb.DeadReferenceError:
             self.log.warning("ZenHub health check: DeadReferenceError - lost connection to ZenHub.")


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-15892

ISSUE - This line is causing the jobs to be marked as failures. It looks like the health check is reporting a failure before the connection to zenhub is made
https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenHub/PBDaemon.py#L997:
```
2014-12-26 16:29:12,770 ERROR zen.ZenDisc: ZenHub health check: ZenHub may be down. 
```

DEMO - ( notice lack of "ZenHub health check" error):
```
Log file: /opt/zenoss/log/jobs/4c59cd28-49b4-4d4d-ab82-8f6dda7e5dc0.log

2015-01-05 15:51:37,943 INFO zen.Job: Job 4c59cd28-49b4-4d4d-ab82-8f6dda7e5dc0 (Products.Jobber.jobs.SubprocessJob) received
2015-01-05 15:51:37,981 INFO zen.Job: Starting job 4c59cd28-49b4-4d4d-ab82-8f6dda7e5dc0 (Products.Jobber.jobs.SubprocessJob)
2015-01-05 15:51:37,982 INFO zen.Job: Spawning subprocess: /opt/zenoss/bin/zendisc run --now -d test-rhel54.zenoss.loc --monitor localhost --deviceclass /Server/Linux --prod_state 1000
2015-01-05 15:51:42,378 INFO zen.ZenDisc: Connecting to localhost:8789
2015-01-05 15:51:42,386 INFO zen.ZenDisc: Connected to ZenHub
2015-01-05 15:51:43,006 INFO zen.ZenDisc: Looking for test-rhel54.zenoss.loc
2015-01-05 15:51:50,541 INFO zen.ZenDisc: Result: Discovered device test-rhel54.zenoss.loc.
2015-01-05 15:51:50,599 INFO zen.ZenDisc: skipping WMI-based collection, PySamba zenpack not installed
2015-01-05 15:51:50,635 INFO zen.ZenDisc: No Python plugins found for test-rhel54.zenoss.loc
2015-01-05 15:51:50,638 INFO zen.ZenDisc: No command plugins found for test-rhel54.zenoss.loc
2015-01-05 15:51:50,643 INFO zen.ZenDisc: SNMP collection device test-rhel54.zenoss.loc
2015-01-05 15:51:50,643 INFO zen.ZenDisc: plugins: zenoss.snmp.NewDeviceMap, zenoss.snmp.DeviceMap, zenoss.snmp.InterfaceMap, zenoss.snmp.RouteMap, zenoss.snmp.IpServiceMap, zenoss.snmp.HRFileSystemMap, zenoss.snmp.HRSWRunMap, zenoss.snmp.CpuMap
2015-01-05 15:51:50,648 INFO zen.ZenDisc: No portscan plugins found for test-rhel54.zenoss.loc
2015-01-05 15:51:56,646 INFO zen.SnmpClient: Device timed out: SNMP info for test-rhel54.zenoss.loc at 10.175.211.137:161 timeout: 1 tries: 6 version: v2c  community: public
2015-01-05 15:51:56,646 INFO zen.SnmpClient: snmp client finished collection for test-rhel54.zenoss.loc
2015-01-05 15:51:56,646 WARNING zen.SnmpClient: Device test-rhel54.zenoss.loc timed out: are your SNMP settings correct?
2015-01-05 15:51:56,647 INFO zen.ZenDisc: No change in configuration detected
2015-01-05 15:51:56,647 INFO zen.ZenDisc: Scan time: 6.11 seconds
2015-01-05 15:51:56,648 INFO zen.ZenDisc: Daemon ZenDisc shutting down
2015-01-05 15:51:56,657 INFO zen.publisher: publishing failed: [<twisted.python.failure.Failure <class 'twisted.internet.error.ConnectionLost'>>]
2015-01-05 15:51:56,657 INFO zen.publisher: queue still contains 3 metrics
2015-01-05 15:51:57,037 INFO zen.Job: Job 4c59cd28-49b4-4d4d-ab82-8f6dda7e5dc0 finished with result 0
```

![screen shot 2015-01-05 at 9 52 01](https://cloud.githubusercontent.com/assets/2837923/5615413/aef54c9c-94c0-11e4-97ce-a6c65cc36b82.png)
