### PR TITLE
ZEN-18971 zendisc now uses nmap for ping

### DIFF
--- a/Products/DataCollector/zendisc.py
+++ b/Products/DataCollector/zendisc.py
@@ -22,37 +22,28 @@ try:
 except ImportError:
     pass
 
-from ipaddr import IPAddress
-
-# Zenoss custom ICMP library
-from icmpecho.Ping import Ping4, Ping6
-
 import Globals
 from optparse import SUPPRESS_HELP
 
 from Products.DataCollector.zenmodeler import ZenModeler
 from Products.ZenUtils.Exceptions import ZentinelException
 from Products.ZenUtils.Utils import unused
-from Products.ZenUtils.Driver import drive
 from Products.ZenUtils.IpUtil import asyncNameLookup, isip, parse_iprange, \
                                      getHostByName, ipunwrap
-from Products.ZenUtils.NJobs import NJobs
 from Products.ZenUtils.snmp import SnmpV1Config, SnmpV2cConfig, SnmpV3Config
 from Products.ZenUtils.snmp import SnmpAgentDiscoverer
 from Products.ZenModel.Exceptions import NoIPAddress
 from Products.ZenEvents.ZenEventClasses import Status_Snmp
 from Products.ZenEvents.Event import Info
-from Products.ZenStatus.PingService import PingService
 from Products.ZenHub.PBDaemon import FakeRemote, PBDaemon
 from Products.ZenHub.services  import DiscoverService, ModelerService
 from Products.ZenHub.services.DiscoverService import JobPropertiesProxy
-unused(DiscoverService, ModelerService, JobPropertiesProxy) # for pb
+from Products.ZenStatus.nmap.util import executeNmapForIps
 
+unused(Globals, DiscoverService, ModelerService, JobPropertiesProxy)
 
-
-from twisted.internet.defer import succeed
 from twisted.python.failure import Failure
-from twisted.internet import reactor
+from twisted.internet import reactor, defer
 from twisted.names.error import DNSNameError
 
 
@@ -75,42 +66,24 @@ class ZenDisc(ZenModeler):
         ZenModeler.__init__(self, single )
         self.discovered = []
 
-        # pyraw inserts IPV4_SOCKET and IPV6_SOCKET globals
-        if IPV4_SOCKET is None:
-            self._pinger4 = None
-        else:
-            protocol = Ping4(IPV4_SOCKET)
-            self._pinger4 = PingService(protocol,
-                                        timeout=self.options.timeout,
-                                        defaultTries=self.options.tries)
-
-        if IPV6_SOCKET is None:
-            self._pinger6 = None
-        else:
-            protocol = Ping6(IPV6_SOCKET)
-            self._pinger6 = PingService(protocol,
-                                        timeout=self.options.timeout,
-                                        defaultTries=self.options.tries)
-
-    def ping(self, ip):
+    @defer.inlineCallbacks
+    def pingMany(self, ipList):
         """
-        Given an IP address, return a deferred that pings the address.
+        Given a list of IP addresses, return a list containing the
+        results of pinging each of those addresses.
         """
-        self.log.debug("Using ipaddr module to convert %s" % ip)
-        ipObj = IPAddress(ip)
-
-        if ipObj.version == 6:
-            if self._pinger6 is None:
-                retval = Failure()
-            else:
-                retval = self._pinger6.ping(ip)
-        else:
-            if self._pinger4 is None:
-                retval = Failure()
-            else:
-                retval = self._pinger4.ping(ip)
-
-        return retval
+        pingResults = yield executeNmapForIps(sorted(ipList))
+        self.log.info("Found %s addresses", len(pingResults))
+        self.log.debug(
+            "Addresses found: %s",
+            type("Addresses", (object,), {
+                "__str__": lambda f: ", ".join(addr for addr in pingResults)
+            })()
+        )
+        defer.returnValue([
+            result if result.isUp else Failure(result)
+            for result in pingResults.itervalues()
+        ])
 
     def config(self):
         """
@@ -121,7 +94,7 @@ class ZenDisc(ZenModeler):
         """
         return self.services.get('DiscoverService', FakeRemote())
 
-
+    @defer.inlineCallbacks
     def discoverIps(self, nets):
         """
         Ping all ips, create entries in the network if necessary.
@@ -131,54 +104,36 @@ class ZenDisc(ZenModeler):
         @return: successful result is a list of IPs that were added
         @rtype: Twisted deferred
         """
