### PR TITLE
ZEN-15393: updated regexp for Cisco ACS syslog messages

### DIFF
--- a/Products/ZenEvents/SyslogProcessing.py
+++ b/Products/ZenEvents/SyslogProcessing.py
@@ -44,7 +44,7 @@ r"%CARD-\S+:(SLOT\d+) %(?P<eventClassKey>\S+): (?P<summary>.*)",
 r"%(?P<eventClassKey>(?P<component>\S+)-(?P<overwriteSeverity>\d)-\S+): *(?P<summary>.*)",
 
 # Cisco ACS
-r"^(?P<ipAddress>\S+)\s+(?P<summary>(?P<eventClassKey>CisACS_\d\d_\S+)\s+(?P<eventKey>\S+)\s.*)",
+r"^(?P<ipAddress>\S+)\s+(?P<summary>(?P<eventClassKey>(CisACS_\d\d|CSCOacs)_\S+)\s+(?P<eventKey>\S+)\s.*)",
 
 # netscreen device msg
 r"device_id=\S+\s+\[\S+\](?P<eventClassKey>\S+\d+):\s+(?P<summary>.*)\s+\((?P<originalTime>\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d)\)",


### PR DESCRIPTION
Fixes https://jira.zenoss.com/browse/ZEN-15393,
Port of https://jira.zenoss.com/browse/ZEN-15936,
Originally reviewed by  Jason Peacock.