### PR TITLE
Keeps declare in zenrun from misinterpreting flags

### DIFF
--- a/bin/zenrun
+++ b/bin/zenrun
@@ -68,7 +68,7 @@ defaultExists=$?
 if [[ $defaultExists=0 && -z "$1" ]]; then
     __DEFAULT__
     RC="$?"
-elif declare -f $1 &> /dev/null; then
+elif declare -f -- "$1" &> /dev/null; then
     "$@"
     RC="$?"
 elif [[ $defaultExists=0 ]]; then

--- a/bin/zenrun.d/zenpack-manager.sh
+++ b/bin/zenrun.d/zenpack-manager.sh
@@ -20,7 +20,7 @@ __DEFAULT__() {
     fi
     set -- "$@" $serviceid
 
-    if declare -f $1 &> /dev/null; then
+    if declare -f -- "$1" &> /dev/null; then
         "$@"
     else
         echo unknown zenpack sub-command: \"$1\"

--- a/bin/zenrun.d/zenpack.sh
+++ b/bin/zenrun.d/zenpack.sh
@@ -20,7 +20,7 @@ __DEFAULT__() {
     fi
     set -- "$@" $serviceid
 
-    if declare -f $1 &> /dev/null; then
+    if declare -f -- "$1" &> /dev/null; then
         "$@"
     else
         echo unknown zenpack sub-command: \"$1\"


### PR DESCRIPTION
A quick -- to mean "this ends the flag arguments" should do the trick.
Quoting $1 for safety.

Fixes ZEN-19369