### PR TITLE
ZEN-20646 Run zminion via supervisord

### DIFF
--- a/Products/ZenModel/migrate/zminionViaSupervisord.py
+++ b/Products/ZenModel/migrate/zminionViaSupervisord.py
@@ -1,0 +1,44 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Migrate
+import servicemigration as sm
+sm.require("1.0.0")
+
+
+class RunZminionViaSupervisord(Migrate.Step):
+    """Modify zminion to run via supervisord and forward logs to logstash. """
+
+    version = Migrate.Version(5, 0, 70)
+
+    def cutover(self, dmd):
+
+        try:
+            ctx = sm.ServiceContext()
+        except sm.ServiceMigrationError:
+            log.info("Couldn't generate service context, skipping.")
+            return
+
+        zminion_services = filter(lambda s: s.name == 'zminion', ctx.services)
+        for zminion in zminion_services:
+            zminion.logConfigs = zminion.logConfigs or []
+            logfiles = [z.path for z in zminion.logConfigs]
+            log_path = "/opt/zenoss/log/zminion.log"
+            if log_path not in logfiles:
+                zminion.startup = 'su - zenoss -c "/bin/supervisord -n -c /opt/zenoss/etc/zminion/supervisord.conf"'
+                zminion.logConfigs.append(sm.LogConfig(path=log_path, type_="zminion"))
+
+        # Commit our changes.
+        ctx.commit()
+
+
+RunZminionViaSupervisord()


### PR DESCRIPTION
Modify zminion's startup command to use supervisord to divert output to rotated logfile.
Add a LogConfigs entry to forward this logfile to logstash.

Requires https://github.com/control-center/service-migration/pull/27 as it modifies a service's LogConfigs.