### PR TITLE
Be safer with error handling

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -985,7 +985,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
                 self._signalZenHubAnswering(False)
 
         def errback(error):
-            self.log.error('Error pinging ZenHub: %s (%s).' % (error, error.message))
+            self.log.error('Error pinging ZenHub: %s (%s).' % (error, getattr(error, 'message', '')))
             self._signalZenHubAnswering(False)
 
         try:


### PR DESCRIPTION
Prevent something like this from happening
```
2015-09-09 13:55:30,374 WARNING zen.pbclientfactory: Perspective ping timed out after 2 seconds
Unhandled error in Deferred:
Unhandled Error
Traceback (most recent call last):
  File "/opt/zenoss/lib/python2.7/site-packages/twisted/internet/tcp.py", line 299, in connectionLost
    protocol.connectionLost(reason)
  File "/opt/zenoss/lib/python2.7/site-packages/twisted/spread/pb.py", line 630, in connectionLost
    d.errback(failure.Failure(PBConnectionLost(reason)))
  File "/opt/zenoss/lib/python2.7/site-packages/twisted/internet/defer.py", line 423, in errback
    self._startRunCallbacks(fail)
  File "/opt/zenoss/lib/python2.7/site-packages/twisted/internet/defer.py", line 490, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/opt/zenoss/lib/python2.7/site-packages/twisted/internet/defer.py", line 577, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/opt/zenoss/Products/ZenHub/PBDaemon.py", line 988, in errback
    self.log.error('Error pinging ZenHub: %!s(MISSING) (%!s(MISSING)).' %!((MISSING)error, error.message))
exceptions.AttributeError: Failure instance has no attribute 'message'
```