### PR TITLE
Update redis and collectorredis healthchecks

### DIFF
--- a/bin/healthchecks/collectorredis/metrics
+++ b/bin/healthchecks/collectorredis/metrics
@@ -8,5 +8,6 @@
 #
 ##############################################################################
 
-/opt/zenoss/bin/redis-mon post
-/opt/zenoss/bin/redis-mon post-length --list metrics
+(timeout 10s /opt/zenoss/bin/redis-mon post) &
+(timeout 10s /opt/zenoss/bin/redis-mon post-length --list metrics) &
+redis-cli ping

--- a/bin/healthchecks/redis/metrics
+++ b/bin/healthchecks/redis/metrics
@@ -8,4 +8,5 @@
 #
 ##############################################################################
 
-/opt/zenoss/bin/redis-mon post
+(timeout 10s /opt/zenoss/bin/redis-mon post) &
+redis-cli ping


### PR DESCRIPTION
Backgrounded use of redis-mon in healthchecks so it still ships
its metrics data, but also added the use of redis-cli ping to make
sure a response from redis is what's being tested for.

Closes ZEN-20103