### PR TITLE
Fixes Zenpack Installation on Europa Instance

### DIFF
--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -664,7 +664,7 @@ def monkeypatchDescriptors(zprops, transformerFactories):
     """
     for id, type in zprops:
         factory = transformerFactories.get(type, IdentityTransformer)
-        descriptor = PropertyDescriptor(id, type, factory())
+        descriptor = PropertyDescriptor(id, type, factory)
         setattr(ZenPropertyManager, id, descriptor)
 
 def setDescriptors(dmd):


### PR DESCRIPTION
When I tried to "zenpack --install....." on Europa instance I got error:

Traceback (most recent call last):
  File "/opt/zenoss/Products/ZenUtils/zenpack.py", line 736, in <module>
    zp.run()
  File "/opt/zenoss/Products/ZenUtils/zenpack.py", line 181, in run
    self.connect()
  File "/opt/zenoss/Products/ZenUtils/ZenScriptBase.py", line 52, in connect
    setDescriptors(self.dmd)
  File "/opt/zenoss/Products/ZenRelations/ZenPropertyManager.py", line 718, in setDescriptors
    monkeypatchDescriptors(zprops, dmd.propertyTransformers)
  File "/opt/zenoss/Products/ZenRelations/ZenPropertyManager.py", line 667, in monkeypatchDescriptors
    descriptor = PropertyDescriptor(id, type, factory())
TypeError: 'CrypterFactory' object is not callable

This should fix it.