### PR TITLE
fixes ZEN-17652: set dmd.version for maintenance branch upgrades

### DIFF
--- a/Products/ZenModel/migrate/setDMDVersion.py
+++ b/Products/ZenModel/migrate/setDMDVersion.py
@@ -1,0 +1,27 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+__doc__='''
+
+Set dmd.version for the maintenance release when zenmigrate runs as part of
+upgrading the release.  This ensures that dmd.version is set when there are
+no migrate scripts between minor versions.
+
+'''
+import Migrate
+
+
+class setDMDVersion(Migrate.Step):
+    version = Migrate.Version(5, 0, 70)
+
+    def cutover(self, dmd):
+        ''' no-op cutover needed for Migrate.Step '''
+
+setDMDVersion()


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17652

TODO: when cherry-picking this into support/5.0.x branch, make sure to set Version to to next release (5, 0, 3)

DEMO - after running the upgrade on a 5.0.1 system, dmd.version should show 5.0.70:
```
[root@resmgr-501 ~]# serviced script run /root/5.0.x/upgrade-resmgr.txt --service Zenoss.resmgr
...
I0430 17:55:31.193890 00913 runner.go:160] executing step 12: SVC_RUN Zenoss.resmgr/Zope upgrade
I0430 17:55:31.775394 00913 eval.go:259] running: serviced service run 348wjyzaxee7klbcqjt8okfqr upgrade
...
I0430 17:56:24.192131 02067 shell.go:225] Committing container
I0430 17:57:00.631921 00913 runner.go:152] Executing exit functions
Script done, file is /var/log/serviced/script-2015-04-30-175127-root.log

[root@resmgr-501 ~]# serviced service attach mariadb-model su - zenoss
Last login: Thu Apr 30 22:57:31 UTC 2015
[zenoss@4beef7968235 ~]$ zendmd
Welcome to the Zenoss dmd command shell!
'dmd' is bound to the DataRoot. 'zhelp()' to get a list of commands.
In [1]: dmd.version
Out[1]: 'Zenoss 5.0.70'
```

DEMO - after running the upgrade on a 5.0.70 system, dmd.version should remain 5.0.70:
```
# plu@plu-mac: ssh root@resmgr-510
root@resmgr-510's password: 
Last login: Thu Apr 30 18:44:20 2015 from vpn-client17.zenoss.loc
[root@resmgr-510 ~]# serviced service attach zope/0 su - zenoss
This master has been configured to be in pool: default
Last login: Thu Apr 30 23:01:06 UTC 2015
[zenoss@f388b4810639 ~]$ cd /opt/zenoss/Products/ZenModel/migrate/
[zenoss@f388b4810639 migrate]$ rsync -a plu@plu-9:src/europa/src/core/Products/ZenModel/migrate/setDMDVersion.py .
The authenticity of host 'plu-9 (10.87.110.39)' can't be established.
ECDSA key fingerprint is 90:76:02:9d:4e:21:c7:15:4a:f9:87:1b:4b:fe:bb:72.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'plu-9,10.87.110.39' (ECDSA) to the list of known hosts.
plu@plu-9's password: 
[zenoss@f388b4810639 migrate]$ zendmd
Welcome to the Zenoss dmd command shell!
'dmd' is bound to the DataRoot. 'zhelp()' to get a list of commands.
In [1]: dmd.version
Out[1]: 'Zenoss 5.0.70'

In [2]: exit

[zenoss@f388b4810639 migrate]$ zenmigrate
[zenoss@f388b4810639 migrate]$ zendmd
Welcome to the Zenoss dmd command shell!
'dmd' is bound to the DataRoot. 'zhelp()' to get a list of commands.
In [1]: dmd.version
Out[1]: 'Zenoss 5.0.70'

In [2]: exit

[zenoss@f388b4810639 migrate]$ 
```