### PR TITLE
Honor zCollectorPlugins order for Python plugins.

### DIFF
--- a/Products/DataCollector/PythonClient.py
+++ b/Products/DataCollector/PythonClient.py
@@ -41,6 +41,10 @@ class PythonClient(BaseClient):
         BaseClient.__init__(self, device, datacollector)
         self.hostname = device.id
         self.plugins = plugins
+
+        # Track the order of plugins so we can sort their results.
+        self.pluginsOrder = {p: i for i, p in enumerate(self.plugins)}
+
         self.results = []
 
 
@@ -101,4 +105,5 @@ class PythonClient(BaseClient):
         @return: list of results
         @rtype: list of results
         """
-        return self.results
+        # Sort results by configured order of plugins.
+        return sorted(self.results, key=lambda x: self.pluginsOrder[x[0]])

--- a/Products/DataCollector/tests/testPythonClient.py
+++ b/Products/DataCollector/tests/testPythonClient.py
@@ -1,0 +1,42 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import mock
+import unittest
+
+from Products.DataCollector.PythonClient import PythonClient
+
+
+class TestPythonClient(unittest.TestCase):
+    def test_getResults_order(self):
+        """PythonClient.getResults() should return orderly results.
+
+        Specifically what this means is that regardless of which data it's able
+        to get first, it will return the plugin results in the order in which
+        the plugins are configured. This is sometimes required when modeler
+        plugins implicitely depend on each other.
+
+        """
+        plugins = [mock.Mock(), mock.Mock()]
+
+        client = PythonClient(mock.Mock(), mock.Mock(), plugins)
+        client.collectComplete('FIRST', plugins[0])
+        client.collectComplete('LAST', plugins[-1])
+        self.assertEquals(
+            client.getResults(),
+            [(plugins[0], 'FIRST'), (plugins[-1], 'LAST')],
+            "plugins processed in order, but getResults() was out of order")
+
+        client = PythonClient(mock.Mock(), mock.Mock(), plugins)
+        client.collectComplete('LAST', plugins[-1])
+        client.collectComplete('FIRST', plugins[0])
+        self.assertEquals(
+            client.getResults(),
+            [(plugins[0], 'FIRST'), (plugins[-1], 'LAST')],
+            "plugins processed out of order, and getResults() was out of order")


### PR DESCRIPTION
The results of SNMP modeler plugins (SnmpPlugin) are already processed
in the order the plugins are configured, but Python modeler plugins
(PythonPlugin) don't work this way. Their results are ordered according
to which plugin returns its data first.

Fixes ZEN-20364.