### PR TITLE
ZEN-21093: Remove getZenossRevision() and it's usage

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -28,22 +28,21 @@ from Globals import DevelopmentMode
 from Products.ZenModel.SiteError import SiteError
 from Products.ZenModel.ZenModelBase import ZenModelBase
 from Products.ZenModel.ZenMenuable import ZenMenuable
-from Products.ZenRelations.RelSchema import *
+from Products.ZenRelations.RelSchema import ToManyCont, ToOne
 from Products.ZenUtils.IpUtil import IpAddressError
 from Products.ZenWidgets import messaging
 from Products.ZenUtils.Security import activateSessionBasedAuthentication, activateCookieBasedAuthentication
 from Commandable import Commandable
-import socket
 import os
 import sys
 import string
 from Products.ZenMessaging.audit import audit
 from Products.ZenUtils.Utils import zenPath, binPath
-from Products.ZenUtils.Utils import extractPostContent
 from Products.ZenUtils.jsonutils import json
 from Products.ZenUtils.ZenTales import talesCompile, getEngine
 
-from Products.ZenEvents.Exceptions import *
+from Products.ZenEvents.Exceptions import (
+    MySQLConnectionError, pythonThresholdException, rpnThresholdException)
 
 from ZenModelRM import ZenModelRM
 from ZenossSecurity import ZEN_COMMON, ZEN_MANAGE_DMD, ZEN_VIEW
@@ -446,7 +445,6 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
                     self.REQUEST.errorValue,
                     self.REQUEST.errorTrace,
                     self.REQUEST.errorUrl,
-                    self.About.getZenossRevision(),
                     self.About.getZenossVersionShort(),
                     self.REQUEST.contactName,
                     self.REQUEST.contactEmail,
@@ -458,7 +456,6 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
                                 self.REQUEST.errorValue,
                                 self.REQUEST.errorTrace,
                                 self.REQUEST.errorUrl,
-                                self.About.getZenossRevision(),
                                 self.About.getZenossVersionShort(),
                                 True,
                                 self.REQUEST.contactName,

--- a/Products/ZenModel/SiteError.py
+++ b/Products/ZenModel/SiteError.py
@@ -46,8 +46,8 @@ class SiteError:
         return header
     createEmailHeader = classmethod(createEmailHeader)
 
-        
-    def createReport(cls, errorType, errorValue, errorTrace, errorUrl, revision,
+
+    def createReport(cls, errorType, errorValue, errorTrace, errorUrl,
                         versionShort,
                         inHtml=True, contactName=None, contactEmail=None, 
                         comments=None):
@@ -74,7 +74,6 @@ class SiteError:
         msg = linebreak.join(['Type: %s' % errorType,
                                 'Value: %s' % errorValue,
                                 'URL: %s' % cls.cleanUrl(errorUrl),
-                                'Revision: %s' % revision,
                                 'Version: %s' % versionShort,
                                 '%s' % errorTrace,
                                 'Contact name: %s' % (contactName or ''),
@@ -84,8 +83,8 @@ class SiteError:
     createReport = classmethod(createReport)
 
 
-    def sendErrorEmail(self, errorType, errorValue, errorTrace, errorUrl, 
-                        revision, versionShort,
+    def sendErrorEmail(self, errorType, errorValue, errorTrace, errorUrl,
+                        versionShort,
                         contactName=None, contactEmail=None, comments=None,
                         smtphost=None, smtpport=25, usetls=False, usr='', 
                         pwd=''):
@@ -101,7 +100,7 @@ class SiteError:
         header = self.createEmailHeader(
                     fromAddress, self.ERRORS_ADDRESS, subject)
         body = self.createReport(errorType, errorValue, errorTrace, cleanUrl,
-                                revision, versionShort,
+                                versionShort,
                                 0, contactName, contactEmail, comments)
         mailSent = False
 

--- a/Products/ZenModel/ZenossInfo.py
+++ b/Products/ZenModel/ZenossInfo.py
@@ -21,22 +21,23 @@ import shutil
 import traceback
 import logging
 import commands
-log = logging.getLogger("zen.ZenossInfo")
 
 from Globals import InitializeClass
 from OFS.SimpleItem import SimpleItem
 from AccessControl import ClassSecurityInfo
 
-from Products.ZenModel.ZenossSecurity import *
+from Products.ZenModel.ZenossSecurity import ZEN_MANAGE_DMD
 from Products.ZenModel.ZenModelItem import ZenModelItem
 from Products.ZenCallHome.transport.methods.versioncheck import version_check
-from Products.ZenUtils import Time
 from Products.ZenUtils.mysql import MySQLdb
 from Products.ZenUtils.GlobalConfig import getGlobalConfiguration
-from Products.ZenUtils.Version import *
+from Products.ZenUtils.Version import (Version, VersionNotSupported,
+                                       getVersionTupleFromString)
 from Products.ZenUtils.Utils import zenPath, binPath, isZenBinFile
 from Products.ZenWidgets import messaging
 from Products.ZenMessaging.audit import audit
+
+log = logging.getLogger("zen.ZenossInfo")
 
 
 def versionmeta(name, href, optional=False):
@@ -147,8 +148,7 @@ class ZenossInfo(ZenModelItem, SimpleItem):
     @versionmeta("Zenoss", "http://www.zenoss.com")
     def getZenossVersion(self):
         from Products.ZenModel.ZVersion import VERSION
-        return Version.parse("Zenoss %s %s" %
-                    (VERSION, self.getZenossRevision()))
+        return Version.parse("Zenoss %s" % VERSION)
     security.declarePublic('getZenossVersion')
 
     def getZenossVersionShort(self):
@@ -278,21 +278,6 @@ class ZenossInfo(ZenModelItem, SimpleItem):
         name = 'Zope'
         major, minor, micro, status, release = version.getZopeVersion()
         return Version(name, major, minor, micro)
-
-    def getZenossRevision(self):
-        """
-        Determine the Zenoss version number
-
-        @return: version number or ''
-        @rtype: string
-        """
-        try:
-            products = zenPath("Products")
-            cmd = "svn info '%s' 2>/dev/null | awk '/Revision/ {print $2}'" % products
-            fd = os.popen(cmd)
-            return fd.readlines()[0].strip()
-        except:
-            return ''
 
     @versionmeta("NetSnmp", "http://net-snmp.sourceforge.net", optional=True)
     def getNetSnmpVersion(self):


### PR DESCRIPTION
getZenossRevision() method makes `svn info` call, which always fails, so
we can safely remove this method to clean code.

Also removed wildcard and unused imports. See PEP8 [0] for motivation

Cherry-Picked From: 9cbc789bf3824269ce5467ec0b504295c4d6660c

[0] - https://www.python.org/dev/peps/pep-0008/#imports