### PR TITLE
ZEN-19400: Use component, related to device, to build graph

### DIFF
--- a/Products/ZenModel/GraphReport.py
+++ b/Products/ZenModel/GraphReport.py
@@ -13,7 +13,7 @@ from AccessControl import ClassSecurityInfo
 from Products.ZenMessaging.audit import audit
 from Products.ZenUtils.deprecated import deprecated
 from Products.ZenModel.BaseReport import BaseReport
-from Products.ZenRelations.RelSchema import *
+from Products.ZenRelations.RelSchema import ToManyCont, ToOne
 from GraphReportElement import GraphReportElement
 from Products.ZenUtils.Utils import getObjByPath, getDisplayType
 from Products.ZenUtils.ZenTales import talesCompile, getEngine
@@ -121,7 +121,10 @@ class GraphReport(BaseReport):
         componentPaths = componentPaths or ('')
         for devId in deviceIds:
             dev = self.dmd.Devices.findDevice(devId)
-            for cPath in componentPaths:
+            # NOTE: There is no much sense to use component, which missed on
+            #       device, so we filred components to use only related to
+            #       device ones.
+            for cPath in filter(lambda path: devId in path, componentPaths):
                 try:
                     thing = getObjByPath(dev, cPath)
                 except KeyError:


### PR DESCRIPTION
There is a possibility to select for graphs elements, which are not
related to device. We should ignore them, because these graphs doesn't
seems to be usefull.

Fixes-issue: ZEN-19400 (Duplicate Component Graphs when multiple devices
selected during addition)

Removed wildcard import as well.

Ported From: 9b743287ca1aa62b28641617ab9e8370bec42cc6 in 4.2.5-RPS