### PR TITLE
Revert "Changed default log level to Warn"

### DIFF
--- a/Products/ZenUtils/CmdBase.py
+++ b/Products/ZenUtils/CmdBase.py
@@ -166,7 +166,7 @@ class CmdBase(object):
             group = OptionGroup(self.parser, "Logging Options")
             group.add_option(
                 '-v', '--logseverity',
-                dest='logseverity', default='WARNING', type='loglevel',
+                dest='logseverity', default='INFO', type='loglevel',
                 help='Logging severity threshold',
             )
             group.add_option(


### PR DESCRIPTION
Reverts zenoss/zenoss-prodbin#1209
This change is too much of a "brute force" approach.  Different aspects of the system need INFO level logging for verification by users (as in, we don't know anything is happening unless we see logging).