### PR TITLE
ZEN-19017: [Event Console] Group and Systems Columns aren't Sortable

### DIFF
--- a/Products/ZenUI3/browser/eventconsole/columns.py
+++ b/Products/ZenUI3/browser/eventconsole/columns.py
@@ -316,14 +316,14 @@ COLUMN_CONFIG = {
 
     'DeviceGroups': dict(
         header='Groups',
-        sortable=False,
+        sortable=True,
         filter='textfield',
         renderer='Zenoss.render.LinkFromGridUidGroup'
         ),
 
     'Systems'   : dict(
         header='Systems',
-        sortable=False,
+        sortable=True,
         filter='textfield',
         renderer='Zenoss.render.LinkFromGridUidGroup'),
 


### PR DESCRIPTION
port from 4.2.5: https://github.com/zenoss/4.2.5-RPS/pull/639/files