### PR TITLE
ZEN-17431: Provide option to install zenpack without mutating CC service...

### DIFF
--- a/Products/ZenModel/ZenPack.py
+++ b/Products/ZenModel/ZenPack.py
@@ -205,6 +205,9 @@ class ZenPack(ZenModelRM):
     # Control Plane service ID for container executing this installation
     currentServiceId = ""
 
+    # Whether or not to skip control center service mutation at install time
+    ignoreServiceInstall = False
+
     # New-style zenpacks (eggs) have this set to True when they are
     # first installed
     eggPack = False
@@ -278,7 +281,8 @@ class ZenPack(ZenModelRM):
         previousVersion = self.prevZenPackVersion
         self.storeBackup()
         self.migrate(previousVersion)
-        self.installServices()
+        if not ZenPack.ignoreServiceInstall:
+            self.installServices()
 
     def storeBackup(self):
         """
@@ -350,6 +354,9 @@ class ZenPack(ZenModelRM):
         if not leaveObjects:
             self.removeZProperties(app)
             self.removeCatalogedObjects(app)
+        
+        # Once ZEN-16599 is fixed, make sure this exits cleanly even if 
+        # the service to delete does not exist
         self.removeServices(self.getServiceTag())
 
     def backup(self, backupDir, logger):

--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -225,10 +225,10 @@ class NonCriticalInstallError(Exception):
         Exception.__init__(self, message)
         self.message = message
 
-def InstallEggAndZenPack(dmd, eggPath, link=False, 
-                            filesOnly=False, sendEvent=True, 
+def InstallEggAndZenPack(dmd, eggPath, link=False,
+                            filesOnly=False, sendEvent=True,
                             previousVersion=None, forceRunExternal=False,
-                            fromUI=False, serviceId=None):
+                            fromUI=False, serviceId=None, ignoreServiceInstall=False):
     """
     Installs the given egg, instantiates the ZenPack, installs in
     dmd.ZenPackManager.packs, and runs the zenpacks's install method.
@@ -243,13 +243,14 @@ def InstallEggAndZenPack(dmd, eggPath, link=False,
                 try:
                     zp = InstallDistAsZenPack(dmd,
                                               d,
-                                              eggPath, 
-                                              link, 
+                                              eggPath,
+                                              link,
                                               filesOnly=filesOnly,
                                               previousVersion=previousVersion,
                                               forceRunExternal=forceRunExternal,
-                                              fromUI=fromUI, 
-                                              serviceId=serviceId)
+                                              fromUI=fromUI,
+                                              serviceId=serviceId,
+                                              ignoreServiceInstall=ignoreServiceInstall)
                     zenPacks.append(zp)
                 except NonCriticalInstallError, ex:
                     nonCriticalErrorEncountered = True
@@ -340,7 +341,7 @@ def InstallEgg(dmd, eggPath, link=False):
 
 def InstallDistAsZenPack(dmd, dist, eggPath, link=False, filesOnly=False,
                          previousVersion=None, forceRunExternal=False,
-                         fromUI=False, serviceId=None):
+                         fromUI=False, serviceId=None, ignoreServiceInstall=False):
     """
     Given an installed dist, install it into Zenoss as a ZenPack.
     Return the ZenPack instance.
@@ -422,6 +423,8 @@ def InstallDistAsZenPack(dmd, dist, eggPath, link=False, filesOnly=False,
                     cmd += ["--fromui"]
                 if serviceId:
                     cmd += ['--service-id', serviceId]
+                if ignoreServiceInstall:
+                    cmd += ['--ignore-service-install']
 
                 cmdStr = " ".join(cmd)
                 log.debug("launching sub process command: %s" % cmdStr)
@@ -440,6 +443,8 @@ def InstallDistAsZenPack(dmd, dist, eggPath, link=False, filesOnly=False,
                 #so we can't change the signature of install to take the
                 #previousVerison
                 zenPack.prevZenPackVersion = previousVersion
+                if ignoreServiceInstall:
+                    ZenPack.ignoreServiceInstall = True
                 zenPack.install(dmd)
                 zenPack.prevZenPackVersion = None
 

--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -224,7 +224,8 @@ class ZenPackCmd(ZenScriptBase):
                     filesOnly=self.options.filesOnly,
                     previousVersion= self.options.previousVersion,
                     fromUI=self.options.fromui,
-                    serviceId=self.options.serviceId)
+                    serviceId=self.options.serviceId,
+                    ignoreServiceInstall=self.options.ignoreServiceInstall)
             if os.path.isfile(self.options.installPackName):
                 packName = self.extract(self.options.installPackName)
             elif os.path.isdir(self.options.installPackName):
@@ -797,7 +798,12 @@ class ZenPackCmd(ZenScriptBase):
                                dest='serviceId',
                                default=os.getenv('CONTROLPLANE_SERVICED_ID', ''),
                                help=optparse.SUPPRESS_HELP)
-
+        self.parser.add_option('--ignore-service-install',
+                               dest='ignoreServiceInstall',
+                               action='store_true',
+                               default=False,
+                               help='On install of a zenpack, do not attempt to install '
+                                    'any associated services into the control center')
         self.parser.prog = "zenpack"
         ZenScriptBase.buildOptions(self)
         self.parser.defaults['logpath'] = zenPath('log')


### PR DESCRIPTION
...s

```
(zenoss)[zenoss@eca08902d8e8 dist]$ zenpack --ignore-service-install --install ZenPacks.zenoss.Import4-0.0.9dev-py2.7.egg
WARNING:root:
************************************************************
The compressed javascript file /opt/zenoss/Products/ZenUI3/browser/resources/js/deploy/zenoss-compiled.js
does not exist.  Zenoss will still run but UI performance is
HEAVILY DEGRADED.  Please fix by running inst/buildjs.sh.
************************************************************
2015-04-10 16:48:55,617 INFO zen.HookReportLoader: Loading reports from /opt/zenoss/ZenPacks/ZenPacks.zenoss.Import4-0.0.9dev-py2.7.egg/ZenPacks/zenoss/Import4/reports
(zenoss)[zenoss@eca08902d8e8 dist]$
```

Note that the CC services were not installed.