### PR TITLE
ZEN-20863 Service migrations for new session db

### DIFF
--- a/Products/ZenModel/migrate/addMemcachedService.py
+++ b/Products/ZenModel/migrate/addMemcachedService.py
@@ -1,0 +1,83 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import json
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Migrate
+import servicemigration as sm
+sm.require("1.0.0")
+
+
+class AddMemcachedService(Migrate.Step):
+    """
+    Update memcache healthcheck, and add the service to Core
+    """
+
+    version = Migrate.Version(5, 0, 70)
+
+    def cutover(self, dmd):
+        try:
+            ctx = sm.ServiceContext()
+        except sm.ServiceMigrationError:
+            log.info("Couldn't generate service context, skipping.")
+            return
+
+        # If the service lacks memcached, add it now.
+        memcached = filter(lambda s: s.name == "memcached", ctx.services)[0]
+        if not memcached:
+            new_memcached = default_memcached_service()
+            infrastructure = ctx.findServices('^[^/]+/Infrastructure$')[0]
+            ctx.deployService(json.dumps(new_memcached), infrastructure)
+            ctx.commit()
+
+
+def default_memcached_service():
+    return {
+      "CPUCommitment": 1, 
+      "Command": "/bin/memcached -u nobody -v -m {{percentScale .RAMCommitment 0.9 | bytesToMB}}", 
+      "ConfigFiles": {
+        "/etc/sysconfig/memcached": {
+          "Filename": "/etc/sysconfig/memcached", 
+          "Owner": "root:root", 
+          "Permissions": "0644",
+          "Content": 'PORT="11211"\nUSER="memcached"\nMAXCONN="1024"\nCACHESIZE="{{.RAMCommitment}}"\nOPTIONS=""\n',
+        }
+      }, 
+      "Description": "Free & open source, high-performance, distributed memory object caching system", 
+      "Endpoints": [
+        {
+          "Application": "memcached", 
+          "Name": "memcached", 
+          "PortNumber": 11211, 
+          "Protocol": "tcp", 
+          "Purpose": "export"
+        }
+      ], 
+      "HealthChecks": {
+        "answering": {
+          "Interval": 5, 
+          "Script": "{ echo stats; sleep 1; } | nc 127.0.0.1 11211 | grep -q uptime"
+        }
+      }, 
+      "Instances": {
+        "Min": 1
+      }, 
+      "Launch": "auto", 
+      "Name": "memcached", 
+      "RAMCommitment": "1G", 
+      "Services": [], 
+      "Tags": [
+        "daemon"
+      ]
+    }
+
+AddMemcachedService()
+

--- a/Products/ZenModel/migrate/makeMemcachedUpdates.py
+++ b/Products/ZenModel/migrate/makeMemcachedUpdates.py
@@ -1,0 +1,61 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Migrate
+import servicemigration as sm
+sm.require("1.0.0")
+
+
+class MakeMemcachedUpdates(Migrate.Step):
+    """
+    Update memcache healthcheck, and add the service to Core
+    """
+
+    version = Migrate.Version(5, 0, 70)
+
+    def cutover(self, dmd):
+        try:
+            ctx = sm.ServiceContext()
+        except sm.ServiceMigrationError:
+            log.info("Couldn't generate service context, skipping.")
+            return
+
+        memcached = filter(lambda s: s.name == "memcached", ctx.services)[0]
+        if not memcached:
+            log.info("Couldn't find memcached service, skipping.")
+            return
+
+        answering = filter(lambda hc: hc.name == 'answering', memcached.healthChecks)
+        if answering:
+            answering[0].script = "{ echo stats; sleep 1; } | nc 127.0.0.1 11211 | grep -q uptime"
+
+        # Create /etc/sysconfig/memcached if it doesn't exist
+        esm_content = """\
+PORT="11211"
+USER="memcached"
+MAXCONN="1024"
+CACHESIZE="{{.RAMCommitment}}"
+OPTIONS=""
+"""
+        e_s_memcached = sm.ConfigFile (
+            name = "/etc/sysconfig/memcached",
+            filename = "/etc/sysconfig/memcached",
+            owner = "zenoss:zenoss",
+            permissions = "0664",
+            content = esm_content,
+        )
+        if '/etc/sysconfig/memcached' not in [cf.name for cf in memcached.configFiles]:
+            memcached.configFiles.append(e_s_memcached)
+
+        ctx.commit()
+
+MakeMemcachedUpdates()

--- a/Products/ZenModel/migrate/useBeakerInZope.py
+++ b/Products/ZenModel/migrate/useBeakerInZope.py
@@ -1,0 +1,59 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Migrate
+import servicemigration as sm
+sm.require("1.0.0")
+
+
+class UseBeakerInZope(Migrate.Step):
+    """
+    Use Beaker in Zope
+    """
+
+    version = Migrate.Version(5, 0, 70)
+
+    def cutover(self, dmd):
+        try:
+            ctx = sm.ServiceContext()
+        except sm.ServiceMigrationError:
+            log.info("Couldn't generate service context, skipping.")
+            return
+        beaker_config_text = """
+<product-config beaker>
+    cache.type              ext:memcached
+    cache.url               127.0.0.1:11211
+    cache.data_dir          /tmp/cache/data
+    cache.lock_dir          /tmp/cache/lock
+    cache.regions           short, long
+    cache.short.expire      60
+    cache.long.expire       3600
+
+    session.type            ext:memcached
+    session.url             127.0.0.1:11211
+    session.data_dir        /tmp/sessions/data
+    session.lock_dir        /tmp/sessions/lock
+    session.key             beaker.session
+    session.secret          supersecret
+</product-config>
+"""
+
+        zopes_and_zauths = filter(lambda s: s.name in ["zope", "zauth"], ctx.services)
+        for z in zopes_and_zauths:
+            for configfile in filter(lambda f: f.name == '/opt/zenoss/etc/zope.conf', z.configFiles):
+                if '<product-config beaker>' in configfile.content:
+                    continue
+                configfile.content += beaker_config_text
+        ctx.commit()
+
+UseBeakerInZope()
+


### PR DESCRIPTION
Adds three migration scripts:
- addMemcachedService adds the memcached service underneath Infrastructure
- makeMemcachedUpdates updates existing memcached service's "answering" healthcheck and
  adds a sysconfig conf file for the same
- useBeakerInZope adds a "product-config beaker" section to Zope's zope.conf

These changes support recent updates to servicedefs to use a beaker session database.