### PR TITLE
Please review branch feature/ZEN-20236

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/Reports.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Reports.js
@@ -167,6 +167,7 @@ Ext.define('Zenoss.ReportTreePanel', {
             parentNode = node.parentNode,
             uid = node.data.uid,
             params = {uid: uid};
+            node.data = {};
 
         function callback(data) {
             if (data.success) {


### PR DESCRIPTION
When a node is deleted in the reports tree an ExtDirect call is made to asyncGetTree() with all of the parameters of the deleted node.  The asyncGetTree method does not know what to do with these and an error appears.  Fix is to remove extra data from the call and just update the tree.