### PR TITLE
Use the same script as applied to ZEN-19663

### DIFF
--- a/Products/ZenModel/migrate/fixZopeHealthCheck.py
+++ b/Products/ZenModel/migrate/fixZopeHealthCheck.py
@@ -47,7 +47,7 @@ class FixZopeHealthCheck(Migrate.Step):
         # Update all of the 'ready' healthchecks
         readyHealthChecks = filter(lambda healthCheck: healthCheck.name == "ready", service.healthChecks)
         for readyCheck in readyHealthChecks:
-            readyCheck.script = "curl --output /dev/null --silent --head --write-out \"%{http_code}\" http://localhost:8080/zport/dmd | grep 401 >/dev/null"
+            readyCheck.script = "curl --output /dev/null --silent --write-out \"%{http_code}\" http://localhost:8080/robots.txt | grep 200 >/dev/null"
 
         ctx.commit()
 


### PR DESCRIPTION
Fixes ZEN-19335

The original fix for ZEN-19335 was based on the first fix for CC-1187. The healthcheck went through a couple of iterations. The fix in this PR matches the last (and hopefully final) iteration of the healthcheck.