### PR TITLE
fixes ZEN-17304: revert pull/735 from ZEN-16639

### DIFF
--- a/Products/ZenHub/services/CommandPerformanceConfig.py
+++ b/Products/ZenHub/services/CommandPerformanceConfig.py
@@ -145,7 +145,6 @@ class CommandPerformanceConfig(CollectorConfigService):
                     cmd.primaryUrlPath = comp.processClassPrimaryUrlPath()
                     cmd.generatedId = comp.id
                     cmd.displayName = comp.displayName
-                    cmd.sequence = comp.osProcessClass().sequence
 
                 # If the datasource supports an environment dictionary, use it
                 cmd.env = getattr(ds, 'env', None)

--- a/Products/ZenRRD/parsers/ps.py
+++ b/Products/ZenRRD/parsers/ps.py
@@ -138,16 +138,6 @@ class ps(CommandParser):
         lines = cmd.result.output.splitlines()[1:]
         metrics = map(self._extractProcessMetrics, lines)
         matchingMetrics = filter(matches, metrics)
-        
-        # We can not take into account processes that have already been
-        # matched by other process class
-        if hasattr(cmd, 'already_matched_cmdAndArgs'):
-            if cmd.already_matched_cmdAndArgs:
-                matchingMetrics = [ m for m in matchingMetrics if m[3] not in cmd.already_matched_cmdAndArgs ]
-                cmd.already_matched_cmdAndArgs.extend([ m[3] for m in matchingMetrics ])
-            else:
-                cmd.already_matched_cmdAndArgs = [ m[3] for m in matchingMetrics ]
-
         pids, rss, cpu = self._combineProcessMetrics(matchingMetrics)
 
         processSet = cmd.displayName

--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -459,30 +459,6 @@ class SshPerformanceCollectionTask(BaseTask):
         parsedResults = self._parseResults(resultList, cacheableDS)
         self._storeResults(parsedResults)
 
-    def _process_os_processes_results_in_sequence(self, process_datasources, collection_result):
-        """
-        Process OSProcesses in sequence order to avoid more than one OSProcess
-        match the same process
-        """
-        process_parseable_results = []
-
-        # Sort process_datasources by sequence
-        process_datasources.sort(key=lambda x: x.sequence)
-
-        already_matched = []
-
-        # Now we process datasources in sequence order
-        for datasource in process_datasources:
-            results = ParsedResults()
-            datasource.result = copy(collection_result)
-            datasource.already_matched_cmdAndArgs = already_matched
-            self._processDatasourceResults(datasource, results)
-            already_matched = datasource.already_matched_cmdAndArgs[:]
-            del datasource.already_matched_cmdAndArgs
-            process_parseable_results.append( (datasource, results) )
-
-        return process_parseable_results
-
     def _parseResults(self, resultList, cacheableDS):
         """
         Interpret the results retrieved from the commands and pass on
@@ -510,14 +486,6 @@ class SshPerformanceCollectionTask(BaseTask):
                 event = self._makeCmdEvent(datasource, msg, severity=Clear, event_key='Timeout')
                 # Re-use our results for any similar datasources
                 cache = cacheableDS.get(datasource.command, [])
-                if datasource.name == "OSProcess/ps":
-                    # We need to process all OSProcess in a special way to
-                    # avoid more than one OSProcess matching the same process
-                    process_datasources = [datasource]
-                    process_datasources.extend(cachedDsList)
-                    process_parseable_results = self._process_os_processes_results_in_sequence(process_datasources, datasource.result)
-                    parseableResults.extend(process_parseable_results)
-                    continue
                 for ds in cache:
                     ds.result = copy(datasource.result)
                     self._processDatasourceResults(ds, parsedResults)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17304

revert #735 from https://jira.zenoss.com/browse/ZEN-16639

DEMO - :
```
[zenoss@7fc542bb3757 zenoss]$ patch --backup -p1 -R < /tmp/735.diff  
patching file Products/ZenHub/services/CommandPerformanceConfig.py
patching file Products/ZenRRD/parsers/ps.py
patching file Products/ZenRRD/zencommand.py
[zenoss@7fc542bb3757 zenoss]$ zencommand run -d 10.87.208.186                                       
2015-04-01 19:56:10,607 INFO zen.zencommand: Connecting to localhost:8789
2015-04-01 19:56:10,622 INFO zen.zencommand: Connected to ZenHub
2015-04-01 19:56:12,973 INFO zen.zencommand: 1 devices processed (118 datapoints)
2015-04-01 19:56:12,973 INFO zen.collector.scheduler: Tasks: 2 Successful_Runs: 1 Failed_Runs: 0 Missed_Runs: 0 Queued_Tasks: 0 Running_Tasks: 1 
2015-04-01 19:56:12,973 INFO zen.CmdClient: command client finished collection for 10.87.208.186
2015-04-01 19:56:12,974 INFO zen.zencommand: Daemon CollectorDaemon shutting down
2015-04-01 19:56:12,985 INFO zen.publisher: publishing failed: Connection was closed cleanly.
[zenoss@7fc542bb3757 zenoss]$ 
```