### PR TITLE
fixes ZEN-16496: Cannot delete device from add device option.

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
@@ -300,9 +300,6 @@
             Zenoss.remote.JobsRouter.deleteJobs({
                 jobids: [record.get('uuid')]
             }, function(response) {
-                if (!response.success) {
-                    return;
-                }
                 if (record.get('status') !== "PENDING") {
                     Zenoss.remote.DeviceRouter.removeDevices({
                         uids: [record.get('deviceUid')],

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
@@ -136,9 +136,7 @@
                         Zenoss.remote.JobsRouter.deleteJobs({
                             jobids: [record.get('uuid')]
                         }, function(response) {
-                            if (response.success) {
-                                store.remove(record);
-                            }
+                            store.remove(record);
                         });
 
                         var uid = record.get('deviceUid');


### PR DESCRIPTION
Zenoss.remote.JobsRouter.deleteJobs doesn't return the response.