### PR TITLE
ZEN-18163 When adding a device, several zProperties get locally set t…

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -1124,7 +1124,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
 
         # apply any zProperties to self
         for prop, value in zProperties.items():
-            if value is not None:
+            if value is not None and value != "":
                 # setZenProperty doesn't set it if it's the same value, so no
                 # need to check here
                 self.setZenProperty(prop, value)


### PR DESCRIPTION
…o blank values on it (only started happening in RM 5.0.3).