### PR TITLE
Feature/zen 16748 revert

### DIFF
--- a/Products/Zuul/decorators.py
+++ b/Products/Zuul/decorators.py
@@ -13,8 +13,8 @@ from decorator import decorator
 from AccessControl import Unauthorized
 from Products import Zuul
 from Products.ZenUtils.Ext import DirectResponse
-from zenoss.protocols.services import ServiceConnectionError, ZepConnectionTimeout
-from zenoss.protocols.services.zep import ZepConnectionError
+from zenoss.protocols.services import ServiceConnectionError
+from zenoss.protocols.services.zep import ZepConnectionError, ZepConnectionTimeout
 
 import logging
 import threading

--- a/Products/Zuul/decorators.py
+++ b/Products/Zuul/decorators.py
@@ -14,7 +14,7 @@ from AccessControl import Unauthorized
 from Products import Zuul
 from Products.ZenUtils.Ext import DirectResponse
 from zenoss.protocols.services import ServiceConnectionError
-from zenoss.protocols.services.zep import ZepConnectionError, ZepConnectionTimeout
+from zenoss.protocols.services.zep import ZepConnectionError
 
 import logging
 import threading
@@ -128,9 +128,6 @@ def serviceConnectionError(func, *args, **kwargs):
         f = func(*args, **kwargs)
         setattr(attempts, 'value', 0)
         return f
-    except ZepConnectionTimeout, e:
-        log.warn('Connection to zeneventserver timed out.')
-        msg = 'Connection to zeneventserver timed out, please try again.'
     except ZepConnectionError, e:
         count += 1
         setattr(attempts, 'value', count)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-16748

reverting: https://github.com/zenoss/zenoss-prodbin/pull/913

ISSUE:
```
Waiting for zeneventserver to start.....
Installing pack ZenPacks.zenoss.ZenJMX from /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX
ERROR:zen.ZenPackCmd:zenpack command failed
Traceback (most recent call last):
...
  File "/opt/zenoss/Products/Zuul/decorators.py", line 16, in <module>
    from zenoss.protocols.services import ServiceConnectionError, ZepConnectionTimeout
zope.configuration.xmlconfig.ZopeXMLConfigurationError: File "/opt/zenoss/etc/site.zcml", line 16.2-16.23
    ZopeXMLConfigurationError: File "/opt/zenoss/Products/ZenUI3/configure.zcml", line 16.4-16.33
    ZopeXMLConfigurationError: File "/opt/zenoss/Products/ZenUI3/browser/configure.zcml", line 24.0-24.33
    ZopeXMLConfigurationError: File "/opt/zenoss/Products/ZenUI3/browser/javascript.zcml", line 7.0-13.10
    ImportError: cannot import name ZepConnectionTimeout
stopping...
dumping DBs
```

DEMO:
```
# plu@plu-9: zendev build devimg
...
Waiting for zeneventserver to start.....
Installing pack ZenPacks.zenoss.ZenJMX from /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX
2015-06-11 20:35:35,122 INFO zen.ZPLoader: Loading /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX/ZenPacks/zenoss/ZenJMX/objects/objects.xml
2015-06-11 20:35:35,353 INFO zen.AddToPack: End loading objects
2015-06-11 20:35:35,353 INFO zen.AddToPack: Processing links
2015-06-11 20:35:35,496 INFO zen.AddToPack: Loaded 45 objects into the ZODB database
2015-06-11 20:35:35,540 INFO zen.HookReportLoader: Loading reports from /mnt/src/zenpacks/ZenPacks.zenoss.ZenJMX/ZenPacks/zenoss/ZenJMX/reports
Creating /opt/zenoss/zenjmx-libs
```