### PR TITLE
ZEN-18858: Merge pull request #969 from zenoss/feature/ZEN-18858

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -24,7 +24,7 @@ import re
 from toposort import toposort_flatten
 from zipfile import ZipFile
 from StringIO import StringIO
-from pkg_resources import parse_requirements, Distribution, DistributionNotFound, get_distribution, parse_version, iter_entry_points
+from pkg_resources import parse_requirements, Distribution, DistributionNotFound, get_distribution, parse_version, iter_entry_points, EGG_NAME
 
 import Globals
 import transaction
@@ -385,6 +385,7 @@ class ZenPackCmd(ZenScriptBase):
 
         # Figure out which packs have dependencies, and sort them accordingly
         zpsToSort = {}
+
         pattern = '(ZenPacks\.zenoss\.[a-zA-Z\.]*)'
         for zpId in zpsToRestore.iterkeys():
             zp = self.dmd.ZenPackManager.packs._objects[zpId]
@@ -424,8 +425,7 @@ class ZenPackCmd(ZenScriptBase):
 
         sortedPacks = toposort_flatten(zpsToSort)
         triedReversing = False
-        if len(sortedPacks) > 0:
-            fixedSomething = True
+        fixedSomething = len(sortedPacks) > 0
         while len(sortedPacks) > 0:
             packListLen = len(sortedPacks)
             # Keep track of all the packs that failed to restore
@@ -459,35 +459,39 @@ class ZenPackCmd(ZenScriptBase):
         with open(os.devnull, 'w') as fnull:
             subprocess.check_call(cmd, stdout=fnull, stderr=fnull)
 
-    def _restore(self, zpId, version, filesOnly):
-        # glob for backup
-        # This is meant to handle standard zenpack naming convention - for exmaple,
-        #    ZenPacks.zenoss.OpenStack-1.2.4dev19_5159496-py2.7.egg
-        backupDirs = (zenPath(".ZenPacks"), zenPath("packs"))
-        dashIndex = version.find('-')
-        # If the version has a dash in it, replace it with an underscore
-        if dashIndex != -1:
-            version = list(version)
-            version[dashIndex] = '_'
-            version = ''.join(version)
-        patterns = [backupDir + "/%s-%s-*" % (zpId, version) for backupDir in backupDirs]
-        # Look through potential .egg locations, breaking out once we find one
-        # (AKA prefer the first location)
-        for pattern in patterns:
-            self.log.info("looking for %s", pattern)
-            candidates = glob.glob(pattern)
-            if len(candidates) > 0:
+    def _restore(self, zenpackID, zenpackVersion, filesOnly):
+        # if the version has a dash, replace with an underscore
+        zenpackVersion = zenpackVersion.replace("-", "_", 1)
+        # look for the egg
+        eggs = []
+        for dirpath in zenPath(".ZenPacks"), zenPath("packs"):
+            for f in os.listdir(dirpath):
+                # verify the .egg extension and strip it from the egg name
+                base, ext = os.path.splitext(f)
+                if ext != ".egg":
+                    break
+                # make sure this is the standard egg name format
+                match = EGG_NAME(base)
+                if not match:
+                    break
+                # extrapolate the values of the name and version
+                # NOTE: also has groupings for 'pyver' and 'plat' if needed for
+                # later.
+                name, version = match.group('name', 'ver')
+                if name == zenpackID and (not zenpackVersion or version == zenpackVersion):
+                    eggs.append(os.path.join(dirpath, f))
+            # no point in checking the other dirpaths if an egg has been found
+            if len(eggs) > 0:
                 break
-        if len(candidates) == 0:
-            self.log.info("could not find install candidate for %s %s", zpId, version)
+        if len(eggs) == 0:
+            self.log.info("Could not find install candidate for %s (%s)", zenpackID, zenpackVersion)
             return
-        if len(candidates) > 1:
-            self.log.error("Found more than one install candidate for %s %s (%s), skipping",
-                          zpId, version, ", ".join(candidates))
+        elif len(eggs) > 1:
+            eggpaths = ", ".join(eggs)
+            self.log.error("Found more than one install candidate for %s (%s): %s [skipping]", zenpackID, zenpackVersion, eggpaths)
             return
-
-        # Make the code below this easier to read
-        candidate = candidates[0]
+        candidate = eggs[0]
+        self.log.info("Loading candidate %s", candidate)
         if candidate.lower().endswith(".egg"):
             try:
                 shutil.copy(candidate, tempfile.gettempdir())


### PR DESCRIPTION
ZEN-18858: Use egg name parser to figure out how to fix broken zenpacks
Conflicts:
	Products/ZenUtils/zenpack.py

https://github.com/zenoss/zenoss-prodbin/pull/969

