### PR TITLE
ZEN-21104: Make propertyItems() accessible only from python code

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -295,6 +295,8 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
 
     security = ClassSecurityInfo()
 
+    security.declarePrivate("propertyItems")
+
     def __init__(self, id, buildRelations=True):
         ManagedEntity.__init__(self, id, buildRelations=buildRelations)
         osObj = OperatingSystem()


### PR DESCRIPTION
Method propertyItems() can return security data (e.g ssh password), so
we should forbidd acees to this method from UI to aviod of security
issues.

Co-Authored-By: Roman Bakaleyko <rbakaleyko@zenoss.com>

Cherry-Picked-From: a837c2cf6f9a5b10ac84c32b518178c9ad4f55b9