### PR TITLE
ZEN-20810: Select-type cProp results in site error on creation

### DIFF
--- a/Products/ZenRelations/tests/TestSchema.py
+++ b/Products/ZenRelations/tests/TestSchema.py
@@ -84,7 +84,8 @@ class Organizer(TestBaseClass):
         self._setProperty("zInt", -1, type="int")
         self._setProperty("zString", "", type="string")
         self._setProperty("zBool", True, type="boolean")
-        self._setProperty("zLines", [], type="lines")
+        self._setProperty("zLines", ["one", "two"], type="lines")
+        self._setProperty("zSelect", "zLines", type="selection")
 
     def getZenRootNode(self):
         return self.unrestrictedTraverse("/zport/dmd/Orgs")

--- a/Products/ZenRelations/tests/testZenPropertyManager.py
+++ b/Products/ZenRelations/tests/testZenPropertyManager.py
@@ -1,10 +1,10 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
 
@@ -14,8 +14,7 @@ if __name__ == '__main__':
 
 from Acquisition import aq_base
 
-from Products.ZenRelations.tests.TestSchema import *
-from Products.ZenRelations.Exceptions import *
+from Products.ZenRelations.tests.TestSchema import Organizer
 
 from ZenRelationsBaseTest import ZenRelationsBaseTest
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
@@ -24,6 +23,7 @@ from Products.ZenRelations.ZenPropertyManager import ZenPropertyManager
 from Products.ZenRelations.ZenPropertyManager import IdentityTransformer
 from Products.ZenRelations.RelationshipManager import RelationshipManager
 from Products.ZenUtils.ZenTales import talesEval
+from Products.ZenWidgets import messaging
 
 class ZenPropertyManagerTest(ZenRelationsBaseTest):
 
@@ -35,8 +35,9 @@ class ZenPropertyManagerTest(ZenRelationsBaseTest):
 
 
     def testZenPropertyIds(self):
-        self.assert_(self.orgroot.zenPropertyIds() ==
-            ["zBool", "zFloat", "zInt", "zLines", "zString"])
+        self.assertEqual(
+            self.orgroot.zenPropertyIds(),
+            ["zBool", "zFloat", "zInt", "zLines", "zSelect", "zString"])
 
 
     def testZenPropertyIdsSubNode(self):
@@ -44,7 +45,7 @@ class ZenPropertyManagerTest(ZenRelationsBaseTest):
         subnode = self.create(self.orgroot, Organizer, "SubOrg")
         subnode._setProperty("zString", "teststring")
         self.assert_(subnode.zenPropertyPath("zString") == "/SubOrg")
-  
+
 
     def testSetZenPropertyString(self):
         """Set the value of a zenProperty with type string"""
@@ -52,27 +53,27 @@ class ZenPropertyManagerTest(ZenRelationsBaseTest):
         subnode.setZenProperty("zString", "teststring")
         self.assert_(subnode.zString == "teststring")
 
-    
+
     def testSetZenPropertyInt(self):
         """Set the value of a zenProperty with type int"""
         subnode = self.create(self.orgroot, Organizer, "SubOrg")
         subnode.setZenProperty("zInt", "1")
         self.assert_(subnode.zInt == 1)
-  
+
 
     def testSetZenPropertyFloat(self):
         """Set the value of a zenProperty with type float"""
         subnode = self.create(self.orgroot, Organizer, "SubOrg")
         subnode.setZenProperty("zFloat", "1.2")
         self.assert_(subnode.zFloat == 1.2)
-  
-    
+
+
     def testSetZenPropertyLines(self):
         """Set the value of a zenProperty with type lines"""
         subnode = self.create(self.orgroot, Organizer, "SubOrg")
         subnode.setZenProperty("zLines", ["1", "2", "3"])
         self.assert_(subnode.zLines == ["1","2","3"])
-  
+
 
     def testSetZenPropertyBool(self):
         """Set the value of a zenProperty with type boolean"""
