### PR TITLE
Make failed zenpack install exit properly

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -303,7 +303,10 @@ def InstallEgg(dmd, eggPath, link=False):
         out, err = p.communicate()
         p.wait()
         if p.returncode:
-            DoEasyUninstall(eggPath)
+            try:
+                DoEasyUninstall(eggPath)
+            except:
+                pass
             raise ZenPackException('Error installing the egg (%s): %s' %
                                 (p.returncode, err))
         zpDists = AddDistToWorkingSet(eggPath)


### PR DESCRIPTION
If something like a ```SystemExit``` gets raised in here, there's no indication that there was an issue and you just get a non-0 exit or the program.