### PR TITLE
fixes ZEN-17569: Editing the "Details" of a manually added "IP Servic…

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/ComponentPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/ComponentPanel.js
@@ -1043,7 +1043,7 @@ Ext.define("Zenoss.component.IpServicePanel", {
                 dataIndex: 'ipaddresses',
                 header: _t('IPs'),
                 renderer: function(ips) {
-                  return Ext.isEmpty(ips) ? '' : ips.join(', ');
+                  return Ext.isEmpty(ips) ? '' : Ext.isArray(ips) ? ips.join(', ') : ips.toString();
                 }
             },{
                 id: 'description',


### PR DESCRIPTION
…e" breaks IP Services Component View