-        def inner(driver):
-            """
-            Twisted driver class to iterate through devices
+        ips = []
+        # it would be nice to interleave ping/discover
+        for net in nets:
+            if self.options.subnets and len(net.children()) > 0:
+                continue
+            if not getattr(net, "zAutoDiscover", False):
+                self.log.info(
+                    "Skipping network %s because zAutoDiscover is False",
+                    net.getNetworkName())
+                continue
+            self.log.info("Discover network '%s'", net.getNetworkName())
+            results = yield self.pingMany(net.fullIpList())
+            goodips = [
+                v.address for v in results if not isinstance(v, Failure)]
+            badips = [
+                v.value.address for v in results if isinstance(v, Failure)]
+            self.log.debug("Got %d good IPs and %d bad IPs",
+                           len(goodips), len(badips))
+            yield self.config().callRemote('pingStatus',
+                                           net,
+                                           goodips,
+                                           badips,
+                                           self.options.resetPtr,
+                                           self.options.addInactive)
+            ips += goodips
+            self.log.info("Discovered %s active ips", len(ips))
+        defer.returnValue(ips)
 
-            @param driver: Zenoss driver
-            @type driver: Zenoss driver
-            @return: successful result is a list of IPs that were added
-            @rtype: Twisted deferred
-            """
-            ips = []
-            goodCount = 0
-            # it would be nice to interleave ping/discover
-            for net in nets:
-                if self.options.subnets and len(net.children()) > 0:
-                    continue
-                if not getattr(net, "zAutoDiscover", False):
-                    self.log.info(
-                        "Skipping network %s because zAutoDiscover is False"
-                        % net.getNetworkName())
-                    continue
-                self.log.info("Discover network '%s'", net.getNetworkName())
-                yield NJobs(self.options.chunkSize,
-                            self.ping,
-                            net.fullIpList()).start()
-                results = driver.next()
-                goodips = [
-                    v.ipaddr for v in results if not isinstance(v, Failure)]
-                badips = [
-                    v.value.ipaddr for v in results if isinstance(v, Failure)]
-                goodCount += len(goodips)
-                self.log.debug("Got %d good IPs and %d bad IPs",
-                               len(goodips), len(badips))
-                yield self.config().callRemote('pingStatus',
-                                               net,
-                                               goodips,
-                                               badips,
-                                               self.options.resetPtr,
-                                               self.options.addInactive)
-                ips += driver.next()
-                self.log.info("Discovered %s active ips", goodCount)
-            # make sure this is the return result for the driver
-            yield succeed(ips)
-            driver.next()
-
-        d = drive(inner)
-        return d
-
-    def discoverRanges(self, driver):
+    @defer.inlineCallbacks
+    def discoverRanges(self):
         """
         Ping all IPs in the range and create devices for the ones that come
         back.
@@ -195,24 +150,18 @@ class ZenDisc(ZenModeler):
             self.options.range = [n.strip() for n in
                                   self.options.range[0].split(',')]
         ips = []
-        goodCount = 0
         for iprange in self.options.range:
             # Parse to find ips included
             ips.extend(parse_iprange(iprange))
-        yield NJobs(self.options.chunkSize,
-                    self.ping,
-                    ips).start()
-        results = driver.next()
-        goodips = [v.ipaddr for v in results if not isinstance(v, Failure)]
-        badips = [v.value.ipaddr for v in results if isinstance(v, Failure)]
-        goodCount += len(goodips)
+        results = yield self.pingMany(ips)
+        goodips = [v.address for v in results if not isinstance(v, Failure)]
+        badips = [v.value.address for v in results if isinstance(v, Failure)]
         self.log.debug("Got %d good IPs and %d bad IPs",
                        len(goodips), len(badips))
         yield self.discoverDevices(goodips)
-        yield succeed("Discovered %d active IPs" % goodCount)
-        driver.next()
+        self.log.info("Discovered %d active IPs", len(goodips))
 
-
+    @defer.inlineCallbacks
     def discoverRouters(self, rootdev, seenips=None):
         """
         Discover all default routers based on DMD configuration.
@@ -226,31 +175,16 @@ class ZenDisc(ZenModeler):
         """
         if not seenips:
             seenips = []
-
-        def inner(driver):
-            """
-            Twisted driver class to iterate through devices
-
-            @param driver: Zenoss driver
-            @type driver: Zenoss driver
-            @return: successful result is a list of IPs that were added
-            @rtype: Twisted deferred
-            """
-            yield self.config().callRemote('followNextHopIps', rootdev.id)
-            for ip in driver.next():
-                if ip in seenips:
-                    continue
-                self.log.info("device '%s' next hop '%s'", rootdev.id, ip)
-                seenips.append(ip)
-                yield self.discoverDevice(ip, devicepath="/Network/Router")
-                router = driver.next()
-                if not router:
-                    continue
-                yield self.discoverRouters(router, seenips)
-                driver.next()
-
-        return drive(inner)
-
+        ips = yield self.config().callRemote('followNextHopIps', rootdev.id)
+        for ip in ips:
+            if ip in seenips:
+                continue
+            self.log.info("device '%s' next hop '%s'", rootdev.id, ip)
+            seenips.append(ip)
+            router = yield self.discoverDevice(ip, devicepath="/Network/Router")
+            if not router:
+                continue
+            yield self.discoverRouters(router, seenips)
 
     def sendDiscoveredEvent(self, ip, dev=None, sev=2):
         """
@@ -273,7 +207,7 @@ class ZenDisc(ZenModeler):
                    agent="Discover")
         self.sendEvent(evt)
 
