### PR TITLE
Fix space-containing component deep-linking.

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -637,7 +637,7 @@ Ext.define('Zenoss.DeviceDetailNav', {
                         componentRootNode.on('append', findAndSelect, this, {single: true});
                     } else {
                         selectOnRender(tosel, sm);
-                        return Ext.getCmp('component_card').selectByToken(rest);
+                        return Ext.getCmp('component_card').selectByToken(unescape(rest));
                     }
                 }
 


### PR DESCRIPTION
When the component deep-link is to a component on a device in a device
class that contains a space character, the UID will contain a
pre-escaped %20. This breaks the deep-linking unless we unescape it
first.

Fixes ZEN-18889.