### PR TITLE
ZEN-15413: Weak Password Hashing Algorithm

### DIFF
--- a/Products/ZenUtils/__init__.py
+++ b/Products/ZenUtils/__init__.py
@@ -17,8 +17,9 @@ from patches import mysqladaptermonkey
 from patches import signalsmonkey
 from patches import advancedquerymonkey
 from patches import xmlmonkey
+from Products.ZenUtils import pbkdf2  # Register PBKDF2 for password hashing
 from Products.ZenUtils.Utils import unused
-unused(pasmonkey, dirviewmonkey, advancedquerymonkey, mysqladaptermonkey, signalsmonkey, xmlmonkey)
+unused(pasmonkey, dirviewmonkey, advancedquerymonkey, mysqladaptermonkey, signalsmonkey, xmlmonkey, pbkdf2)
 
 from Products.ZenUtils.MultiPathIndex import MultiPathIndex , \
                                              manage_addMultiPathIndex, \

--- a/Products/ZenUtils/patches/pasmonkey.py
+++ b/Products/ZenUtils/patches/pasmonkey.py
@@ -28,6 +28,7 @@ import urlparse
 from uuid import uuid1
 from cgi import parse_qs
 from Acquisition import aq_base
+from AccessControl import AuthEncoding
 from AccessControl.SpecialUsers import emergency_user
 from zope.event import notify
 from ZODB.POSException import POSKeyError
@@ -227,6 +228,20 @@ def authenticateCredentials( self, credentials ):
 
 
 ZODBUserManager.ZODBUserManager.authenticateCredentials = authenticateCredentials
+
+
+def _pw_encrypt( self, password ):
+    """Returns the AuthEncoding encrypted password
+
+    If 'password' is already encrypted, it is returned
+    as is and not encrypted again.
+    """
+    if AuthEncoding.is_encrypted(password):
+        return password
+    return AuthEncoding.pw_encrypt(password, encoding='PBKDF2-SHA256')
+
+ZODBUserManager.ZODBUserManager._pw_encrypt = _pw_encrypt
+
 
 def extractCredentials(self, request):
     creds = {}

