### PR TITLE
Incorporate vSphere modeling optimization.

### DIFF
--- a/Products/DataCollector/ApplyDataMap.py
+++ b/Products/DataCollector/ApplyDataMap.py
@@ -112,9 +112,20 @@ class ApplyDataMap(object):
         if deviceClass and device.getDeviceClassPath().startswith(CLASSIFIER_CLASS):
             device.changeDeviceClass(deviceClass)
 
+    def _applyDataMap(self, device, datamap, commit=True):
+        """Apply datamap to device. Return True if datamap changed device.
 
-    @transact
-    def _applyDataMap(self, device, datamap):
+        The default value for commit is True for backwards-compatibility
+        reasons. If you're a new caller to ApplyDataMap._applyData you should
+        probably set commit to False and handle your own transactions.
+
+        """
+        if commit:
+            return transact(self._applyDataMapImpl(device, datamap))
+        else:
+            return self._applyDataMapImpl(device, datamap)
+
+    def _applyDataMapImpl(self, device, datamap):
         """Apply a datamap to a device.
         """
         self.num_obj_changed=0;

--- a/Products/ZenHub/invalidationfilter.py
+++ b/Products/ZenHub/invalidationfilter.py
@@ -20,6 +20,7 @@ from Products.ZenModel.OSProcessOrganizer import OSProcessOrganizer
 from Products.ZenModel.OSProcessClass import OSProcessClass
 from Products.ZenModel.GraphDefinition import GraphDefinition
 from Products.ZenModel.GraphPoint import GraphPoint
+from Products.ZenModel.ProductClass import ProductClass
 from Products.ZenModel.Software import Software
 from Products.Zuul.interfaces import ICatalogTool
 
@@ -35,7 +36,15 @@ class IgnorableClassesFilter(object):
     """
     implements(IInvalidationFilter)
 
-    CLASSES_TO_IGNORE = (IpAddress, IpNetwork, GraphDefinition, GraphPoint, Software)
+    CLASSES_TO_IGNORE = (
+        IpAddress,
+        IpNetwork,
+        GraphDefinition,
+        GraphPoint,
+        ProductClass,
+        Software,
+        )
+
     def initialize(self, context):
         pass
 


### PR DESCRIPTION
This change incorporates the essence of the modeling optimization
currently being monkeypatched in by the vSphere ZenPack.

The optimization is first to wrap the application of all datamaps in a
single transaction instead of one transaction per datamap. This can
potentially reduce the number of invalidations generated by modeling a
large device.

The second part of the optimization is to wrap all datamap application
in a pausedAndOptimizedIndexing context manager to reduce roundtrips to
CatalogService. This can greatly reduce the time spent inside
ApplyDataMap when modeling a large device.

The final piece of this change is adding ProductClass to the list of
classes that are ignored by invalidation processing. This is mostly
unrelated to the optimization other than I saw a large number
HardwareClass and SoftwareClass objects being invalidated when modeling
UCS devices. These objects are global and only linked to devices through
their instances relationships, so there's no need for collectors to know
they've changed.

Fixes ZEN-19701.