### PR TITLE
Add a dummy license

### DIFF
--- a/Products/ZenUI3/docs/licenses.html
+++ b/Products/ZenUI3/docs/licenses.html
@@ -1,0 +1,3 @@
+This license is a mirage.  It should be replaced with a real license
+before shipping.  The Dockerfile that builds the production images is currently
+responsible for this.


### PR DESCRIPTION
This is necessary to run Zenoss w/devimg, and should be replaced before
shipping the actual product