DEMO:
```bash
$ serviced service run zope zenpack restore
I0723 13:32:29.831465 08928 server.go:341] Connected to the control center at port 172.17.42.1:4979
I0723 13:32:30.324930 08928 server.go:435] Acquiring image from the dfs...
I0723 13:32:30.326152 08928 server.go:437] Acquired!  Starting shell
I0723 13:32:30.327276 08928 shell.go:215] started command in container &{/usr/bin/docker [/usr/bin/docker run -v /home/smousa/src/europa/src/golang/bin:/serviced -v /home/smousa/src/europa/src/core:/mnt/pwd -v /home/smousa/src/europa/src/golang/src/github.com/control-center/serviced/isvcs/resources:/usr/local/serviced/resources -u root -w / -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenpack-backup:/opt/zenoss/.ZenPacks -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/.ssh:/home/zenoss/.ssh -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/var-zenpacks:/var/zenoss -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenjobs:/opt/zenoss/log/jobs -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenoss-custom-patches:/opt/zenoss/patches -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenoss-custom-patches-pc:/opt/zenoss/.pc -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenoss-export:/opt/zenoss/export -v /opt/serviced/var/volumes/3msr9vyxg0g4du581gb2x0zqr/zenoss-var-ext:/opt/zenoss/var/ext --name=5fyBKEJ1qG0nm9MuyD5BA8 -e CONTROLPLANE_SYSTEM_USER=system_user  -e CONTROLPLANE_SYSTEM_PASSWORD=6gwsmobconvybkdcvollm00nf  -e SERVICED_NOREGISTRY= -e SERVICED_IS_SERVICE_SHELL=true -e SERVICED_SERVICE_IMAGE=localhost:5000/3msr9vyxg0g4du581gb2x0zqr/core_5.1 localhost:5000/3msr9vyxg0g4du581gb2x0zqr/core_5.1 /serviced/serviced --logtostderr=false service proxy --autorestart=false --disable-metric-forwarding --logstash=true --logstash-idle-flush-time=100ms --logstash-settle-time=5s 75pvhobum1ky92psuiwra9zxi 0 su - root -c '${ZENHOME:-/opt/zenoss}/bin/zenrun zenpack.sh --service-id=75pvhobum1ky92psuiwra9zxi restore'] []  %!s(*os.File=&{0xc20803c1b0}) %!s(*os.File=&{0xc20803c1e0}) %!s(*os.File=&{0xc20803c210}) [] %!s(*syscall.SysProcAttr=<nil>) %!s(*os.Process=&{9003 0 0}) <nil> <nil> %!s(bool=false) [%!s(*os.File=&{0xc20803c1b0}) %!s(*os.File=&{0xc20803c1e0}) %!s(*os.File=&{0xc20803c210})] [] [] [] %!s(chan error=0xc2081212c0)}
WARNING: could not read default configs: open /etc/default/serviced: no such file or directory
2015/07/23 18:32:30 publisher init
2015/07/23 18:32:30 
			{
				"network": {
					"servers": [ "127.0.0.1:5043" ],
					"ssl certificate": "/usr/local/serviced/resources/logstash/logstash-forwarder.crt",
					"ssl key": "/usr/local/serviced/resources/logstash/logstash-forwarder.key",
					"ssl ca": "/usr/local/serviced/resources/logstash/logstash-forwarder.crt",
					"timeout": 15
				},
				"files": [
					
		{
			"paths": [ "/opt/zenoss/log/event.log" ],
			"fields": {"instance":"0","service":"75pvhobum1ky92psuiwra9zxi","type":"zope_eventlog"}
		},
				{
					"paths": [ "/opt/zenoss/log/Z2.log" ],
					"fields": {"instance":"0","service":"75pvhobum1ky92psuiwra9zxi","type":"zope_access_logs"}
				},
				{
					"paths": [ "/opt/zenoss/log/audit.log" ],
					"fields": {"instance":"0","service":"75pvhobum1ky92psuiwra9zxi","type":"zenossaudit"}
				}
				]
			}
2015/07/23 18:32:30.817036 Launching harvester on new file: /opt/zenoss/log/event.log
2015/07/23 18:32:30.817111 Launching harvester on new file: /opt/zenoss/log/Z2.log
2015/07/23 18:32:30.817194 Loading client ssl certificate: /usr/local/serviced/resources/logstash/logstash-forwarder.crt and /usr/local/serviced/resources/logstash/logstash-forwarder.key
2015/07/23 18:32:30.819252 Starting harvester: /opt/zenoss/log/event.log
2015/07/23 18:32:30.819298 Current file offset: 750
2015/07/23 18:32:30.819356 Starting harvester: /opt/zenoss/log/Z2.log
2015/07/23 18:32:30.819431 Current file offset: 1380
2015/07/23 18:32:31.032914 Setting trusted CA from file: /usr/local/serviced/resources/logstash/logstash-forwarder.crt
2015/07/23 18:32:31.033366 Connecting to 127.0.0.1:5043 (127.0.0.1) 
2015/07/23 18:32:31.103109 Connected to 127.0.0.1
Trying to connect to logstash server... 127.0.0.1:5042
Connected to logstash server.
INFO:zen.ZenPackCmd:Restoring zenpacks
INFO:zen.ZenPackCmd:Attempting to install packs: ZenPacks.zenoss.WSMAN
INFO:zen.ZenPackCmd:Loading candidate /opt/zenoss/.ZenPacks/ZenPacks.zenoss.WSMAN-1.0.1.egg
INFO:zen.ZenPackCMD:Previous ZenPack exists with same name ZenPacks.zenoss.WSMAN
INFO:zen.ZenPackCmd:Successfully restored zenpacks!
I0723 13:32:58.967300 08928 shell.go:250] Committing container
```