### PR TITLE
Feature/zen 21271

### DIFF
--- a/Products/ZenUI3/browser/resources/css/quickstart.css
+++ b/Products/ZenUI3/browser/resources/css/quickstart.css
@@ -24,7 +24,9 @@ strong { font-weight: bold; }
     background: #dfe8f6 url('/zport/img/ext_rowindicator.gif') right center no-repeat;
 }
 #center_panel {
-
+    border: 1px solid #777;
+    background-color: white;
+    margin: 20px;
 }
 #header-extra {
     float: right;
@@ -53,15 +55,12 @@ h2 {
 }
 
 #content-wrapper {
-    padding: 1em;
-    border: 1px solid black;
-    background-color: white;
-    margin: 1em 1em 0 1em;
+    max-width: 1000px;
+    margin: auto;
 }
 
 #content {
     text-align: left;
-    margin-top: 1.5em;
     margin: 0 auto;
 }
 
@@ -147,38 +146,107 @@ table.step-content {
     margin-left: -85px;
 }
 .wizardStep {
-    background-image: url("/++resource++zenui/img/bluesquare.png");
-    background-repeat:no-repeat;
-    height:250px;
-    width: 250px;
+    height: 175px;
+    padding: 20px;
+    background-color: #99bce8;
+    color: #444;
+    border-radius: 4px;
+    position: relative;
     font-family: helvetica,arial,sans-serif;
     font-weight: bolder;
 }
 .wizardStepHeader {
     font-size: 25px;
-    left: 30px;
-    position: relative;
-    top: 30px;
+    margin: 5px 0 35px 0;
 }
 
 .wizardIcon {
-    float: right;
-    margin: -30px 73px;
+    position: absolute;
+    top: 15px;
+    right: 15px;
 }
 .wizardStepTitle {
     font-size: 18px;
-    position: relative;
-    top: 65px;
-    left: 30px;
+    margin-bottom: 5px;
 }
 .wizardStepDescription {
-    position: relative;
-    font-weight: lighter;
-    top: 95px;
-    left: 30px;
-    width: 180px;
-    text-align: left;
+    max-width: 200px;
 }
+
+.wizardColumn {
+    border-right: solid 1px #CACACA !important;
+    padding-right: 10px;
+}
+
+.quickstart .empty-grid-text {
+    padding-top: 10px;
+    text-align: center;
+    font-size: 1.4em;
+    color: #AAA;
+    font-style: italic;
+}
+
+
+/* CSS reset button style */
+.quickstart .btn {
+    background: none;
+    border: 0;
+    border-radius: 0;
+    color: inherit;
+    /* cursor: default; */
+    font: inherit;
+    line-height: normal;
+    overflow: visible;
+    padding: 0;
+    -webkit-user-select: none; /* for button */
+       -moz-user-select: none;
+        -ms-user-select: none;
+}
+.quickstart .btn::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+}
+
+/* base button style */
+.quickstart .btn {
+    padding: 7px 12px;
+    cursor: pointer;
+    background-color: #BBB;
+}
+.quickstart .btn .x-btn-inner {
+    font-size: 1.1em;
+    color: #444;
+}
+.quickstart .btn:hover {
+    background-color: #AAA;
+}
+.quickstart .btn:hover .x-btn-inner {
+    font-size: 1.1em;
+    color: #222;
+}
+
+/* diabled button */
+.quickstart .btn.disabled .x-btn-inner {
+    color: #777 !important;
+}
+
+
+/* minor button */
+.quickstart .btn.minor {
+    background-color: transparent;
+    border: solid #CCC 1px;
+}
+.quickstart .btn.minor .x-btn-inner {
+}
+.quickstart .btn.minor:hover {
+    background-color: #EEE;
+}
+
 img.stepbox {
    margin-bottom: 30px;
+}
+
+.list li {
+    margin-left: 15px;
+    list-style-type: disc;
 }

