### PR TITLE
ZEN-14139: Improve getChildLinks performance

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -1811,6 +1811,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
             audit('UI.Device.Delete', self, deleteStatus=deleteStatus,
                   deleteHistory=deleteHistory, deletePerf=deletePerf)
         self.getDmdRoot("Monitors").deletePreviousCollectorForDevice(self.getId())
+        self.dmd.getDmdRoot("ZenLinkManager").remove_device_from_cache(self.getId())
         parent._delObject(self.getId())
         if REQUEST:
             if parent.getId()=='devices':

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -220,9 +220,11 @@ class IpInterface(OSComponent, Layer2Linkable):
         Reindexes all the ip addresses on this interface
         after it has been deleted
         """
+        device = self.device()
         ips = self.ipaddresses()
         super(IpInterface, self).manage_deleteComponent(REQUEST)
         for ip in ips:
+            self.dmd.getDmdRoot("ZenLinkManager").remove_device_network_from_cache(device.getId(), ip.network().getPrimaryUrlPath())
             ip.primaryAq().index_object()
 
     def manage_editProperties(self, REQUEST):
@@ -283,6 +285,7 @@ class IpInterface(OSComponent, Layer2Linkable):
         ipobj.index_object()
         os = self.os()
         notify(ObjectMovedEvent(self, os, self.id, os, self.id))
+        self.dmd.getDmdRoot("ZenLinkManager").add_device_network_to_cache(self.device().getId(), ipobj.network().getPrimaryUrlPath())
 
 
 

--- a/Products/ZenModel/migrate/addNetworksPerDeviceCache.py
+++ b/Products/ZenModel/migrate/addNetworksPerDeviceCache.py
@@ -1,0 +1,31 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+__doc__='''
+Adds the attribute networks_per_device_cache to ZenLinkManager in case it has not already been added
+'''
+
+import Migrate
+from Products.ZenModel.LinkManager import DeviceNetworksCache
+
+class AddNetworksPerDeviceCache(Migrate.Step):
+    version = Migrate.Version(5, 1, 70)
+
+    def cutover(self, dmd):
+        if not hasattr(dmd.ZenLinkManager, 'networks_per_device_cache'):
+            dmd.ZenLinkManager.networks_per_device_cache = DeviceNetworksCache()
+            l3_catalog = dmd.ZenLinkManager.layer3_catalog
+            brains = l3_catalog.searchResults()
+            print "Loading {0} links from the layer 3 catalog. This may take some time...".format(len(brains))
+            for brain in brains:
+                if brain.deviceId and brain.networkId:
+                    dmd.ZenLinkManager.add_device_network_to_cache(brain.deviceId, brain.networkId)
+
+AddNetworksPerDeviceCache()


### PR DESCRIPTION
New data structure add to dmd.ZenLinkManager that stores the networks a device belongs to. Havin this information ready improves the overall performance of getChildLinks.
The data structure chosen is the following:
```
        OOBTree
            Key:    Device.id
            Value:  OOBtree
                        Key:    Network
                        Value:  number of ip addresses that belong to that network
```