### PR TITLE
fixes ZEN-16572: clean_html routine can fail causing event properties to...

### DIFF
--- a/Products/Zuul/infos/event.py
+++ b/Products/Zuul/infos/event.py
@@ -19,6 +19,7 @@ from Products.Zuul.interfaces import ICatalogTool
 from Products.ZenUtils.guid.interfaces import IGUIDManager
 from Products.Zuul.interfaces import IMarshallable
 from lxml.html.clean import clean_html
+from lxml.etree import ParserError
 
 
 _status_name = ProtobufEnum(EventSummary,'status').getPrettyName
@@ -359,7 +360,10 @@ class EventCompatDetailInfo(EventCompatInfo):
                     values = list(values)
                 for value in (v for v in values if v):
                     if not detail['name'].startswith('__meta__'):
-                        d.append(dict(key=clean_html(detail['name']), value=clean_html(value)))
+                        try:
+                            d.append(dict(key=clean_html(detail['name']), value=clean_html(value)))
+                        except ParserError:
+                            d.append(dict(key=detail['name'], value=value))
         return d
 
     @property


### PR DESCRIPTION
... not be displayed