### PR TITLE
fix Migrate.Version

### DIFF
--- a/Products/ZenModel/migrate/ChangeConInfoEngine.py
+++ b/Products/ZenModel/migrate/ChangeConInfoEngine.py
@@ -19,7 +19,7 @@ log = logging.getLogger('zen.Migrate')
 class ChangeConInfoEngine(Migrate.Step):
     " Change engine for connection_info table. "
 
-    version = Migrate.Version(5,0,70)
+    version = Migrate.Version(5,0,3)
 
     def cutover(self, dmd):
         conf = GlobalConfig.globalConfToDict()


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-17756

UPGRADE from 5.0.0:
```
INFO:zen.migrate:Database going to version Zenoss 5.0.70
INFO:zen.migrate:Installing addPrefixToTriggerRule (5.0.3)
INFO:zen.migrate:Installing setDMDVersion (5.0.3)
INFO:zen.migrate:Installing ChangeConInfoEngine (5.0.70)
```

ISSUE:
```
# serviced service attach mariadb-model su - zenoss
[zenoss@5e1cab152109 ~]$ echo "print 'dmd.version=%s' % dmd.version;" | zendmd --script /dev/stdin
dmd.version=Zenoss 5.0.70
```