### PR TITLE
Fixes ZEN-19507: Unauthorized flares

### DIFF
--- a/Products/ZenUtils/controlplane/client.py
+++ b/Products/ZenUtils/controlplane/client.py
@@ -309,10 +309,9 @@ class ControlPlaneClient(object):
         self._opener.close()
 
     def _dorequest(self, uri, method=None, data=None, query=None):
-        request = self._makeRequest(
-            uri, method=method, data=data, query=query)
         # Try to perform the request up to five times
         for trycount in range(5):
+            request = self._makeRequest(uri, method=method, data=data, query=query)
             try:
                 return self._opener.open(request)
             except urllib2.HTTPError as ex:


### PR DESCRIPTION
If an HTTP Request already has a cookie inserted, HTTPCookieProcessor
apparently does not update it. So in our retry loop that handles the 401
error, rebuild the Request each time.