### PR TITLE
ZEN-16855: Linux_ifconfig Command Plugin fails on CentOS 7

### DIFF
--- a/Products/DataCollector/plugins/zenoss/cmd/linux/ifconfig.py
+++ b/Products/DataCollector/plugins/zenoss/cmd/linux/ifconfig.py
@@ -15,7 +15,6 @@ ifconfig maps a linux ifconfig command to the interfaces relation.
 import re
 
 from Products.DataCollector.plugins.CollectorPlugin import LinuxCommandPlugin
-from pprint import pprint
 
 speedPattern = re.compile(r'(\d+)\s*[gm]bps', re.I)
 
@@ -67,7 +66,7 @@ class ifconfig(LinuxCommandPlugin):
     ip_ifstart = re.compile(r"^(\d+):\s(\w+):\s(.*)mtu\s(\d+)(.*)")
     ip_v4addr = re.compile(r"inet (\S+)")
     ip_v6addr = re.compile(r"inet6 (\S+)")
-    ip_hwaddr = re.compile(r"link/(\S+)\s(\S+)") 
+    ip_hwaddr = re.compile(r"link/(\S+)\s(\S+)")
 
     def process(self, device, results, log):
         log.info('Modeler %s processing data for device %s', self.name(), device.id)


### PR DESCRIPTION
Changes:
 - Updated flags 
 - Renamed interfaces names exactly as for ifconfig
 
Retested again, Screenshot https://www.dropbox.com/s/imov2b062jzuvrd/Screenshot%202015-05-22%2000.33.52.png?dl=0
