### PR TITLE
ZEN-17714: Uninstall linked ZP

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -909,7 +909,7 @@ def RemoveZenPack(dmd, packName, filesOnly=False, skipDepsCheck=False,
             deleteFiles = zp.shouldDeleteFilesOnRemoval()
             if uninstallEgg:
                 if zp.isDevelopment():
-                    zenPackDir = zenPath('ZenPacks')
+                    zenPackDir = varPath('ZenPacks')
                     cmd = ('%s setup.py develop -u '
                             % binPath('python') +
                             '--site-dirs=%s ' % zenPackDir +


### PR DESCRIPTION
Prior to this fix, uninstalling a linked zenpack would not remove the
entry from easy-install.pth, or the egg link.