-
+    @defer.inlineCallbacks
     def discoverDevices(self,
                         ips,
                         devicepath=None,
@@ -294,22 +228,10 @@ class ZenDisc(ZenModeler):
             devicepath = self.options.deviceclass
         if prodState is None:
             prodState = self.options.productionState
+        for ip in ips:
+            yield self.discoverDevice(ip, devicepath, prodState)
 
-        def discoverDevice(ip):
-            """
-            Discover a particular device
-            NB: Wrapper around self.discoverDevice()
-
-            @param ip: IP address
-            @type ip: string
-            @return: Twisted/Zenoss Python iterable
-            @rtype: Python iterable
-            """
-            return self.discoverDevice(ip, devicepath, prodState)
-
-        return NJobs(self.options.parallel, discoverDevice, ips).start()
-
-
+    @defer.inlineCallbacks
     def findRemoteDeviceInfo(self, ip, devicePath, deviceSnmpCommunities=None):
         """
         Scan a device for ways of naming it: PTR DNS record or a SNMP name
@@ -326,75 +248,61 @@ class ZenDisc(ZenModeler):
         @rtype: deferred: Twisted deferred
         """
         from pynetsnmp.twistedsnmp import AgentProxy
+        self.log.debug("[findRemoteDeviceInfo] Doing SNMP lookup on device %s", ip)
+        snmp_conf = yield self.config().callRemote('getSnmpConfig', devicePath)
 
-        def inner(driver):
-            """
-            Twisted driver class to iterate through devices
+        configs = []
+        ports = snmp_conf.get('zSnmpDiscoveryPorts') or [snmp_conf['zSnmpPort']]
+        timeout, retries = snmp_conf['zSnmpTimeout'], snmp_conf['zSnmpTries']
+        if snmp_conf['zSnmpVer'] == SnmpV3Config.version:
+            for port in ports:
+                if snmp_conf['zSnmpPrivType'] and snmp_conf['zSnmpAuthType']:
+                    configs.append(SnmpV3Config(
+                        ip, port=port, timeout=timeout, retries=retries, weight=3,
+                        securityName=snmp_conf['zSnmpSecurityName'],
+                        authType=snmp_conf['zSnmpAuthType'],
+                        authPassphrase=snmp_conf['zSnmpAuthPassword'],
+                        privType=snmp_conf['zSnmpPrivType'],
+                        privPassphrase=snmp_conf['zSnmpPrivPassword']))
+                elif snmp_conf['zSnmpAuthType']:
+                    configs.append(SnmpV3Config(
+                        ip, port=port, timeout=timeout, retries=retries, weight=2,
+                        securityName=snmp_conf['zSnmpSecurityName'],
+                        authType=snmp_conf['zSnmpAuthType'],
+                        authPassphrase=snmp_conf['zSnmpAuthPassword']))
+                else:
+                    configs.append(SnmpV3Config(
+                        ip, port=port, timeout=timeout, retries=retries, weight=1,
+                        securityName=snmp_conf['zSnmpSecurityName']))
+        else:
+            self.log.debug("[findRemoteDeviceInfo] override acquired community strings")
+            # Override the device class communities with the ones set on
+            # this device, if they exist
+            communities = snmp_conf['zSnmpCommunities']
+            if deviceSnmpCommunities is not None:
+                communities = deviceSnmpCommunities
 
-            @param driver: Zenoss driver
-            @type driver: Zenoss driver
-            @return: successful result is a list of IPs that were added
-            @rtype: Twisted deferred
-            """
-            self.log.debug("findRemoteDeviceInfo.inner: Doing SNMP lookup on device %s", ip)
-            yield self.config().callRemote('getSnmpConfig', devicePath)
-            snmp_conf = driver.next()
+            # Reverse the communities so that ones earlier in the list have a
+            # higher weight.
+            communities.reverse()
 
-            configs = []
-            ports = snmp_conf.get('zSnmpDiscoveryPorts') or [snmp_conf['zSnmpPort']]
-            timeout, retries = snmp_conf['zSnmpTimeout'], snmp_conf['zSnmpTries']
-            if snmp_conf['zSnmpVer'] == SnmpV3Config.version:
+            for i, community in enumerate(communities):
                 for port in ports:
-                    if snmp_conf['zSnmpPrivType'] and snmp_conf['zSnmpAuthType']:
-                        configs.append(SnmpV3Config(
-                            ip, port=port, timeout=timeout, retries=retries, weight=3,
-                            securityName=snmp_conf['zSnmpSecurityName'],
-                            authType=snmp_conf['zSnmpAuthType'],
-                            authPassphrase=snmp_conf['zSnmpAuthPassword'],
-                            privType=snmp_conf['zSnmpPrivType'],
-                            privPassphrase=snmp_conf['zSnmpPrivPassword']))
-                    elif snmp_conf['zSnmpAuthType']:
-                        configs.append(SnmpV3Config(
-                            ip, port=port, timeout=timeout, retries=retries, weight=2,
-                            securityName=snmp_conf['zSnmpSecurityName'],
-                            authType=snmp_conf['zSnmpAuthType'],
-                            authPassphrase=snmp_conf['zSnmpAuthPassword']))
-                    else:
-                        configs.append(SnmpV3Config(
-                            ip, port=port, timeout=timeout, retries=retries, weight=1,
-                            securityName=snmp_conf['zSnmpSecurityName']))
-            else:
-                self.log.debug("findRemoteDeviceInfo.inner: override acquired community strings")
-                # Override the device class communities with the ones set on
-                # this device, if they exist
-                communities = snmp_conf['zSnmpCommunities']
-                if deviceSnmpCommunities is not None:
-                    communities = deviceSnmpCommunities
+                    port = int(port)
+                    configs.append(SnmpV1Config(
+                        ip, weight=i, port=port, timeout=timeout,
+                        retries=retries, community=community))
+                    configs.append(SnmpV2cConfig(
+                        ip, weight=i + 100, port=port, timeout=timeout,
+                        retries=retries, community=community))
 
-                # Reverse the communities so that ones earlier in the list have a
-                # higher weight.
-                communities.reverse()
+        yield SnmpAgentDiscoverer().findBestConfig(configs)
+        self.log.debug("Finished SNMP lookup on device %s", ip)
 
-                for i, community in enumerate(communities):
-                    for port in ports:
-                        port = int(port)
-                        configs.append(SnmpV1Config(
-                            ip, weight=i, port=port, timeout=timeout,
-                            retries=retries, community=community))
-                        configs.append(SnmpV2cConfig(
-                            ip, weight=i + 100, port=port, timeout=timeout,
-                            retries=retries, community=community))
-
-            yield SnmpAgentDiscoverer().findBestConfig(configs)
-            driver.next()
-            self.log.debug("Finished SNMP lookup on device %s", ip)
-
-        return drive(inner)
-
-
+    @defer.inlineCallbacks
     def discoverDevice(self, ip, devicepath=None, prodState=None):
         """
-        Discover a device based on its IP address.
+        Discover the device at the given IP address.
 
         @param ip: IP address
         @type ip: string
@@ -413,175 +321,151 @@ class ZenDisc(ZenModeler):
         self.scanned += 1
         if self.options.maxdevices:
             if self.scanned >= self.options.maxdevices:
-                self.log.info("Limit of %d devices reached" %
+                self.log.info("Limit of %d devices reached",
                               self.options.maxdevices)
-                return succeed(None)
+                defer.returnValue(None)
 
-        def inner(driver):
-            """
-            Twisted driver class to iterate through devices
+        try:
+            kw = dict(deviceName=ip,
+                      discoverProto=None,
+                      devicePath=devicepath,
+                      performanceMonitor=self.options.monitor,
+                      locationPath=self.options.location,
+                      groupPaths=self.options.groups,
+                      systemPaths=self.options.systems,
+                      productionState=prodState)
 
-            @param driver: Zenoss driver
-            @type driver: Zenoss driver
-            @return: successful result is a list of IPs that were added
-            @rtype: Twisted deferred
-            @todo: modularize this function (130+ lines is ridiculous)
-            """
-            try:
-                kw = dict(deviceName=ip,
-                          discoverProto=None,
-                          devicePath=devicepath,
-                          performanceMonitor=self.options.monitor,
-                          locationPath=self.options.location,
-                          groupPaths=self.options.groups,
-                          systemPaths=self.options.systems,
-                          productionState=prodState)
+            # If zProperties are set via a job, get them and pass them in
+            if self.options.job:
+                job_props = yield self.config().callRemote('getJobProperties',
+                                                           self.options.job)
+                if job_props is not None:
+                    # grab zProperties from Job
+                    kw['zProperties'] = getattr(job_props, 'zProperties', {})
+                    # grab other Device properties from jobs
+                    #deviceProps = job_props.get('deviceProps', {})
+                    #kw.update(deviceProps)
+                    #@FIXME we are not getting deviceProps, check calling
+                    #  chain for clues. twisted upgrade heartburn perhaps?
 
-                # If zProperties are set via a job, get them and pass them in
-                if self.options.job:
-                    yield self.config().callRemote('getJobProperties',
-                                                   self.options.job)
-                    job_props = driver.next()
-                    if job_props is not None:
-                        # grab zProperties from Job
-                        kw['zProperties'] = getattr(job_props, 'zProperties', {})
-                        # grab other Device properties from jobs
-                        #deviceProps = job_props.get('deviceProps', {})
-                        #kw.update(deviceProps)
-                        #@FIXME we are not getting deviceProps, check calling
-                        # chain for clues. twisted upgrade heartburn perhaps?
+            # if we are using SNMP, lookup the device SNMP info and use the
+            # name defined there for deviceName
+            if not self.options.nosnmp:
+                self.log.debug("Scanning device with address %s", ip)
+                snmpCommunities = kw.get('zProperties', {}).get(
+                    'zSnmpCommunities', None)
+                snmp_config = yield self.findRemoteDeviceInfo(ip, devicepath,
+                                                              snmpCommunities)
+                if snmp_config:
+                    if snmp_config.sysName:
+                        kw['deviceName'] = snmp_config.sysName
 
-                # if we are using SNMP, lookup the device SNMP info and use the
-                # name defined there for deviceName
-                if not self.options.nosnmp:
-                    self.log.debug("Scanning device with address %s", ip)
-                    snmpCommunities = kw.get('zProperties', {}).get(
-                        'zSnmpCommunities', None)
-                    yield self.findRemoteDeviceInfo(ip, devicepath,
-                                                    snmpCommunities)
-                    snmp_config = driver.next()
-                    if snmp_config:
-                        if snmp_config.sysName:
-                            kw['deviceName'] = snmp_config.sysName
+                    if snmp_config.version:
+                        kw['zSnmpVer'] = snmp_config.version
 
-                        if snmp_config.version:
-                            kw['zSnmpVer'] = snmp_config.version
+                    if snmp_config.port:
+                        kw['zSnmpPort'] = snmp_config.port
 
-                        if snmp_config.port:
-                            kw['zSnmpPort'] = snmp_config.port
+                    if snmp_config.community:
+                        kw['zSnmpCommunity'] = snmp_config.community
 
-                        if snmp_config.community:
-                            kw['zSnmpCommunity'] = snmp_config.community
+                # if we are using SNMP, did not find any snmp info,
+                # and we are in strict discovery mode, do not
+                # create a device
+                elif self.options.zSnmpStrictDiscovery:
+                    self.log.info('zSnmpStrictDiscovery is True.  ' +
+                                  'Not creating device for %s.'
+                                  % ip )
+                    defer.returnValue(None)
 
-                    # if we are using SNMP, did not find any snmp info,
-                    # and we are in strict discovery mode, do not
-                    # create a device
-                    elif self.options.zSnmpStrictDiscovery:
-                        self.log.info('zSnmpStrictDiscovery is True.  ' +
-                                      'Not creating device for %s.'
-                                      % ip )
-                        return
-
-                # RULES FOR DEVICE NAMING:
-                # 1. If zPreferSnmpNaming is true:
-                #        If snmp name is returned, use snmp name. Otherwise,
-                #        use the passed device name.  If no device name was passed,
-                #        do a dns lookup on the ip.
-                # 2. If zPreferSnmpNaming is false:
-                #        If we are discovering a single device and a name is
-                #        passed in instead of an IP, use the passed-in name.
-                #        Otherwise, do a dns lookup on the ip.
-                if self.options.zPreferSnmpNaming and \
-                   not isip( kw['deviceName'] ):
-                    # In this case, we want to keep kw['deviceName'] as-is,
-                    # because it is what we got from snmp
-                    pass
-                elif self.options.device and not isip(self.options.device):
-                    kw['deviceName'] = self.options.device
-                else:
-                    # An IP was passed in so we do a reverse lookup on it to get
-                    # deviceName
-                    yield asyncNameLookup(ip)
-                    try:
-                        kw.update(dict(deviceName=driver.next()))
-                    except Exception, ex:
-                        self.log.debug("Failed to lookup %s (%s)" % (ip, ex))
-
-                # If it's discovering a particular device,
-                # ignore zAutoDiscover limitations
-                forceDiscovery = bool(self.options.device)
-
-
-                # now create the device by calling zenhub
-                yield self.config().callRemote('createDevice', ipunwrap(ip),
-                                   force=forceDiscovery, **kw)
-
-                result = driver.next()
-                self.log.debug("ZenDisc.discoverDevice.inner: got result from remote_createDevice")
-                if isinstance(result, Failure):
-                    raise ZentinelException(result.value)
-                dev, created = result
-
-                # if no device came back from createDevice we assume that it
-                # was told to not auto-discover the device.  This seems very
-                # dubious to me! -EAD
-                if not dev:
-                    self.log.info("IP '%s' on no auto-discover, skipping",ip)
-                    return
-                else:
-                    # A device came back and it already existed.
-                    if not created and not dev.temp_device:
-                        # if we shouldn't remodel skip the device by returning
-                        # at the end of this block
-                        if not self.options.remodel:
-                            self.log.info("Found IP '%s' on device '%s';"
-                                          " skipping discovery", ip, dev.id)
-                            if self.options.device:
-                                self.setExitCode(3)
-                            yield succeed(dev)
-                            driver.next()
-                            return
-                        else:
-                        # we continue on to model the device.
-                            self.log.info("IP '%s' on device '%s' remodel",
-                                          ip, dev.id)
-                    self.sendDiscoveredEvent(ip, dev)
-
-                # the device that we found/created or that should be remodeled
-                # is added to the list of devices to be modeled later
-                if not self.options.nosnmp:
-                    self.discovered.append(dev.id)
-                yield succeed(dev)
-                driver.next()
-            except ZentinelException, e:
-                self.log.exception(e)
-                evt = dict(device=ip,
-                           component=ip,
-                           ipAddress=ip,
-                           eventKey=ip,
-                           eventClass=Status_Snmp,
-                           summary=str(e),
-                           severity=Info,
-                           agent="Discover")
-                if self.options.snmpMissing:
-                    self.sendEvent(evt)
-            except Exception, e:
-                self.log.exception("Failed device discovery for '%s'", ip)
-
+            # RULES FOR DEVICE NAMING:
+            # 1. If zPreferSnmpNaming is true:
+            #        If snmp name is returned, use snmp name. Otherwise,
+            #        use the passed device name.  If no device name was passed,
+            #        do a dns lookup on the ip.
+            # 2. If zPreferSnmpNaming is false:
+            #        If we are discovering a single device and a name is
+            #        passed in instead of an IP, use the passed-in name.
+            #        Otherwise, do a dns lookup on the ip.
+            if self.options.zPreferSnmpNaming and \
+               not isip( kw['deviceName'] ):
+                # In this case, we want to keep kw['deviceName'] as-is,
+                # because it is what we got from snmp
+                pass
+            elif self.options.device and not isip(self.options.device):
+                kw['deviceName'] = self.options.device
             else:
-                yield self.config().callRemote('succeedDiscovery', dev.id)
-                driver.next()
-                #device needs to be the last thing yielded so that
-                #calling methods will get the deviceproxy
-                yield succeed(dev)
-                driver.next()
+                # An IP was passed in so we do a reverse lookup on it to get
+                # deviceName
+                try:
+                    kw.update({"deviceName": (yield asyncNameLookup(ip))})
+                except Exception as ex:
+                    self.log.debug("Failed to lookup %s (%s)", ip, ex)
 
-            self.log.debug("Finished scanning device with address %s", ip)
+            # If it's discovering a particular device,
+            # ignore zAutoDiscover limitations
+            forceDiscovery = bool(self.options.device)
 
-        return drive(inner)
+            # now create the device by calling zenhub
+            result = yield self.config().callRemote(
+                'createDevice', ipunwrap(ip), force=forceDiscovery, **kw
+            )
+            self.log.debug("[ZenDisc.discoverDevice] got result from remote_createDevice")
+            if isinstance(result, Failure):
+                raise ZentinelException(result.value)
+            dev, created = result
 
+            # if no device came back from createDevice we assume that it
+            # was told to not auto-discover the device.  This seems very
+            # dubious to me! -EAD
+            if not dev:
+                self.log.info("IP '%s' on no auto-discover, skipping", ip)
+                defer.returnValue(None)
 
-    def collectNet(self, driver):
+            # A device came back and it already existed.
+            if not created and not dev.temp_device:
+                # if we shouldn't remodel skip the device by returning
+                # at the end of this block
+                if not self.options.remodel:
+                    self.log.info("Found IP '%s' on device '%s';"
+                                  " skipping discovery", ip, dev.id)
+                    if self.options.device:
+                        self.setExitCode(3)
+                    defer.returnValue(dev)
+                else:
+                    # we continue on to model the device.
+                    self.log.info("IP '%s' on device '%s' remodel",
+                                  ip, dev.id)
+            self.sendDiscoveredEvent(ip, dev)
+
+            # the device that we found/created or that should be remodeled
+            # is added to the list of devices to be modeled later
+            if not self.options.nosnmp:
+                self.discovered.append(dev.id)
+            defer.returnValue(dev)
+        except ZentinelException, e:
+            self.log.exception(e)
+            evt = dict(device=ip,
+                       component=ip,
+                       ipAddress=ip,
+                       eventKey=ip,
+                       eventClass=Status_Snmp,
+                       summary=str(e),
+                       severity=Info,
+                       agent="Discover")
+            if self.options.snmpMissing:
+                self.sendEvent(evt)
+        except Exception, e:
+            self.log.exception("Failed device discovery for '%s'", ip)
+        else:
+            yield self.config().callRemote('succeedDiscovery', dev.id)
+            # device needs to be the last thing yielded so that
+            # calling methods will get the deviceproxy
+            defer.returnValue(dev)
+        self.log.debug("Finished scanning device with address %s", ip)
+
+    @defer.inlineCallbacks
+    def collectNet(self):
         """
         Twisted driver class to iterate through networks
 
@@ -590,7 +474,6 @@ class ZenDisc(ZenModeler):
         @return: successful result is a list of IPs that were added
         @rtype: Twisted deferred
         """
-
         # net option from the config file is a string
         if isinstance(self.options.net, basestring):
             self.options.net = [self.options.net]
@@ -599,49 +482,33 @@ class ZenDisc(ZenModeler):
         if isinstance(self.options.net, (list,tuple)) and ',' in self.options.net[0]:
             self.options.net = [
                 n.strip() for n in self.options.net[0].split(',')
-                ]
+            ]
         count = 0
         devices = []
         if not self.options.net:
-            yield self.config().callRemote('getDefaultNetworks')
-            self.options.net = driver.next()
+            self.options.net = yield self.config().callRemote('getDefaultNetworks')
 
         if not self.options.net:
             self.log.warning("No networks configured")
-            return
+            defer.returnValue(None)
 
         for net in self.options.net:
             try:
-                yield self.config().callRemote('getNetworks',
-                                               net,
-                                               self.options.subnets)
-                nets = driver.next()
+                nets = yield self.config().callRemote('getNetworks', net, self.options.subnets)
                 if not nets:
                     self.log.warning("No networks found for %s" % (net,))
                     continue
-                yield self.discoverIps(nets)
-                ips = driver.next()
+                ips = yield self.discoverIps(nets)
                 devices += ips
                 count += len(ips)
             except Exception, ex:
                 self.log.exception("Error performing net discovery on %s", ex)
-        def discoverDevice(ip):
-            """
-            Discover a particular device
-            NB: Wrapper around self.discoverDevice()
+        self.log.info("[collectNet] Working on devices: %s", devices)
 
-            @param ip: IP address
-            @type ip: string
-            @return: Twisted/Zenoss Python iterable
-            @rtype: Python iterable
-            """
-            return self.discoverDevice(ip,
-                                       self.options.deviceclass,
-                                       self.options.productionState)
-        yield NJobs(self.options.parallel, discoverDevice, devices).start()
-        yield succeed("Discovered %d devices" % count)
-        driver.next()
-
+        for device in devices:
+            yield self.discoverDevice(
+                device, self.options.deviceclass, self.options.productionState
+            )
 
     def printResults(self, results):
         """
@@ -659,15 +526,10 @@ class ZenDisc(ZenModeler):
             self.log.info("Result: %s", results)
         self.main()
 
-
-    def createDevice(self, driver):
+    @defer.inlineCallbacks
+    def createDevice(self):
         """
         Add a device to the system by name or IP.
-
-        @param driver: driver object
-        @type driver: Twisted/Zenoss object
-        @return: Twisted deferred
-        @rtype: Twisted deferred
         """
         deviceName = self.options.device
         self.log.info("Looking for %s" % deviceName)
@@ -676,32 +538,28 @@ class ZenDisc(ZenModeler):
             ip = ipunwrap(deviceName)
         else:
             try:
-                # FIXME ZenUtils.IpUtil.asyncIpLookup is probably a better tool
-                # for this, but it hasn't been tested, so it's for another day
-                self.log.debug("getHostByName")
                 ip = getHostByName(deviceName)
-            except socket.error:
-                ip = ""
+            except socket.error as ex:
+                self.log.debug(
+                    "Hostname lookup failed for %s: %s", deviceName, ex
+                )
+
         if not ip:
             raise NoIPAddress("No IP found for name %s" % deviceName)
-        else:
-            self.log.debug("Found IP %s for device %s" % (ip, deviceName))
-            yield self.config().callRemote('getDeviceConfig', [deviceName])
-            me, = driver.next() or [None]
-            if not me or me.temp_device or self.options.remodel:
-                yield self.discoverDevice(ip,
-                                     devicepath=self.options.deviceclass,
-                                     prodState=self.options.productionState)
-                yield succeed("Discovered device %s." % deviceName)
-                driver.next()
 
+        self.log.debug("Found IP %s for device %s" % (ip, deviceName))
+        configs = yield self.config().callRemote('getDeviceConfig', [deviceName])
+        config = configs[0] if configs else None
+        if not config or config.temp_device or self.options.remodel:
+            yield self.discoverDevice(ip,
+                                 devicepath=self.options.deviceclass,
+                                 prodState=self.options.productionState)
+            self.log.info("Discovered device %s." % deviceName)
 
-    def walkDiscovery(self, driver):
+    @defer.inlineCallbacks
+    def walkDiscovery(self):
         """
         Python iterable to go through discovery
-
-        @return: Twisted deferred
-        @rtype: Twisted deferred
         """
         myname = socket.getfqdn()
         self.log.debug("My hostname = %s", myname)
@@ -711,14 +569,12 @@ class ZenDisc(ZenModeler):
             self.log.debug("My IP address = %s", myip)
         except (socket.error, DNSNameError):
             raise SystemExit("Failed lookup of my IP for name %s", myname)
-
-        yield self.config().callRemote('getDeviceConfig', [myname])
-        me, = driver.next() or [None]
+        configs = yield self.config().callRemote('getDeviceConfig', [myname])
+        me = configs[0] if configs else None
         if not me or self.options.remodel:
-            yield self.discoverDevice(myip,
-                                      devicepath=self.options.deviceclass,
-                                      prodState=self.options.productionState)
-            me = driver.next()
+            me = yield self.discoverDevice(myip,
+                                           devicepath=self.options.deviceclass,
+                                           prodState=self.options.productionState)
         if not me:
             raise SystemExit("SNMP discover of self '%s' failed" % myname)
         if not myip:
@@ -728,17 +584,14 @@ class ZenDisc(ZenModeler):
 
         yield self.discoverRouters(me, [myip])
 
-        driver.next()
         if self.options.routersonly:
             self.log.info("Only routers discovered, skipping ping sweep.")
         else:
-            yield self.config().callRemote('getSubNetworks')
-            yield self.discoverIps(driver.next())
-            ips = driver.next()
+            ips = yield self.discoverIps(
+                (yield self.config().callRemote('getSubNetworks'))
+            )
             if not self.options.nosnmp:
                 yield self.discoverDevices(ips)
-                driver.next()
-
 
     def getDeviceList(self):
         """
@@ -747,8 +600,7 @@ class ZenDisc(ZenModeler):
         @return: list of discovered devices
         @rtype: Twisted succeed() object
         """
-        return succeed(self.discovered)
-
+        return defer.succeed(self.discovered)
 
     def connected(self):
         """
@@ -758,22 +610,20 @@ class ZenDisc(ZenModeler):
         d.addCallback(self.startDiscovery)
         d.addErrback(self.reportError)
 
-
-
+    @defer.inlineCallbacks
     def startDiscovery(self, data):
         if self.options.walk:
-            d = drive(self.walkDiscovery)
+            results = yield self.walkDiscovery()
 
         elif self.options.device:
-            d = drive(self.createDevice)
+            results = yield self.createDevice()
 
         elif self.options.range:
-            d = drive(self.discoverRanges)
+            results = yield self.discoverRanges()
 
         else:
-            d = drive(self.collectNet)
-
-        d.addBoth(self.printResults)
+            results = yield self.collectNet()
+        self.printResults(results)
 
     def buildOptions(self):
         """
@@ -781,66 +631,66 @@ class ZenDisc(ZenModeler):
         """
         ZenModeler.buildOptions(self)
         self.parser.add_option('--net', dest='net', action="append",
-                    help="Discover all device on this network")
+            help="Discover all device on this network")
         self.parser.add_option('--range', dest='range', action='append',
-                    help="Discover all IPs in this range")
+            help="Discover all IPs in this range")
         self.parser.add_option('--deviceclass', dest='deviceclass',
-                    default="/Discovered",
-                    help="Default device class for discovered devices")
+            default="/Discovered",
+            help="Default device class for discovered devices")
         self.parser.add_option('--prod_state', dest='productionState',
-                    default=1000, type='int',
-                    help="Initial production state for discovered devices")
+            default=1000, type='int',
+            help="Initial production state for discovered devices")
         self.parser.add_option('--location', dest='location',
-                    default=None,
-                    help="Initial location for discovered devices")
+            default=None,
+            help="Initial location for discovered devices")
         self.parser.add_option('--group', dest='groups', action="append",
-                    help="Group to which discovered devices should be added")
+            help="Group to which discovered devices should be added")
         self.parser.add_option('--system', dest='systems', action="append",
-                    help="System to which discovered devices should be added")
+            help="System to which discovered devices should be added")
         self.parser.add_option('--remodel', dest='remodel',
-                    action="store_true", default=False,
-                    help="Remodel existing objects")
+            action="store_true", default=False,
+            help="Remodel existing objects")
         self.parser.add_option('--routers', dest='routersonly',
-                    action="store_true", default=False,
-                    help="Only discover routers")
+            action="store_true", default=False,
+            help="Only discover routers")
         self.parser.add_option('--tries', dest='tries', default=1, type="int",
-                    help="How many ping tries")
+            help="How many ping tries")
         self.parser.add_option('--timeout', dest='timeout',
-                    default=2, type="float",
-                    help="ping timeout in seconds")
+            default=2, type="float",
+            help="ping timeout in seconds")
         self.parser.add_option('--chunk', dest='chunkSize',
-                    default=10, type="int",
-                    help="Number of in-flight ping packets")
+            default=10, type="int",
+            help="Number of in-flight ping packets")
         self.parser.add_option('--snmp-missing', dest='snmpMissing',
-                    action="store_true", default=False,
-                    help="Send an event if SNMP is not found on the device")
+            action="store_true", default=False,
+            help="Send an event if SNMP is not found on the device")
         self.parser.add_option('--add-inactive', dest='addInactive',
-                    action="store_true", default=False,
-                    help="Add all IPs found, even if they are unresponsive")
+            action="store_true", default=False,
+            help="Add all IPs found, even if they are unresponsive")
         self.parser.add_option('--reset-ptr', dest='resetPtr',
-                    action="store_true", default=False,
-                    help="Reset all IP PTR records")
+            action="store_true", default=False,
+            help="Reset all IP PTR records")
         self.parser.add_option('--no-snmp', dest='nosnmp',
-                    action="store_true", default=False,
-                    help="Skip SNMP discovery on found IP addresses")
+            action="store_true", default=False,
+            help="Skip SNMP discovery on found IP addresses")
         self.parser.add_option('--subnets', dest='subnets',
-                    action="store_true", default=False,
-                    help="Recurse into subnets for discovery")
+            action="store_true", default=False,
+            help="Recurse into subnets for discovery")
         self.parser.add_option('--walk', dest='walk', action='store_true',
-                    default=False,
-                    help="Walk the route tree, performing discovery on all networks")
+            default=False,
+            help="Walk the route tree, performing discovery on all networks")
         self.parser.add_option('--max-devices', dest='maxdevices',
-                    default=0,
-                    type='int',
-                    help="Collect a maximum number of devices. Default is no limit.")
+            default=0,
+            type='int',
+            help="Collect a maximum number of devices. Default is no limit.")
         self.parser.add_option('--snmp-strict-discovery',
-                    dest='zSnmpStrictDiscovery',
-                    action="store_true", default=False,
-                    help="Only add devices that can be modeled via SNMP." )
+            dest='zSnmpStrictDiscovery',
+            action="store_true", default=False,
+            help="Only add devices that can be modeled via SNMP." )
         self.parser.add_option('--prefer-snmp-naming',
-                    dest='zPreferSnmpNaming',
-                    action="store_true", default=False,
-                    help="Prefer SNMP name to DNS name when modeling via SNMP." )
+            dest='zPreferSnmpNaming',
+            action="store_true", default=False,
+            help="Prefer SNMP name to DNS name when modeling via SNMP." )
         # --job: a development-only option that jobs will use to communicate
         # their existence to zendisc. Not for users, so help is suppressed.
         self.parser.add_option('--job', dest='job', help=SUPPRESS_HELP )
@@ -850,5 +700,4 @@ class ZenDisc(ZenModeler):
 if __name__ == "__main__":
     d = ZenDisc()
     d.processOptions()
-    reactor.run = d.reactorLoop
     d.run()

--- a/Products/ZenStatus/nmap/util.py
+++ b/Products/ZenStatus/nmap/util.py
@@ -1,0 +1,147 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+import math
+import tempfile
+import os
+
+from cStringIO import StringIO
+from twisted.internet import utils, defer
+
+from Products.ZenStatus.nmap.PingResult import parseNmapXmlToDict
+from Products.ZenStatus import nmap
+from Products.ZenUtils.Utils import binPath
+
+log = logging.getLogger("zen.nmap")
+
+MAX_PARALLELISM = 150
+DEFAULT_PARALLELISM = 10
+MAX_NMAP_OVERHEAD = 0.5  # in seconds
+MIN_PING_TIMEOUT = 0.1  # in seconds
+
+_NMAP_BINARY = "/usr/bin/nmap"
+
+
+@defer.inlineCallbacks
+def executeNmapForIps(
+        ips, traceroute=False, outputType='xml', dataLength=0,
+        pingTries=2, pingTimeOut=1.5, pingCycleInterval=60):
+    """
+    Execute nmap and return its output.
+    """
+    with tempfile.NamedTemporaryFile(prefix='nmap_ips_') as tfile:
+        for ip in ips:
+            tfile.write("%s\n" % ip)
+        tfile.flush()
+        results = yield executeNmapCmd(
+            tfile.name, traceroute, outputType, len(ips),
+            dataLength, pingTries, pingTimeOut, pingCycleInterval
+        )
+        defer.returnValue(results)
+
+
+@defer.inlineCallbacks
+def executeNmapCmd(
+        inputFileFilename, traceroute=False, outputType='xml',
+        num_devices=0, dataLength=0, pingTries=2, pingTimeOut=1.5,
+        pingCycleInterval=60):
+    """
+    Execute nmap and return its output.
+    """
+    args = ["-iL", inputFileFilename]  # input file
+
+    args.extend([
+        "-sn",           # don't port scan the hosts
+        "-PE",           # use ICMP echo
+        "-n",            # don't resolve hosts internally
+        "--privileged",  # assume we can open raw socket
+        "--send-ip",     # don't allow ARP responses
+        "-T5",           # "insane" speed
+    ])
+
+    if dataLength > 0:
+        args.extend(["--data-length", str(dataLength)])
+
+    cycle_interval = pingCycleInterval
+    ping_tries = pingTries
+    ping_timeout = pingTimeOut
+
+    # Make sure the timeout fits within one cycle.
+    if ping_timeout + MAX_NMAP_OVERHEAD > cycle_interval:
+        ping_timeout = cycle_interval - MAX_NMAP_OVERHEAD
+
+    # Give each host at least that much time to respond.
+    args.extend(["--min-rtt-timeout", "%.1fs" % ping_timeout])
+
+    # But not more, so we can be exact with our calculations.
+    args.extend(["--max-rtt-timeout", "%.1fs" % ping_timeout])
+
+    # Make sure we can safely complete the number of tries within one cycle.
+    if (ping_tries * ping_timeout + MAX_NMAP_OVERHEAD > cycle_interval):
+        ping_tries = int(math.floor(
+            (cycle_interval - MAX_NMAP_OVERHEAD) / ping_timeout
+        ))
+    args.extend(["--max-retries", "%d" % (ping_tries - 1)])
+
+    # Try to force nmap to go fast enough to finish within one cycle.
+    min_rate = int(math.ceil(
+        num_devices / (1.0 * cycle_interval / ping_tries)
+    ))
+    args.extend(["--min-rate", "%d" % min_rate])
+
+    if num_devices > 0:
+        min_parallelism = int(math.ceil(
+            2 * num_devices * ping_timeout / cycle_interval
+        ))
+        if min_parallelism > MAX_PARALLELISM:
+            min_parallelism = MAX_PARALLELISM
+        if min_parallelism > DEFAULT_PARALLELISM:
+            args.extend(["--min-parallelism", "%d" % min_parallelism])
+
+    if traceroute:
+        args.append("--traceroute")
+        # FYI, all bets are off as far as finishing within the cycle interval.
+
+    if outputType != 'xml':
+        raise ValueError("Unsupported nmap output type: %s" % outputType)
+
+    args.extend(["-oX", '-'])  # outputXML to stdout
+
+    # execute nmap
+    if log.isEnabledFor(logging.DEBUG):
+        log.debug("executing nmap %s", " ".join(args))
+    args = ["-n", _NMAP_BINARY,] + args
+    log.info("Executing /bin/sudo %s", ' '.join(args))
+    out, err, exitCode = yield utils.getProcessOutputAndValue(
+        "/bin/sudo", args
+    )
+
+    if exitCode != 0:
+        input = open(inputFileFilename).read()
+        log.debug("input file: %s", input)
+        log.debug("stdout: %s", out)
+        log.debug("stderr: %s", err)
+        raise nmap.NmapExecutionError(
+            exitCode=exitCode, stdout=out, stderr=err, args=args
+        )
+
+    try:
+        nmapResults = parseNmapXmlToDict(StringIO(out))
+        log.info("nmapResults -> %s", nmapResults)
+        defer.returnValue(nmapResults)
+    except Exception as e:
+        input = open(inputFileFilename).read()
+        log.debug("input file: %s", input)
+        log.debug("stdout: %s", out)
+        log.debug("stderr: %s", err)
+        log.exception(e)
+        raise nmap.NmapExecutionError(
+            exitCode=exitCode, stdout=out, stderr=err, args=args
+        )

--- a/Products/ZenStatus/nmap/util.py
+++ b/Products/ZenStatus/nmap/util.py
@@ -10,14 +10,12 @@
 import logging
 import math
 import tempfile
-import os
 
 from cStringIO import StringIO
 from twisted.internet import utils, defer
 
 from Products.ZenStatus.nmap.PingResult import parseNmapXmlToDict
 from Products.ZenStatus import nmap
-from Products.ZenUtils.Utils import binPath
 
 log = logging.getLogger("zen.nmap")
 
@@ -116,7 +114,7 @@ def executeNmapCmd(
     # execute nmap
     if log.isEnabledFor(logging.DEBUG):
         log.debug("executing nmap %s", " ".join(args))
-    args = ["-n", _NMAP_BINARY,] + args
+    args = ["-n", _NMAP_BINARY] + args
     log.info("Executing /bin/sudo %s", ' '.join(args))
     out, err, exitCode = yield utils.getProcessOutputAndValue(
         "/bin/sudo", args

--- a/Products/ZenStatus/nmap/util.py
+++ b/Products/ZenStatus/nmap/util.py
@@ -74,7 +74,7 @@ def executeNmapCmd(
     ping_timeout = pingTimeOut
 
     # Make sure the timeout fits within one cycle.
-    if ping_timeout + MAX_NMAP_OVERHEAD > cycle_interval:
+    if (ping_timeout + MAX_NMAP_OVERHEAD) > cycle_interval:
         ping_timeout = cycle_interval - MAX_NMAP_OVERHEAD
 
     # Give each host at least that much time to respond.
@@ -84,7 +84,7 @@ def executeNmapCmd(
     args.extend(["--max-rtt-timeout", "%.1fs" % ping_timeout])
 
     # Make sure we can safely complete the number of tries within one cycle.
-    if (ping_tries * ping_timeout + MAX_NMAP_OVERHEAD > cycle_interval):
+    if (ping_tries * ping_timeout + MAX_NMAP_OVERHEAD) > cycle_interval:
         ping_tries = int(math.floor(
             (cycle_interval - MAX_NMAP_OVERHEAD) / ping_timeout
         ))
@@ -111,7 +111,6 @@ def executeNmapCmd(
 
     if outputType != 'xml':
         raise ValueError("Unsupported nmap output type: %s" % outputType)
-
     args.extend(["-oX", '-'])  # outputXML to stdout
 
     # execute nmap
@@ -134,7 +133,7 @@ def executeNmapCmd(
 
     try:
         nmapResults = parseNmapXmlToDict(StringIO(out))
-        log.info("nmapResults -> %s", nmapResults)
+        log.debug("nmapResults -> %s", nmapResults)
         defer.returnValue(nmapResults)
     except Exception as e:
         input = open(inputFileFilename).read()


### PR DESCRIPTION
The major change was converting the code from the older twisted "driver" framework to the new "inline callbacks" framework.  Also made changes so that both zenmodeler and zendisc both used the same nmap based ping code.  The remaining changes were for improving some of the error handling, addressing issues identified by flake8 (a pyflakes + pep8 tool), and updates to use Python idioms.