### PR TITLE
ZEN-19774: Add __eq__() method to MultiArgs class

### DIFF
--- a/Products/DataCollector/plugins/DataMaps.py
+++ b/Products/DataCollector/plugins/DataMaps.py
@@ -118,16 +118,18 @@ pb.setUnjellyableForClass(ObjectMap, ObjectMap)
 
 class MultiArgs(PBSafe):
     """
-    Can be used as the value in an ObjectMap when the key is a function that 
+    Can be used as the value in an ObjectMap when the key is a function that
     takes multiple arguments.
     """
-    
+
     def __init__(self, *args):
         self.args = args
-        
-        
+
     def __repr__(self):
         return str(self.args)
-    
-    
+
+    def __eq__(self, other):
+        return self.args == other.args
+
+
 pb.setUnjellyableForClass(MultiArgs, MultiArgs)


### PR DESCRIPTION
Objects of the MultiArgs type cant't be used in tests, because of missed
__eq__() method implementation. Added the __eq__() method to fix it.

Fix suggested by @ssbunyk 