@@ -81,8 +82,51 @@ class ZenPropertyManagerTest(ZenRelationsBaseTest):
         self.assert_(subnode.zBool == False)
         subnode.setZenProperty("zBool", "True")
         self.assert_(subnode.zBool == True)
-  
-    
+
+    def test_setPropertySelect(self):
+        """Set the value with type select"""
+
+        # FIXME: Use mock library here
+        class IMessageSenderMock(object):
+            def __init__(self, cls):
+                self.__cls = cls
+                self.__cls._mock_calls = []
+
+            def sendToBrowser(self, *args, **kwargs):
+                self.cls._mock_calls.append((args, kwargs))
+
+        from Products.ZenRelations import ZenPropertyManager as property_manager
+        IMessageSenderOrig = property_manager.IMessageSender
+        property_manager.IMessageSender = IMessageSenderMock
+        self.addCleanup(setattr, property_manager,
+                        'IMessageSender', IMessageSenderOrig)
+
+        subnode = self.create(self.orgroot, Organizer, "SubOrg")
+
+        # Check that a new property was added
+        subnode._setProperty("zSelect", "zLines", type='selection')
+        self.assertIn({'select_variable': 'zLines', 'visible': True,
+                       'type': 'selection', 'id': 'zSelect'},
+                      subnode._properties)
+
+        # Check that a new property was not added and sendToBrowser() was called
+        old_properties = subnode._properties
+        subnode._setProperty("zSelectWrong", "zSometingWrong", type='selection')
+        self.assertEqual(old_properties, subnode._properties)
+        mock_args = ('Wrong value in the `Value` field.',
+                     'Object has no zSometingWrong attribute.')
+        mock_kwargs = {'priority': messaging.WARNING}
+        self.assertEqual([(mock_args, mock_kwargs)], subnode._mock_calls)
+
+        # Check that a new property was not added and sendToBrowser() was called
+        subnode._setProperty("zSelectWrong", "zInt", type='selection')
+        self.assertEqual(old_properties, subnode._properties)
+        mock_args = (
+            'Wrong value in the `Value` field.',
+            'Property in Value field should contain a list of strings.')
+        mock_kwargs = {'priority': messaging.WARNING}
+        self.assertEqual([(mock_args, mock_kwargs)], subnode._mock_calls)
+
     def testdeleteZenProperty(self):
         """Set delete a zenProperty from a sub node"""
         subnode = self.create(self.orgroot, Organizer, "SubOrg")
@@ -129,19 +173,19 @@ class ZenPropertyManagerTest(ZenRelationsBaseTest):
         self.assert_(subnode.ptest == 'b')
 
 class Transformer(object):
-    
+
     def transformForSet(self, input):
         return 'foo_%s' % input
-        
+
     def transformForGet(self, input):
         return 'bar_%s' % input
 
 class TransformerBaseTest(BaseTestCase):
-    
+
     def beforeTearDown(self):
         self.manager = None
         super(TransformerBaseTest, self).beforeTearDown()
