### PR TITLE
ZEN-19077: Advanced Tab is not visible in 5.x Application after Migra…

### DIFF
--- a/Products/ZenUtils/patches/pasmonkey.py
+++ b/Products/ZenUtils/patches/pasmonkey.py
@@ -221,7 +221,7 @@ def authenticateCredentials( self, credentials ):
     user_id = credentials.get('session_user_id', '')
     info = credentials.get('session_user_info', '')
 
-    if user_id:
+    if user_id and self._getPAS().getUserById(user_id):
         return user_id, info
 
     return _originalZODBUserManager_authenticateCredentials(self, credentials)


### PR DESCRIPTION
…tion

https://jira.zenoss.com/browse/ZEN-19077

Zenoss has 2 authentication managers (`/acl_users` and `/zport/dmd/acl_users`). This change makes authentication plugin to check whether saved to session user belongs to it authentication manager and as result roles assignment works correctly.