### PR TITLE
Fix onOrganizerBeforeDelete with CatalogService.

### DIFF
--- a/Products/Zuul/catalog/events.py
+++ b/Products/Zuul/catalog/events.py
@@ -105,7 +105,7 @@ def onOrganizerBeforeDelete(ob, event):
         # remove the device's path from this organizer
         # from the indexes
         for device in ob.devices.objectValuesGen():
-            catalog.unindex_object_from_paths(device, [device.getPhysicalPath()])
+            notify(IndexingEvent(device, idxs=['path']))
         
 
 @adapter(ITreeSpanningComponent, IObjectWillBeMovedEvent)


### PR DESCRIPTION
catalog.unindex_object_from_paths() doesn't work with CatalogService.
This was resulting in devices remaining indexed under DeviceGroup and
System paths even after those organizers were deleted. The result of
this was devices still being shown under the "Groups" and "Systems" root
organizers even though they no longer belonged to any groups or systems.

See comments of ZEN-20628 for a script that reproduces the problem and
verifies this solution.

Fixes ZEN-20628.