--- a/Products/ZenUI3/browser/resources/css/quickstart.css
+++ b/Products/ZenUI3/browser/resources/css/quickstart.css
@@ -148,9 +148,8 @@ table.step-content {
 .wizardStep {
     height: 175px;
     padding: 20px;
-    background-color: #99bce8;
+    background-color: #D4E2E5;
     color: #444;
-    border-radius: 4px;
     position: relative;
     font-family: helvetica,arial,sans-serif;
     font-weight: bolder;
@@ -240,6 +239,23 @@ table.step-content {
 }
 .quickstart .btn.minor:hover {
     background-color: #EEE;
+}
+
+.quickstart .btn.big {
+    padding: 10px 12px
+}
+.quickstart .btn.big .x-btn-inner {
+    font-size: 1.4em;
+}
+
+.quickstart .device-type-grid .x-grid-cell {
+    font-size: 1em;
+}
+.quickstart .device-type-grid .x-grid-row-selected .x-grid-cell-inner{
+    font-weight: bold;
+}
+.quickstart .device-type-grid .x-grid-row-selected:hover .x-grid-cell-inner{
+    color: white !important;
 }
 
 img.stepbox {

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/app.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/app.js
@@ -57,11 +57,11 @@
         launch: function() {
             Zenoss.quickstart.Wizard.events.fireEvent('beforeapplaunch', this);
             var panel = Ext.create('Ext.Panel', {
-                layout: 'border',
+                layout: 'anchor',
+                anchor: "100% 100%",
                 renderTo: 'center_panel',
-                height: 400,
                 style: {
-                    padding: "40px 0px 0px 100px"
+                    padding: "40px"
                 },
                 items: [{
                     region: 'north',
@@ -72,7 +72,7 @@
                         height: 28
                     },{
                         html: '<hr />',
-                        width: 870,
+                        width: "100%",
                         height: 25
                     }],
                     height: 70
@@ -86,30 +86,45 @@
                         itemId: 'toolbar',
                         baseCls: 'no-grey',
                         cls: 'no-grey',
-                        hidden: true,
                         xtype: 'toolbar',
                         items: [{
                             xtype: 'button',
                             hidden: true,
                             itemId: 'doneButton',
+                            cls: "btn",
+                            disabledCls: "disabled",
                             text: _t('Done'),
                             handler: function() {
                                 window.globalApp.doneAddingDevices();
                             }
                         }, {
                             xtype: 'button',
+                            hidden: true,
                             itemId: 'previousButton',
-                            text: _t('Previous'),
+                            cls: "btn minor",
+                            disabledCls: "disabled",
+                            text: _t('« Previous'),
                             handler: function() {
                                 window.globalApp.fireEvent('previousstep');
                             }
                         }, {
-                            xtype: 'tbspacer',
-                            width: 763
+                            xtype: 'tbfill'
                         }, {
                             xtype: 'button',
+                            hidden: true,
                             itemId: 'nextButton',
-                            text: _t('Next'),
+                            cls: "btn",
+                            disabledCls: "disabled",
+                            text: _t('Next »'),
+                            handler: function() {
+                                window.globalApp.fireEvent('nextstep');
+                            }
+                        }, {
+                            xtype: 'button',
+                            itemId: 'getStartedButton',
+                            cls: "btn",
+                            disabledCls: "disabled",
+                            text: _t('Get Started »'),
                             handler: function() {
                                 window.globalApp.fireEvent('nextstep');
                             }
@@ -117,13 +132,20 @@
                             xtype: 'button',
                             hidden: true,
                             itemId: 'finishButton',
-                            text: _t('Finish'),
+                            cls: "btn",
+                            disabledCls: "disabled",
+                            text: _t('✔ Finish'),
                             handler: function() {
                                 window.globalApp.fireEvent('finish');
                             }
                         }]
                     }]
                 }]
+            });
+
+            // resize panel on window resize
+            Ext.EventManager.onWindowResize(function(){
+                panel.doComponentLayout();
             });
             // set shortcuts for wizard controls
             this.mainPanel = panel;
@@ -132,6 +154,7 @@
             this.previous = this.cardPanel.query('button[itemId="previousButton"]')[0];
             this.next = this.cardPanel.query('button[itemId="nextButton"]')[0];
             this.done = this.cardPanel.query('button[itemId="doneButton"]')[0];
