### PR TITLE
ZEN-20640: zenmail failing on 5.x

### DIFF
--- a/Products/ZenModel/migrate/addZenMailHealthCheck.py
+++ b/Products/ZenModel/migrate/addZenMailHealthCheck.py
@@ -1,0 +1,48 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2015, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import os
+import re
+import logging
+log = logging.getLogger("zen.migrate")
+
+import Migrate
+import servicemigration as sm
+from servicemigration import HealthCheck
+sm.require("1.0.0")
+
+
+class AddZenMailHealthCheck(Migrate.Step):
+    """Add `service_ready` healthcheck to zenmail service"""
+
+    version = Migrate.Version(5,1,70)
+
+    def cutover(self, dmd):
+
+        try:
+            ctx = sm.ServiceContext()
+        except sm.ServiceMigrationError:
+            log.info("Couldn't generate service context, skipping.")
+            return
+
+        service_ready_healthcheck = HealthCheck(
+            name="service_ready",
+            interval="10.0",
+            script="echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025 | grep -q '^220 '")
+
+        zenmail_service = filter(lambda s: s.name == "zenmail", ctx.services)[0]
+
+        if not filter(lambda c: c.name == 'service_ready', zenmail_service.healthChecks):
+            zenmail_service.healthChecks.append(service_ready_healthcheck)
+
+        # Commit our changes.
+        ctx.commit()
+
+
+AddZenMailHealthCheck()

--- a/Products/ZenModel/migrate/addZenMailHealthCheck.py
+++ b/Products/ZenModel/migrate/addZenMailHealthCheck.py
@@ -34,7 +34,7 @@ class AddZenMailHealthCheck(Migrate.Step):
         service_ready_healthcheck = HealthCheck(
             name="service_ready",
             interval="10.0",
-            script="echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025 | grep -q '^220 '")
+            script="echo 'QUIT' | nc -w 10 -C 127.0.0.1 50025 | grep -q '^220 '")
 
         zenmail_service = filter(lambda s: s.name == "zenmail", ctx.services)[0]
 


### PR DESCRIPTION
In `zenmail` container:
```
[root@13159066a9a9 /]# echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025                  
220 13159066a9a9 NO UCE NO UBE NO RELAY PROBES
221 See you later
[root@13159066a9a9 /]# echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025 | grep '^220 '   
220 13159066a9a9 NO UCE NO UBE NO RELAY PROBES
[root@13159066a9a9 /]# echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025 | grep -q '^220 '
[root@13159066a9a9 /]# echo $?
0
[root@13159066a9a9 /]# echo 'QUIT' | nc -w 20 -C 127.0.0.1 50025 | grep -q '^225 '
[root@13159066a9a9 /]# echo $?                                                    
1
[root@13159066a9a9 /]# echo 'QUIT' | nc -w 20 -C 127.0.0.1 50026 | grep -q '^220 '
Ncat: Connection refused.
[root@13159066a9a9 /]# echo $?
1
[root@13159066a9a9 /]# 
```

For reply code 220 please see https://tools.ietf.org/html/rfc821#page-35