--- a/Products/ZenUtils/pbkdf2.py
+++ b/Products/ZenUtils/pbkdf2.py
@@ -37,10 +37,10 @@ class PBKDF2DigestScheme:
 
             <iterations>$<base64_salt>$<base64_hash>
         """
-        salt = self._generate_salt(DEFAULT_SALT_LEN)
+        salt = _generate_salt(DEFAULT_SALT_LEN)
         iterations = DEFAULT_ITERATIONS_COUNT
 
-        password_hash = self._encrypt(pw, salt, iterations, DEFAULT_HASH_LEN)
+        password_hash = _encrypt(pw, salt, iterations, DEFAULT_HASH_LEN)
 
         return '%s$%s$%s' % (iterations, base64.b64encode(salt),
                              base64.b64encode(password_hash))
@@ -63,24 +63,25 @@ class PBKDF2DigestScheme:
         if iterations <= 0:
             return False
 
-        attempt_hash = self._encrypt(attempt, salt, iterations,
-                                     len(password_hash))
+        attempt_hash = _encrypt(attempt, salt, iterations, len(password_hash))
 
         return constant_time.bytes_eq(attempt_hash, password_hash)
 
-    def _generate_salt(self, salt_len):
-        """Generates random string for salt."""
-        return os.urandom(salt_len)
 
-    def _encrypt(self, password, salt, iterations, hash_len):
-        """Performs key derivation according to the PKCS#5 standard (v2.0), by
-        means of the PBKDF2 algorithm using HMAC-SHA256 as a pseudorandom
-        function.
-        """
-        backend = default_backend()
-        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=hash_len,
-                         salt=salt, iterations=iterations, backend=backend)
-        return kdf.derive(password)
+def _generate_salt(salt_len):
+    """Generates random string for salt."""
+    return os.urandom(salt_len)
+
+
+def _encrypt(password, salt, iterations, hash_len):
+    """Performs key derivation according to the PKCS#5 standard (v2.0), by
+    means of the PBKDF2 algorithm using HMAC-SHA256 as a pseudorandom
+    function.
+    """
+    backend = default_backend()
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=hash_len,
+                     salt=salt, iterations=iterations, backend=backend)
+    return kdf.derive(password)
 
 
 registerScheme('PBKDF2-SHA256', PBKDF2DigestScheme())

--- a/Products/ZenUtils/pbkdf2.py
+++ b/Products/ZenUtils/pbkdf2.py
@@ -1,0 +1,86 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""This module provides PKCS#5 v2.0 Password-Based Key Derivation (PBKDF2)
+algorithm for secure password hashing.
+"""
+
+import base64
+import os
+
+from AccessControl.AuthEncoding import registerScheme
+
+from cryptography.hazmat.primitives import hashes, constant_time
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.backends import default_backend
+
+
+# Default number of iterations to perform of the hash function.
+DEFAULT_ITERATIONS_COUNT = 100000
+
+DEFAULT_HASH_LEN = 24  # Default length of the generated hash.
+DEFAULT_SALT_LEN = 24  # Default length of the random generated salt.
+
+
+class PBKDF2DigestScheme:
+
+    def encrypt(self, pw):
+        """Encrypt the provided plain text password.
+
+        Returns string in format:
+
+            <iterations>$<base64_salt>$<base64_hash>
+        """
+        salt = self._generate_salt(DEFAULT_SALT_LEN)
+        iterations = DEFAULT_ITERATIONS_COUNT
+
+        password_hash = self._encrypt(pw, salt, iterations, DEFAULT_HASH_LEN)
+
+        return '%s$%s$%s' % (iterations, base64.b64encode(salt),
+                             base64.b64encode(password_hash))
+
+    def validate(self, reference, attempt):
+        """Validate the provided password string.
+
+        Reference is the correct password, which may be encrypted; attempt is
+        clear text password attempt.
+        """
+        try:
+            iterations_str, salt_b64, password_hash_b64 = reference.split('$')
+
+            iterations = int(iterations_str)
+            salt = base64.b64decode(salt_b64)
+            password_hash = base64.b64decode(password_hash_b64)
+        except (ValueError, TypeError):
+            return False
+
+        if iterations <= 0:
+            return False
+
+        attempt_hash = self._encrypt(attempt, salt, iterations,
+                                     len(password_hash))
+
+        return constant_time.bytes_eq(attempt_hash, password_hash)
+
+    def _generate_salt(self, salt_len):
+        """Generates random string for salt."""
+        return os.urandom(salt_len)
+
+    def _encrypt(self, password, salt, iterations, hash_len):
+        """Performs key derivation according to the PKCS#5 standard (v2.0), by
+        means of the PBKDF2 algorithm using HMAC-SHA256 as a pseudorandom
+        function.
+        """
+        backend = default_backend()
+        kdf = PBKDF2HMAC(algorithm=hashes.SHA256(), length=hash_len,
+                         salt=salt, iterations=iterations, backend=backend)
+        return kdf.derive(password)
+
+
+registerScheme('PBKDF2-SHA256', PBKDF2DigestScheme())


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-15413

Time measurements of `PBKDF2-SHA256` hashing function on the XX-Large Mem (8 CPU / 61GB / 100GB / High Network) AWS box:

```
In [1]: from Products.ZenUtils import pbkdf2
In [2]: s = pbkdf2.PBKDF2DigestScheme()
In [5]: salt = s._generate_salt(24)

In [14]: %timeit -n 50 s._encrypt('password', salt, iterations=100000, hash_len=24)
50 loops, best of 3: 214 ms per loop

In [16]: %timeit -n 50 s._encrypt('password', salt, iterations=200000, hash_len=24)
50 loops, best of 3: 444 ms per loop

In [17]: %timeit -n 50 s._encrypt('password', salt, iterations=300000, hash_len=24)
50 loops, best of 3: 668 ms per loop

In [18]: %timeit -n 50 s._encrypt('password', salt, iterations=400000, hash_len=24)
50 loops, best of 3: 887 ms per loop
```