### PR TITLE
Fix packZProperties/packZProperties_data clashing.

### DIFF
--- a/Products/ZenModel/tests/testZenPack.py
+++ b/Products/ZenModel/tests/testZenPack.py
@@ -1,0 +1,106 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import unittest
+
+from Products.ZenModel.ZenPack import ZenPack
+
+
+class TestZenPack(unittest.TestCase):
+
+    def test_getZProperties(self):
+        class ZenPack1(ZenPack):
+            pass
+
+        self.assertEquals(ZenPack1.getZProperties(), {})
+
+        class ZenPack2(ZenPack):
+            packZProperties = [
+                ('zMyString', 'default', 'string'),
+                ]
+
+        self.assertEquals(ZenPack2.getZProperties(), {
+            'zMyString': {
+                'type': 'string',
+                'defaultValue': 'default',
+                },
+            })
+
+        class ZenPack3(ZenPack):
+            packZProperties_data = {
+                'zMyString': {
+                    'type': 'string',
+                    'defaultValue': 'default',
+                    'category': 'My Category',
+                    'label': 'My String',
+                    'description': 'This is my string.',
+                    },
+                'zMyNoType': {
+                    'defaultValue': 'default',
+                    'description': "I don't have a type.",
+                    },
+                'zMyNoDefault': {
+                    'type': 'string',
+                    'description': "I don't have a default value.",
+                    },
+                }
+
+        self.assertEquals(ZenPack3.getZProperties(), {
+            'zMyString': {
+                'type': 'string',
+                'defaultValue': 'default',
+                'category': 'My Category',
+                'label': 'My String',
+                'description': 'This is my string.',
+                },
+            })
+
+        class ZenPack4(ZenPack):
+            packZProperties = [
+                ('zMyString', 'default', 'string'),
+                ('zMyLines', ['default'], 'lines'),
+                ]
+
+            packZProperties_data = {
+                'zMyString': {
+                    'type': 'int',
+                    'defaultValue': 'new-default',
+                    'category': 'Mine',
+                    'label': 'My String',
+                    'description': 'This is my string.',
+                    },
+                'zMyBoolean': {
+                    'type': 'boolean',
+                    'defaultValue': True,
+                    'category': 'Mine',
+                    'label': 'My Boolean',
+                    'description': 'This is my boolean.',
+                    },
+                }
+
+        self.assertEquals(ZenPack4.getZProperties(), {
+            'zMyString': {
+                'type': 'string',
+                'defaultValue': 'default',
+                'category': 'Mine',
+                'label': 'My String',
+                'description': 'This is my string.',
+                },
+            'zMyLines': {
+                'type': 'lines',
+                'defaultValue': ['default'],
+                },
+            'zMyBoolean': {
+                'type': 'boolean',
+                'defaultValue': True,
+                'category': 'Mine',
+                'label': 'My Boolean',
+                'description': 'This is my boolean.',
+                },
+            })


### PR DESCRIPTION
This corrects a problem where the type for a ZenPack's zProperty as
defined in its ZenPack.packZProperties property would be erased if the
same zProperty was also defined in ZenPack.packZProperties_data without
setting the type. This could end up being a common occurrence once
packZProperties_data becomes more widely known.

This fix prevents the erasure and makes packZProperties win any
disagreements in an attempt to provide the best backwards compatibility.

This problem can also easily be worked around in the ZenPack by adding a
type into the packZProperties_data for each zProperty in that dict.

Fixes ZEN-20359.