### PR TITLE
ZEN-16380: Retry to restore zenpacks that failed

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -376,13 +376,41 @@ class ZenPackCmd(ZenScriptBase):
                         depsSet.add(depName)
             zpsToSort[zpId] = depsSet
 
-        sortedPacks = toposort_flatten(zpsToSort)
-        if len(sortedPacks) != 0:
-            for pack in sortedPacks:
+        def doRestore(pack):
+            try:
                 self._restore(pack, zpsToRestore[pack][0], zpsToRestore[pack][1])
+                return True
+            except subprocess.CalledProcessError as cpe:
+                self.log.exception(cpe)
+                # Keep pack in list of sorted packs, and try again
+                # (ZEN-16380).  If B depends on A and A fails, then B will
+                # fail too, but that's OK, because it will just try again
+                return False
+
+        sortedPacks = toposort_flatten(zpsToSort)
+        triedReversing = False
+        if len(sortedPacks) > 0:
+            fixedSomething = True
+        while len(sortedPacks) > 0:
+            packListLen = len(sortedPacks)
+            # Keep track of all the packs that failed to restore
+            self.log.info("Attempting to install packs: %s", ", ".join(sortedPacks))
+            sortedPacks[:] = [ pack for pack in sortedPacks if not doRestore(pack) ]
+            if len(sortedPacks) == packListLen:
+                if triedReversing:
+                    self.log.error("Unable to install zenpacks: %s", ", ".join(sortedPacks))
+                    sys.exit(1)
+                else:
+                    # Try reversing the order or packs as a last ditch effort
+                    sortedPacks.reverse()
+                    triedReversing = True
+            elif len(sortedPacks) != 0:
+                self.log.info("Failed to install packs: %s, will try again", ", ".join(sortedPacks))
+
+        if not fixedSomething:
+            self.log.info("No broken zenpacks found")
         else:
-            if not fixedSomething:
-                self.log.info("No broken zenpacks found")
+            self.log.info("Successfully restored zenpacks: %s", ", ".join(sortedPacks))
 
     def _linkedRestore(self, zp):
         """
@@ -418,24 +446,24 @@ class ZenPackCmd(ZenScriptBase):
         for candidate in candidates:
             if candidate.lower().endswith(".egg"):
                 try:
-                     shutil.copy(candidate, tempfile.gettempdir())
-                     cmd = ["zenpack"]
-                     if filesOnly:
-                         cmd.append("--files-only")
-                     cmd.extend(["--install", os.path.join(tempfile.gettempdir(), os.path.basename(candidate))])
-                     try:
-                         with open(os.devnull, 'w') as fnull:
-                             # the first time fixes the easy-install path
-                             subprocess.check_call(cmd, stdout=fnull, stderr=fnull)
-                     except Exception:
-                         pass
-                     # the second time runs the loaders
-                     subprocess.check_call(cmd)
+                    shutil.copy(candidate, tempfile.gettempdir())
+                    cmd = ["zenpack"]
+                    if filesOnly:
+                        cmd.append("--files-only")
+                    cmd.extend(["--install", os.path.join(tempfile.gettempdir(), os.path.basename(candidate))])
+                    try:
+                        with open(os.devnull, 'w') as fnull:
+                            # the first time fixes the easy-install path
+                            subprocess.check_call(cmd, stdout=fnull, stderr=fnull)
+                    except Exception:
+                        pass
+                    # the second time runs the loaders
+                    subprocess.check_call(cmd)
                 finally:
-                     try:
-                         os.remove(os.path.join(tempfile.gettempdir(), os.path.basename(candidate)))
-                     except Exception:
-                         pass
+                    try:
+                        os.remove(os.path.join(tempfile.gettempdir(), os.path.basename(candidate)))
+                    except Exception:
+                        pass
             else:
                 self.log.warning("non-egg zenpacks can not currently be restored automatically: %s", candidate)
 


### PR DESCRIPTION
This is to cover a specific type of issue where a zenpack install tries
to touch database objects while the system has objects supplied by a
broken zenpack.  The solution is to try and fix the broken zenpack
objects, then retry the install of the pervasive touch-everything
zenpack.