### PR TITLE
fix ZEN-21338 saving event listed filtered with 'git status' as csv

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
@@ -1464,7 +1464,7 @@
             if (params === false) {
                 params = {
                     evids: [],
-                    excludeIds: []
+                    excludeIds: {}
                 };
                 Ext.apply(params, this.getUpdateParameters());
             }

--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -390,6 +390,10 @@ class EventsRouter(DirectRouter):
         @rtype:   generator
         @return:  Generator returning events.
         """
+
+        if isinstance(params, basestring):
+            params = loads(params)
+
         if not self._canViewEvents():
             return
         includeFilter, excludeFilter = self._buildRequestFilters(uid, params, evids, excludeIds)
@@ -626,8 +630,8 @@ class EventsRouter(DirectRouter):
             log.debug('Found specific event ids, adding to params.')
             includeUuids = evids
 
-        includeFilter = self._buildFilter([uid], params, specificEventUuids=includeUuids)
         exclude_params = self._filterParser.findExclusionParams(params)
+        includeFilter = self._buildFilter([uid], params, specificEventUuids=includeUuids)
 
         # the only thing excluded in an event filter is a list of event uuids
         # which are passed as EventTagFilter using the OR operator.


### PR DESCRIPTION
fixes https://jira.zenoss.com/browse/ZEN-21338

When the event query code is hit from the export button in the ui, the arguments were passed in as json which was not properly handled by the code that looks for "!!" and adds it to exclusion filter before performing the query.

The fix was to make sure that the `params` value passed into `findExclusionParams()` was a dict, and also to make sure the exclusion filter work was done before `_buildFilter()` was called on the `params` object.