### PR TITLE
zenhubworkers don't need to ping. Collector daemons need a longer int…

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -1096,7 +1096,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
 
         self.parser.add_option('--zenhubpinginterval',
                                dest='zhPingInterval',
-                               default=30,
+                               default=120,
                                type='int',
                                help='How often to ping zenhub')
 

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -72,7 +72,7 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
         loadPlugins(self.dmd)
         self.pid = os.getpid()
         self.services = {}
-        factory = ReconnectingPBClientFactory()
+        factory = ReconnectingPBClientFactory(pingPerspective=False)
         self.log.debug("Connecting to %s:%d",
                        self.options.hubhost,
                        self.options.hubport)


### PR DESCRIPTION
…erval to avoid issues with large config payloads.