+            this.getStarted = this.cardPanel.query('button[itemId="getStartedButton"]')[0];
             this.finish = this.cardPanel.query('button[itemId="finishButton"]')[0];
             this.toolbar = this.cardPanel.getDockedItems()[0];
 
@@ -184,16 +207,6 @@
             if (this.params.came_from) {
                 var title = document.title.split(":")[0];
                 document.title = title + ": " + cardTitle;
-            }
-        },
-        /**
-         * Hide the toolbar for the initial page.
-         **/
-        setToolbar: function() {
-            if (this.currentStep > 0) {
-                this.toolbar.show();
-            } else {
-                this.toolbar.hide();
             }
         },
         /**
@@ -250,33 +263,38 @@
         updateWizard: function() {
             var stepCount = this.cardPanel.items.getCount() - 1,
                 params = this.params;
-            this.setHeight();
             this.setTitle();
-            this.setToolbar();
             this.updateHistory();
 
             // we can redirected here to add devices after the user has finished the wizard
+            // TODO - more sensible state handling for buttons
             if (params && params.came_from) {
                 this.done.show();
                 this.next.hide();
                 this.previous.hide();
+                this.getStarted.hide();
+                this.finish.hide();
+            }else if (this.currentStep === 0) {
+                // they are on the first step
+                this.done.hide();
+                this.next.hide();
+                this.previous.hide();
+                this.getStarted.show();
                 this.finish.hide();
             }else if (this.currentStep === stepCount) {
                 // they are on the last step
+                this.done.hide();
                 this.next.hide();
+                this.previous.show();
+                this.getStarted.hide();
                 this.finish.show();
             } else {
                 // they have more steps to go
+                this.done.hide();
                 this.next.show();
+                this.previous.show();
+                this.getStarted.hide();
                 this.finish.hide();
-            }
-        },
-        setHeight: function() {
-            var item = this.cardPanel.layout.getActiveItem();
-            if (item.stepHeight) {
-                this.mainPanel.setHeight(item.stepHeight);
-            } else {
-                this.mainPanel.setHeight(600);
             }
         },
         formValidityChange: function(isValid) {

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/app.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/app.js
@@ -122,7 +122,7 @@
                         }, {
                             xtype: 'button',
                             itemId: 'getStartedButton',
-                            cls: "btn",
+                            cls: "btn big",
                             disabledCls: "disabled",
                             text: _t('Get Started »'),
                             handler: function() {

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
@@ -39,12 +39,15 @@
                         this.setDeviceTypes(val.category);
                     }
                 },
-                'combo[itemId="deviceType"]': {
-                    change: function(combo, val) {
+                'grid[itemId="deviceType"]': {
+                    select: function(select, record, index){
+                        var val = record.get("value");
                         if (!val) {
-                            this.getCredentials(combo.getStore().getAt(0).get('value'));
+                            // select the first item
+                            this.getCredentials(select.getStore().getAt(0).get('value'));
+                        } else {
+                            this.getCredentials(val);
                         }
-                        this.getCredentials(val);
                     }
                 },
                 'fieldset[itemId="credentials"]': {
@@ -95,16 +98,16 @@
             }, this);
         },
         setDeviceTypes: function(uid) {
-            var combo = this.getForm().query('combo[itemId="deviceType"]')[0],
-                store = combo.getStore();
+            var grid = this.getForm().query('grid[itemId="deviceType"]')[0],
+                store = grid.getStore();
 
-            // reload the combo store and select the first one when done loading
+            // reload the grid store and select the first one when done loading
             store.load({
                 params: {
                     uid: uid
                 },
                 callback: function() {
-                    combo.setValue(store.getAt(0));
+                    grid.selModel.doSelect(store.getAt(0));
                 }
             });
         },
@@ -231,14 +234,15 @@
         onClickAddButton: function() {
             var values = this.getForm().getForm().getFieldValues(),
                 hosts = values.hosts,
-                deviceClass = values.deviceclass,
                 collector = values.collector,
                 zProperties = this.getZProperties(values),
-                combo = this.getForm().query('combo[itemId="deviceType"]')[0],
-                grid = this.getGrid();
+                typeGrid = this.getForm().query('grid[itemId="deviceType"]')[0],
+                grid = this.getGrid(),
+                deviceClass = typeGrid.selModel.getSelection()[0].get("value");
+
             // allow either commas to separate or new lines or both
             hosts = this.parseHosts(values.hosts);
-            var displayDeviceClass = combo.getStore().getAt(combo.getStore().findExact('value', deviceClass)).get('shortdescription');
+            var displayDeviceClass = typeGrid.getStore().findRecord('value', deviceClass).get('shortdescription');
             // go through each host and add a record
             Ext.Array.each(hosts, function(host){
                 if (Ext.isEmpty(host)) {
@@ -260,7 +264,7 @@
         },
         getZProperties: function(values) {
             var zProperties = {};
-            for (key in values) {
+            for (var key in values) {
                 if (key.startswith('z')) {
                     zProperties[key] = values[key];
                 }

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
@@ -140,10 +140,10 @@
                 name: 'hosts',
                 allowBlank: false,
                 fieldLabel:  _t('Enter multiple similar devices, separated by a comma, using either hostname or IP Address'),
-                width: 300
+                width: "100%"
             } ,collectorField = {
                 xtype: 'combo',
-                width: 300,
+                width: "100%",
                 // only show if we have multiple collectors
                 hidden: Zenoss.env.COLLECTORS.length === 1,
                 // if visible give it a good tabindex
@@ -166,15 +166,18 @@
             }, fields = [hostField], i;
 
             var isSnmp = Ext.Array.some(connectionInfo, function(item) {
-                return item.category == 'SNMP';
+                return item.category === 'SNMP';
             });
             // convert the zproperty information into a field
             for (i=0; i < connectionInfo.length; i++ ) {
-                var item =  Zenoss.zproperties.createZPropertyField(connectionInfo[i]),
-                property = connectionInfo[i],
-                id=property.id;
+                var item = Zenoss.zproperties.createZPropertyField(connectionInfo[i]),
+                    property = connectionInfo[i],
+                    id = property.id;
+
                 item.name = id;
                 item.fieldLabel = property.label;
+                item.width = "100%";
+
                 if (!property.label) {
                     item.fieldLabel = Zenoss.zproperties.inferZPropertyLabel(id);
                 }
@@ -201,7 +204,6 @@
             fields.push({
                 xtype: 'button',
                 formBind: true,
-                anchor: '25%',
                 disabled: true,
                 text: _t('Add'),
                 handler: Ext.bind(this.onClickAddButton, this)
@@ -231,7 +233,7 @@
                 hosts = values.hosts,
                 deviceClass = values.deviceclass,
                 collector = values.collector,
-                zProperties = this.getZProperties(values), key,
+                zProperties = this.getZProperties(values),
                 combo = this.getForm().query('combo[itemId="deviceType"]')[0],
                 grid = this.getGrid();
             // allow either commas to separate or new lines or both

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
@@ -181,23 +181,24 @@
         alias: 'widget.wizardadddeviceview',
         stepTitle:  _t('Add Infrastructure'),
         stepId: 'add-device',
-        stepHeight: 630,
         constructor: function(config) {
             config = config || {};
             Ext.applyIf(config, {
-                layout: 'border',
+                layout: "vbox",
                 items:[{
                     xtype: 'form',
-                    height: 400,
+                    region: 'center',
                     layout: 'hbox',
+                    width: "100%",
+                    defaults: {
+                        height: 220,
+                        flex: 1,
+                        cls: "wizardColumn",
+                        overflowY: "auto"
+                    },
+                    defaultType: "fieldset",
                     items: [{
-                        width: 175,
-                        xtype: 'fieldset',
-                        height: 275,
                         autoScroll: true,
-                        style: {
-                            borderRight: '1px solid #CACACA !important'
-                        },
                         title: _t('Category'),
                         items:[{
                             xtype: 'radiogroup',
@@ -208,58 +209,44 @@
                             items: []
                         }]
                     }, {
-                        xtype: 'fieldset',
-                        width: 250,
-                        height: 275,
                         title: _t('Type'),
-                        style: {
-                            borderRight: '1px solid #CACACA !important',
-                            paddingLeft: "15px"
-                        },
+                        layout: "anchor",
                         items: [{
                             xtype: 'combo',
                             name: 'deviceclass',
                             itemId: 'deviceType',
                             queryMode: 'local',
                             queryParam: false,
-                            width: 220,
                             emptyText:  _t('Select one...'),
                             editable: true,
                             store: Ext.create('Zenoss.quickstart.Wizard.store.DeviceType', {}),
                             valueField: 'value',
-                            displayField: 'shortdescription'
+                            displayField: 'shortdescription',
+                            anchor: "100%"
                         }]
                     },{
-                        xtype: 'fieldset',
-                        width: 250,
                         itemId: 'credentials',
                         title: _t('Connection Information'),
+                        flex: 1.5,
                         style: {
-                            paddingLeft: "15px"
+                            borderRight: "0 !important"
                         },
-                        layout: 'anchor',
-                        autoHeight: true,
-                        autoScroll: true,
-                        minHeight: 300,
                         defaults: {
+                            width: "100%",
                             labelAlign: 'top',
-                            anchor: "90%"
                         }
                     }]
                 }, {
                     region: 'south',
-                    xtype: 'fieldset',
                     title: _t('Devices'),
-                    width: 860,
-                    height: 190,
+                    xtype: "fieldset",
+                    width: "100%",
                     items: [{
                         xtype: 'deviceaddgrid',
                         autoScroll: true,
                         height: 150,
                         emptyText: _t('Add infrastructure using the above form'),
-                        // the width is so that the right edge of the
-                        // grid lines up with the Authentication form
-                        width: 860
+                        emptyCls: "empty-grid-text"
                     }]
 
                 }]

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddDeviceView.js
@@ -192,7 +192,6 @@
                     width: "100%",
                     defaults: {
                         height: 220,
-                        flex: 1,
                         cls: "wizardColumn",
                         overflowY: "auto"
                     },
@@ -200,6 +199,7 @@
                     items: [{
                         autoScroll: true,
                         title: _t('Category'),
+                        flex: 0.7,
                         items:[{
                             xtype: 'radiogroup',
                             itemId: 'category',
@@ -210,19 +210,27 @@
                         }]
                     }, {
                         title: _t('Type'),
+                        flex: 1,
                         layout: "anchor",
                         items: [{
-                            xtype: 'combo',
-                            name: 'deviceclass',
+                            xtype: "grid",
                             itemId: 'deviceType',
-                            queryMode: 'local',
-                            queryParam: false,
+                            anchor: "100%",
+                            cls: "device-type-grid",
+                            header: false,
+                            hideHeaders: true,
+                            columns: [
+                                {
+                                    dataIndex: "value",
+                                    flex: 1,
+                                    // use shortdescription as display field
+                                    renderer: function(value, metaData, record){
+                                        return record.get("shortdescription");
+                                    }
+                                }
+                            ],
                             emptyText:  _t('Select one...'),
-                            editable: true,
-                            store: Ext.create('Zenoss.quickstart.Wizard.store.DeviceType', {}),
-                            valueField: 'value',
-                            displayField: 'shortdescription',
-                            anchor: "100%"
+                            store: Ext.create('Zenoss.quickstart.Wizard.store.DeviceType', {})
                         }]
                     },{
                         itemId: 'credentials',
@@ -252,6 +260,8 @@
                 }]
             });
             this.callParent([config]);
+
+            this.query("grid[itemId='deviceType']")[0].getView().stripeRows = false;
         }
 
     });

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddUserView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AddUserView.js
@@ -16,16 +16,15 @@
             // If the password field has initialPassField (2nd box), do a comparison.
             if (field.initialPassField) {
                 var pwd = Ext.getCmp(field.initialPassField);
-                if (val != pwd.getValue()){
+                if (val !== pwd.getValue()){
                     Ext.form.VTypes["passwordText"] = _t("The passwords you've typed don't match.");
                     return false;
                 }
             }
             // Validate the validity of the password field (either of them)
-            var pattern = new RegExp("(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}")
+            var pattern = new RegExp("(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}");
             if (!val.match(pattern)){
-                Ext.form.VTypes["passwordText"] = _t("That must contain 8 or more characters" +
-                                                 " that are of at least one number, and one uppercase and lowercase letter.");
+                Ext.form.VTypes["passwordText"] = _t("Password does not meet password rules");
                 return false;
             }
             return true;
@@ -47,18 +46,18 @@
             Ext.applyIf(config, {
                 labelWidth: 100,
                 frame: false,
-                stepHeight: 400,
                 border: false,
-                bodyStyle: 'padding:5px 5px 0',
                 layout: {
                     type: 'hbox'
                 },
                 defaults: {
                     layout: 'anchor',
                     frame: false,
-                    width: 450,
+                    width: "50%",
                     border: false,
-                    style: 'padding 25px'
+                    style: {
+                        padding: "25px"
+                    }
                 },
                 items: [{
                     xtype: 'fieldset',
@@ -67,7 +66,8 @@
                     defaultType: 'textfield',
                     defaults: {
                         anchor: '95%',
-                        labelAlign: 'top'
+                        labelAlign: 'top',
+                        padding: "0 0 7px 0"
                     },
                     title: _t("Set admin password"),
                     items: [{
@@ -75,13 +75,19 @@
                         frame: false,
                         border: false,
                         cls: 'helptext',
-                        html: _t("The admin account has extended privileges,"+
-                            " similar to Linux's <"+"span class='noem'>root<"+
-                            "/span> or Windows' <" + "span class='noem'>"+
-                            "Administrator<"+"/span>. "+
-                            "Its use should be limited to administrative"+
-                            " tasks.<"+"br/><"+"br/>Enter and "+
-                            "confirm a password for the admin account.")
+                        html: _t("\
+                            The admin account has extended privileges,\
+                            similar to Linux's <span class='noem'>root</span>\
+                            or Windows' <span class='noem'>Administrator</span>.\
+                            Its use should be limited to administrative tasks.\
+                            <br><br>\
+                            <strong>Password Must:</strong><br>\
+                            <ul class='list'>\
+                                <li>Contain 8 or more characters</li>\
+                                <li>Contain at least one number</li>\
+                                <li>Contain at least one upper and lower case character</li>\
+                            </ul>\
+                        ")
                     },{
                         fieldLabel: _t('Admin password'),
                         inputType: 'password',
@@ -90,7 +96,7 @@
                         id: 'admin-password1',
                         allowBlank: false
                     },{
-                        fieldLabel: _t('Retype password'),
+                        fieldLabel: _t('Confirm password'),
                         inputType: 'password',
                         vtype: 'password',
                         name: 'admin-password2',
@@ -105,7 +111,7 @@
                     defaults: {
                         anchor: '95%',
                         labelAlign: 'top',
-                        padding: "0px 0px 5px 0px"
+                        padding: "0 0 7px 0"
                     },
                     id: 'userfieldset',
                     defaultType: 'textfield',

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AutoDiscoveryView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AutoDiscoveryView.js
@@ -187,12 +187,10 @@
         alias: 'widget.wizardautodiscoveryview',
         stepTitle: _t('Network Discovery'),
         stepId: 'discover-network',
-        stepHeight: 630,
         constructor: function(config) {
             config = config || {};
             Ext.applyIf(config, {
-                layout: 'border',
-                width: 600,
+                layout: "vbox",
                 items:[{
                     region: 'north',
                     height: 30,
@@ -202,28 +200,30 @@
                     xtype: 'form',
                     region: 'center',
                     layout: 'hbox',
+                    width: "100%",
+                    defaults: {
+                        height: 175,
+                        flex: 1,
+                        cls: "wizardColumn",
+                        overflowY: "auto"
+                    },
+                    defaultType: "fieldset",
                     items: [{
-                        width: 200,
-                        xtype: 'fieldset',
-                        height: 225,
-                        style: {
-                            borderRight: '1px solid #CACACA !important'
-                        },
                         title: _t('Networks/Range'),
+                        defaults: {
+                            width: "100%"
+                        },
                         items:[{
                             xtype: 'textarea',
                             name: 'ip_ranges',
                             vtype: 'ipRange',
-                            labelWidth: 175,
                             fieldLabel: _t("Enter one or more networks (such " + "as 10.0.0.0/24) or " + "IP ranges " + "(such as 10.0.0.1-50)"),
                             tabIndex: 2,
                             labelAlign: 'top',
                             id: 'wizard_ip_ranges',
                             allowBlank: false,
-                            width: 175
                         }, {
                             xtype: 'combo',
-                            width: 100,
                             // only show if we have multiple collectors
                             hidden: Zenoss.env.COLLECTORS.length === 1,
                             // if visible give it a good tabindex
@@ -252,19 +252,10 @@
                             text: _t('Discover')
                         }]
                     }, {
-                        xtype: 'fieldset',
-                        style: {
-                            borderRight: '1px solid #CACACA !important',
-                            paddingLeft: "15px"
-                        },
-                        width: 200,
-                        height: 225,
                         title: _t('SNMP'),
-                        layout: 'anchor',
                         defaults: {
-                            anchor: '90%',
+                            width: "100%",
                             labelAlign: 'top',
-                            padding: "0px 0px 5px 0px"
                         },
                         items: [{
                             xtype: 'textarea',
@@ -272,24 +263,14 @@
                             inputAttrTpl: Ext.String.format(" data-qtip='{0}' ", _t("Zenoss will try each of these community strings in turn when connecting to the device.")),
                             tabIndex: 2,
                             allowBlank: false,
-                            labelWidth: 120,
                             fieldLabel: _t('Community Strings'),
                             name: 'zSnmpCommunities'
                         }]
                     },{
-                        xtype: 'fieldset',
-                        style: {
-                            borderRight: '1px solid #CACACA !important',
-                            paddingLeft: "15px"
-                        },
-                        width: 200,
-                        height: 225,
                         title: _t('SSH Authentication'),
-                        layout: 'anchor',
                         defaults: {
-                            anchor: '90%',
+                            width: "100%",
                             labelAlign: 'top',
-                            padding: "0px 0px 5px 0px"
                         },
                         items: [{
                             xtype: 'textfield',
@@ -304,18 +285,14 @@
                             name: 'zCommandPassword'
                         }]
                     },{
-                        xtype: 'fieldset',
                         style: {
-                            paddingLeft: "15px"
+                            border: "none !important",
+                            paddingRight: 0
                         },
-                        width: 250,
-                        height: 225,
                         title: _t('Windows Authentication'),
-                        layout: 'anchor',
                         defaults: {
-                            anchor: '80%',
+                            width: "100%",
                             labelAlign: 'top',
-                            padding: "0px 0px 5px 0px"
                         },
                         items: [{
                             xtype: 'textfield',
@@ -334,18 +311,15 @@
                 }, {
                     region: 'south',
                     xtype: 'fieldset',
+                    width: "100%",
                     title: _t('Discoveries'),
-                    height: 240,
                     items: [{
                         xtype: 'discoverygrid',
-                        height: 180,
+                        height: 150,
                         autoScroll: true,
-                        emptyText: _t('Add network  discoveries using the above form'),
-                        // the width is so that the right edge of the
-                        // grid lines up with the Authentication form
-                        width: 860
+                        emptyText: _t('Add network discoveries using the above form'),
+                        emptyCls: "empty-grid-text"
                     }]
-
                 }]
             });
             this.callParent([config]);

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/OutlineView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/OutlineView.js
@@ -52,7 +52,7 @@
                         width: "100%",
                         defaults: {
                             flex: 1,
-                            style: { margin: "0 20px 20px 0" }
+                            style: { margin: "0 10px 20px 0" }
                         },
                         items: [{
                             xtype: 'wizardstep',

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/OutlineView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/OutlineView.js
@@ -14,15 +14,15 @@
         alias: 'widget.wizardstep',
         constructor: function(config) {
             config.html =  Ext.String.format('<div class="wizardStep">' +
-                                             '<div class="wizardStepHeader"> <span class="wizardStepNumber">Step {0}</span> <img class="wizardIcon" src="{1}" /></div>' +
+                 '<div class="wizardStepHeader"> <span class="wizardStepNumber">Step {0}</span> <img class="wizardIcon" src="{1}" /></div>' +
 
-                                             '<div class="wizardStepTitle"> {2} </div>' +
-                                             '<div class="wizardStepDescription"> {3} </div> '+
-                                             '</div>',
-                                            config.stepNumber,
-                                            config.iconPath,
-                                            config.stepTitle,
-                                            config.stepDescription);
+                 '<div class="wizardStepTitle"> {2} </div>' +
+                 '<div class="wizardStepDescription"> {3} </div> '+
+                 '</div>',
+                config.stepNumber,
+                config.iconPath,
+                config.stepTitle,
+                config.stepDescription);
             this.callParent([config]);
         }
     });
@@ -37,18 +37,23 @@
     Ext.define('Zenoss.quickstart.Wizard.view.OutlineView', {
         extend: 'Ext.panel.Panel',
         alias: 'widget.wizardoutlineview',
-        stepHeight: 400,
         constructor: function(config) {
             config = config || {};
             Ext.applyIf(config, {
                 stepTitle: _t('Zenoss Installation Wizard'),
                 items:[{
                     layout: 'vbox',
+                    width: "100%",
                     items:[{
                         cls: 'wizard_subtitle',
                         html: '<h2>' + _t('This wizard will guide you through the initial setup of Zenoss.  Click <strong>Get Started</strong> to begin.') + '</h2>'
                     }, {
                         layout: 'hbox',
+                        width: "100%",
+                        defaults: {
+                            flex: 1,
+                            style: { margin: "0 20px 20px 0" }
+                        },
                         items: [{
                             xtype: 'wizardstep',
                             stepNumber: 1,
@@ -64,16 +69,14 @@
                         },{
                             xtype: 'wizardstep',
                             stepNumber: 3,
+                            style: { margin: "0 0 20px 0" },
                             iconPath: '/++resource++zenui/img/monitoring.png',
                             stepTitle: _t('Add Infrastructure'),
                             stepDescription: _t('Manually add the devices in your infrastructure.')
-                        }, {
-                            xtype: 'image',
-                            itemId: 'get_started',
-                            src: 'img/qs_img_3.png',
-                            width: 230
                         }]
                     }]
+                },{
+                    xtype: "text"
                 }]
             });
             this.callParent([config]);

--- a/Products/ZenUI3/browser/templates/quickstart.pt
+++ b/Products/ZenUI3/browser/templates/quickstart.pt
@@ -23,7 +23,7 @@
             html {background-color:#eae9dc}
         </style>
 
-        
+
         <tal:block tal:content="structure provider:js-security"/>
         <tal:block tal:content="structure provider:all-js"/>
 
@@ -47,19 +47,19 @@
           <input type="hidden" id="login_password" name="__ac_password"/>
         </form>
 
-        <div id="content-wrapper">
+        <div id="content-wrapper" class="quickstart" style="overflow: auto;">
           <script
               tal:attributes="src python: context.zport.getVersionedResourcePath('/++resource++zenui/js/zenoss/quickstart/app.js')"
               >
           </script>
-           <div id="center_panel">
+           <div id="center_panel" style="min-width: 900px;" >
            </div>
         </div>
         <div id="footer">&copy; 2005-2015 Zenoss, Inc.</div>
 
 
     </div>
-    
+
     </body>
 </html>
 </tal:block>


### PR DESCRIPTION
ticket targeting 5.2/develop: https://jira.zenoss.com/browse/ZEN-21323

The ticket identifies poor language in the password rules error message, but the password rules should be visible at all times, rather than relegated to an error message. To include the password rules requires changes to the way the form is laid out, and for consistency those changes were applied throughout the wizard.

Also, the "device type" combobox wastes a lot of space, so it was changed to a grid (the grid is not in the attached screenshot. if you wanna see it, lemme know)

![quickstart1](https://cloud.githubusercontent.com/assets/1927558/11788325/0366c474-a256-11e5-8297-b4880325b7d7.png)
![quickstart2](https://cloud.githubusercontent.com/assets/1927558/11788323/03644fdc-a256-11e5-9c81-7f82adab80cf.png)
![quickstart3](https://cloud.githubusercontent.com/assets/1927558/11788324/0365dd0c-a256-11e5-9ac5-a230e5857768.png)
![quickstart4](https://cloud.githubusercontent.com/assets/1927558/11788326/03679b9c-a256-11e5-9d5b-f8516279baf3.png)
