### PR TITLE
ZEN-18377: Error in modelling using SSH Linux devices with ethernet d…

### DIFF
--- a/Products/DataCollector/plugins/zenoss/cmd/linux/ifconfig.py
+++ b/Products/DataCollector/plugins/zenoss/cmd/linux/ifconfig.py
@@ -51,7 +51,7 @@ class ifconfig(LinuxCommandPlugin):
            'zInterfaceMapIgnoreNames', 'zInterfaceMapIgnoreTypes')
 
     # variables for ifconfig
-    ifstart = re.compile(r"^(\w+):?\s+")
+    ifstart = re.compile(r"^(\S+?):?\s+")
     oldiftype = re.compile(r"^\S+\s+Link encap:(.+)HWaddr (\S+)"
                            r"|^\S+\s+Link encap:(.+)")
     v4addr = re.compile(r"inet addr:(\S+).*Mask:(\S+)"
@@ -64,7 +64,7 @@ class ifconfig(LinuxCommandPlugin):
     newifctype = re.compile(r"txqueuelen\s+\d+\s+\(([^)]+)\)")
 
     # variables for ip tool (ip addr)
-    ip_ifstart = re.compile(r"^(\d+):\s(\w+):\s(.*)mtu\s(\d+)(.*)")
+    ip_ifstart = re.compile(r"^(\d+):\s(\S+):\s(.*)mtu\s(\d+)(.*)")
     ip_v4addr = re.compile(r"inet (\S+)")
     ip_v6addr = re.compile(r"inet6 (\S+)")
     ip_hwaddr = re.compile(r"link/(\S+)\s(\S+)")


### PR DESCRIPTION
…evices with multiple IP addresses

https://jira.zenoss.com/browse/ZEN-18377

Fixed RegExps to handle interface names with colon(:). I.e.:

    eth0:1    Link encap:Ethernet  HWaddr 00:50:56:8A:0A:28

or

    eth0:2: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001