### PR TITLE
CC-1669 Removed zodb as target of upgrade.sh

### DIFF
--- a/bin/zenrun.d/upgrade.sh
+++ b/bin/zenrun.d/upgrade.sh
@@ -23,12 +23,7 @@ doUpgrade() {
     port=$(${zengc} -p zodb-port)
     user=$(${zengc} -p zodb-user)
     userpass=$(${zengc} -p zodb-password)
-    dbname=$(${zengc} -p zodb-db)
-    /opt/zenoss/bin/zeneventserver-create-db \
-        --dbtype $dbtype --dbhost $host --dbport $port \
-        --dbuser $user --dbpass "${userpass}" \
-        --dbname $dbname \
-        --update_schema_only || return "$?"
+    # TODO: zodb upgrade path
     /opt/zenoss/bin/zeneventserver-create-db \
         --dbtype $dbtype --dbhost $host --dbport $port \
         --dbuser $user --dbpass "${userpass}" \


### PR DESCRIPTION
zeneventserver-create-db schemas aren't relevant to the zodb table.

Addresses error messages during upgrade as mentiond in CC-1669