### PR TITLE
fixes ZEN-16757: zenhub should use socket options for keep alive on PB connections

### DIFF
--- a/Products/ZenHub/__init__.py
+++ b/Products/ZenHub/__init__.py
@@ -12,6 +12,8 @@
 
 XML_RPC_PORT = 8081
 PB_PORT = 8789
+OPTION_STATE = 1
+CONNECT_TIMEOUT = 60
 
 def installReactor():
     # Tries to install epoll first, then poll, and if neither are


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-16757

5.1.0 and 5.0.1 are missing Products/ZenHub/zenhub.py fix from 4.1.1 (https://jira.zenoss.com/browse/ZEN-6388) and 4.2.5:
https://dev.zenoss.com/tracint/browser/branches/core/zenoss-4.1.1-patches/patches/changeset_76100.diff?rev=76535


DEMO:
```
******** REMOTE ZENCOMMAND:
2015-02-20 17:41:32,441 INFO zen.zencommand: Attempting to connect to zenhub
2015-02-20 17:41:34,470 ERROR zen.zencommand: No event service: None

******** ZENHUB:
2015-02-20 16:48:40,435 DEBUG zen.ZenHub: set socket('0.0.0.0', 8789)  CONNECT_TIMEOUT:60  TCP_KEEPINTVL:15

2015-02-20 17:21:40,660 DEBUG zen.hub: removing listener for localhost:EventService
2015-02-20 17:21:40,660 DEBUG zen.hub: removing listener for localhost:CommandPerformanceConfig
```