### PR TITLE
Please review branch feature/ZEN-18954

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
@@ -165,6 +165,9 @@
                 triggerAction: 'all'
             }, fields = [hostField], i;
 
+            var isSnmp = Ext.Array.some(connectionInfo, function(item) {
+                return item.category == 'SNMP';
+            });
             // convert the zproperty information into a field
             for (i=0; i < connectionInfo.length; i++ ) {
                 var item =  Zenoss.zproperties.createZPropertyField(connectionInfo[i]),
@@ -179,9 +182,11 @@
                     item.value = property.value || property.valueAsString;
                 }
                 // if it seems like credentials make it required
-                if (item.name.toLowerCase().indexOf('username') !== -1 ||
+                // do not make fields required if the category is SNMP per ZEN-18954
+                if (!isSnmp &&
+                    (item.name.toLowerCase().indexOf('username') !== -1 ||
                     item.name.toLowerCase().indexOf('password') !== -1 ||
-                    item.name.toLowerCase().indexOf('community') !== -1) {
+                    item.name.toLowerCase().indexOf('community') !== -1)) {
                     item.allowBlank = false;
                 }
 


### PR DESCRIPTION
When adding a multiple devices SNMP credentials should be optional to match the behavior of the add a single device form.