### PR TITLE
Use the graph id as the title of a multi-graph with multiple devices

### DIFF
--- a/Products/Zuul/infos/metricserver.py
+++ b/Products/Zuul/infos/metricserver.py
@@ -296,7 +296,7 @@ class MultiContextMetricServiceGraphDefinition(MetricServiceGraphDefinition):
 
     @property
     def contextTitle(self):
-        pass
+        return self._object.id
 
     def _getGraphPoints(self, klass):
         """


### PR DESCRIPTION
A single graph with multiple devices was showing null for the title.  It now uses the graph id.