-        
+
     def testMyTestType(self):
         "test that property of type 'my test type' is transformed"
         self.manager.__class__.quux = PropertyDescriptor(
@@ -150,7 +194,7 @@ class TransformerBaseTest(BaseTestCase):
         self.assertEqual('bar_foo_blah', self.manager.getProperty('quux'))
         self.manager._updateProperty('quux', 'clash')
         self.assertEqual('bar_foo_clash', self.manager.getProperty('quux'))
-        
+
     def testString(self):
         "test that a string property isn't mucked with"
         self.manager.__class__.halloween = PropertyDescriptor(
@@ -158,34 +202,34 @@ class TransformerBaseTest(BaseTestCase):
         self.manager._setProperty('halloween', 'cat')
         self.assertEqual('cat', self.manager.getProperty('halloween'))
         self.assertEqual('cat', self.manager.halloween)
-        
+
     def testNormalAttribute(self):
         "make sure that a normal attribute isn't mucked with"
         self.manager.dog = 'Ripley'
         self.assertEqual('Ripley', self.manager.dog)
-        
+
 class TransformerTest(TransformerBaseTest):
-    
+
     def afterSetUp(self):
         """
         Test ZenPropertyManager that does not acquire a dmd attribute.
         """
         super(TransformerTest, self).afterSetUp()
         self.manager = ZenPropertyManager()
-        
+
 class RelationshipManagerTest(TransformerBaseTest):
-    
+
     def afterSetUp(self):
         """
-        Test ZenPropertyManager subclass that does not acquire a dmd 
+        Test ZenPropertyManager subclass that does not acquire a dmd
         attribute.
         """
         super(RelationshipManagerTest, self).afterSetUp()
 
         self.manager = RelationshipManager('manager')
-        
+
 class TransformerDmdTest(TransformerBaseTest):
-    
+
     def afterSetUp(self):
         """
         Test getting the transformers dictionary from the well-known dmd
@@ -196,32 +240,32 @@ class TransformerDmdTest(TransformerBaseTest):
         managerId = 'manager'
         self.dmd._setObject(managerId, RelationshipManager(managerId))
         self.manager = self.dmd.manager
-        
+
 class AcquisitionTest(BaseTestCase):
-    
+
     def runTest(self):
         "test that getProperty acquires"
         self.dmd._setProperty('foo', 'quux')
         self.assertEqual('quux', self.dmd.Devices.getProperty('foo'))
-        
+
 class TalesTest(BaseTestCase):
-    
+
     def runTest(self):
         manager = self.dmd.Devices
         talesEval('python: here.setZenProperty("foo", "bar")', manager)
         result = talesEval('python: here.getProperty("foo")', manager)
         self.assertEqual('bar', result)
-        
+
 class GetZTest(BaseTestCase):
     "getZ should not return passwords"
-    
+
     def runTest(self):
         manager = self.dmd.Devices
         manager._setProperty('foo', 'bar')
         self.assertEqual('bar', manager.getZ('foo'))
         manager._setProperty('something_new', 'blah', 'password')
         self.assertEqual(None, manager.getZ('something_new'))
-        
+
 class OldStyleClass:
     """
     Test that MyPropertyManager can inherit from an old-style class that does
@@ -229,30 +273,30 @@ class OldStyleClass:
     an old-style class and ZenPropertyManager inherits from it.
     """
     pass
-    
+
 class MyPropertyManager(object, OldStyleClass):
-    
+
     myProp = PropertyDescriptor('myProp', 'my test type', Transformer())
     myProp2 = PropertyDescriptor('myProp2', 'string', IdentityTransformer())
     _properties = [dict(id='myProp', value='', type='my test type'),
                    dict(id='myProp2', value='', type='string')]
-    
+
 class PropertyDescriptorTest(BaseTestCase):
-    
+
     def afterSetUp(self):
         super(PropertyDescriptorTest, self).afterSetUp()
         self.manager = MyPropertyManager()
-        
+
     def beforeTearDown(self):
         del self.manager
         super(PropertyDescriptorTest, self).beforeTearDown()
-        
+
     def testProperty(self):
         self.manager.myProp = 'quux'
         self.assertEqual('bar_foo_quux', self.manager.myProp)
         self.manager.myProp2 = 'duck'
         self.assertEqual('duck', self.manager.myProp2)
-        
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
@@ -265,6 +309,6 @@ def test_suite():
     suite.addTest(makeSuite(GetZTest))
     suite.addTest(makeSuite(PropertyDescriptorTest))
     return suite
-    
+
 if __name__=="__main__":
     framework()


### PR DESCRIPTION
Added some validation in custom attribute creation code.

Now the proper algoritm to create a custom property with `select` type is:

1. (Optional) Create first custom property with `Lines` type with each
selection separated with a carriage return.
2. Create second custom property with "Selection" type. You must set
existing
property or the custom property from (1) as the `Value`.

In this case the second cProp has a working drop down filled with the contents
from the 1st cProp.

Ported From: 85dea502ba13777282ddd113bbfeac1fd70ad4dc in 4.2.5-RPS