### PR TITLE
Foundation to start removing zcatalogs

### DIFF
--- a/Products/DataCollector/ApplyDataMap.py
+++ b/Products/DataCollector/ApplyDataMap.py
@@ -191,6 +191,10 @@ class ApplyDataMap(object):
 
         if changed:
             device.setLastChange()
+            # This is for IpInterfaces so the device get its paths updated.
+            # Should we think of doing this differently?
+            #
+            notify(IndexingEvent(device))
 
         log.debug(
             "_applyDataMap for Device %s will modify %d objects for %s",
@@ -386,7 +390,7 @@ class ApplyDataMap(object):
         if changed:
             if getattr(aq_base(obj), "index_object", False):
                 log.debug("indexing object %s", obj.id)
-                obj.index_object()
+                obj.index_object()  # @TODO REMOVE THIS ONCE ALL CATALOGS ARE MIGRATED TO SOLR
             notify(IndexingEvent(obj))
         else:
             obj._p_deactivate()

--- a/Products/ZenCallHome/ZenossAppData.py
+++ b/Products/ZenCallHome/ZenossAppData.py
@@ -16,7 +16,7 @@ from Products.Zuul import getFacade
 from itertools import *
 
 import logging
-from Products.Zuul.interfaces.tree import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from zenoss.protocols.services.zep import ZepConnectionError
 from . import IDeviceLink
 
@@ -27,7 +27,7 @@ class ZenossAppData(object):
 
     def callHomeData(self, dmd):
         self.dmd = dmd
-        self._catalog = ICatalogTool(self.dmd)
+        self._catalog = IModelCatalogTool(self.dmd)
         stats = (self.server_key,
                       self.google_key,
                       self.version,
@@ -201,7 +201,7 @@ class ZenossResourceData(object):
 
     def callHomeData(self, dmd):
         self._dmd = dmd
-        self._catalog = ICatalogTool(self._dmd)
+        self._catalog = IModelCatalogTool(self._dmd)
         stats = self._process_devices()
         for key, value in stats.items():
             yield key, value

--- a/Products/ZenEvents/Availability.py
+++ b/Products/ZenEvents/Availability.py
@@ -20,7 +20,7 @@ from Products.ZenEvents.ZenEventClasses import Status_Ping, Status_Snmp
 from Products.ZenEvents.ZenEventClasses import Status_OSProcess
 from Products.Zuul import getFacade
 from Products.AdvancedQuery import And, Eq, Generic, Or
-from Products.Zuul.interfaces.tree import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from zenoss.protocols.protobufs.zep_pb2 import (SEVERITY_CRITICAL, SEVERITY_ERROR,
                                                 SEVERITY_WARNING, SEVERITY_INFO,
                                                 SEVERITY_DEBUG, SEVERITY_CLEAR)
@@ -196,7 +196,7 @@ class Report(object):
         zep = getFacade("zep", dmd)
 
         path = '/zport/dmd/'
-        
+
         pathFilterList = [Generic('path',{'query':path})]
         
         if self.DeviceClass:
@@ -210,7 +210,7 @@ class Report(object):
         if self.device:
             pathFilterList.append(Or(Eq('name', self.device), Eq('id', self.device)))
 
-        results = ICatalogTool(dmd.Devices).search(types='Products.ZenModel.Device.Device',
+        results = IModelCatalogTool(dmd.Devices).search(types='Products.ZenModel.Device.Device',
                 query=And(*pathFilterList))
 
         if not results.total:

--- a/Products/ZenEvents/events2/processing.py
+++ b/Products/ZenEvents/events2/processing.py
@@ -18,7 +18,7 @@ from Products.ZenEvents.events2.proxy import ZepRawEventProxy, EventProxy
 from Products.ZenUtils.guid.interfaces import IGUIDManager, IGlobalIdentifier
 from Products.ZenUtils.IpUtil import isip, ipToDecimal
 from Products.ZenUtils.FunctionCache import FunctionCache
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.AdvancedQuery import Eq, Or
 from zope.component import getUtility, getUtilitiesFor
 from Acquisition import aq_chain
@@ -127,7 +127,7 @@ class Manager(object):
         if cls:
             catalog = catalog or self._catalogs.get(element_type_id)
             if catalog:
-                results = ICatalogTool(catalog).search(cls,
+                results = IModelCatalogTool(catalog).search(cls,
                                                        query=Or(Eq('id', id),
                                                                 Eq('name', id)),
                                                        filterPermissions=False,
@@ -167,7 +167,7 @@ class Manager(object):
         Returns a tuple ([device brains], [devices]) searching manage IP and
         interface IPs. limit is the maximum total number in both lists.
         """
-        dev_cat = ICatalogTool(self._devices)
+        dev_cat = IModelCatalogTool(self._devices)
 
         try:
             ip_address = next(i for i in (ipAddress, identifier) if isip(i))
@@ -197,7 +197,7 @@ class Manager(object):
         if ip_decimal is None:
             return [], []
 
-        net_cat = ICatalogTool(self._networks)
+        net_cat = IModelCatalogTool(self._networks)
         results = net_cat.search(types=IpAddress,
                                  query=(Eq('name', ip_address)),
                                  limit = limit,

--- a/Products/ZenHub/invalidationfilter.py
+++ b/Products/ZenHub/invalidationfilter.py
@@ -22,7 +22,7 @@ from Products.ZenModel.GraphDefinition import GraphDefinition
 from Products.ZenModel.GraphPoint import GraphPoint
 from Products.ZenModel.ProductClass import ProductClass
 from Products.ZenModel.Software import Software
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 from .interfaces import IInvalidationFilter, FILTER_EXCLUDE, FILTER_CONTINUE
 
@@ -73,7 +73,7 @@ class BaseOrganizerFilter(object):
 
     def initialize(self, context):
         root = self.getRoot(context)
-        brains = ICatalogTool(root).search(self._types)
+        brains = IModelCatalogTool(root).search(self._types)
         results = {}
         for brain in brains:
             try:

--- a/Products/ZenHub/services/ModelerService.py
+++ b/Products/ZenHub/services/ModelerService.py
@@ -147,30 +147,30 @@ class ModelerService(PerformanceConfig):
         adm.setDeviceClass(device, devclass)
 
         changed = False
-        with pausedAndOptimizedIndexing():
-            for map in maps:
-                start_time = time.time()
-                if adm._applyDataMap(device, map, commit=False):
-                    changed = True
+        #with pausedAndOptimizedIndexing():
+        for map in maps:
+            start_time = time.time()
+            if adm._applyDataMap(device, map, commit=False):
+                changed = True
 
-                end_time = time.time() - start_time
-                if hasattr(map, "relname"):
-                    log.debug(
-                        "Time in _applyDataMap for Device %s with relmap %s objects: %.2f",
-                        device.getId(),
-                        map.relname,
-                        end_time)
-                elif hasattr(map, "modname"):
-                    log.debug(
-                        "Time in _applyDataMap for Device %s with objectmap, size of %d attrs: %.2f",
-                        device.getId(),
-                        len(map.items()),
-                        end_time)
-                else:
-                    log.debug(
-                        "Time in _applyDataMap for Device %s: %.2f . Could not find if relmap or objmap",
-                        device.getId(),
-                        end_time)
+            end_time = time.time() - start_time
+            if hasattr(map, "relname"):
+                log.debug(
+                    "Time in _applyDataMap for Device %s with relmap %s objects: %.2f",
+                    device.getId(),
+                    map.relname,
+                    end_time)
+            elif hasattr(map, "modname"):
+                log.debug(
+                    "Time in _applyDataMap for Device %s with objectmap, size of %d attrs: %.2f",
+                    device.getId(),
+                    len(map.items()),
+                    end_time)
+            else:
+                log.debug(
+                    "Time in _applyDataMap for Device %s: %.2f . Could not find if relmap or objmap",
+                    device.getId(),
+                    end_time)
 
         if setLastCollection:
             device.setSnmpLastCollection()

--- a/Products/ZenHub/services/ProcessConfig.py
+++ b/Products/ZenHub/services/ProcessConfig.py
@@ -21,7 +21,7 @@ from Products.ZenEvents import Event
 from Products.ZenModel.OSProcessClass import OSProcessClass
 from Products.ZenModel.OSProcessOrganizer import OSProcessOrganizer
 from Products.ZenHub.zodb import onUpdate
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 unused(DeviceProxy)
 
 from twisted.spread import pb
@@ -166,7 +166,7 @@ class ProcessConfig(CollectorConfigService):
 
     @onUpdate(OSProcessOrganizer)
     def processOrganizerUpdated(self, object, event):
-        catalog = ICatalogTool(object.primaryAq())
+        catalog = IModelCatalogTool(object.primaryAq())
         results = catalog.search(OSProcessClass)
         if not results.total:
             return

--- a/Products/ZenHub/services/SnmpTrapConfig.py
+++ b/Products/ZenHub/services/SnmpTrapConfig.py
@@ -27,7 +27,7 @@ from Products.ZenHub.zodb import onUpdate, onDelete
 from Products.ZenModel.Device import Device
 from Products.ZenModel.DeviceClass import DeviceClass
 from Products.ZenModel.MibBase import MibBase
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 SNMPV3_USER_ZPROPS = ["zSnmpEngineId",
                       "zSnmpSecurityName",            
@@ -102,7 +102,7 @@ class SnmpTrapConfig(CollectorConfigService):
         return user
 
     def remote_createAllUsers(self):
-        cat = ICatalogTool(self.dmd)
+        cat = IModelCatalogTool(self.dmd)
         brains = cat.search(("Products.ZenModel.Device.Device", "Products.ZenModel.DeviceClass.DeviceClass"))
         users = []
         for brain in brains:

--- a/Products/ZenModel/ComponentGroup.py
+++ b/Products/ZenModel/ComponentGroup.py
@@ -10,7 +10,7 @@
 from Globals import InitializeClass
 
 from Products.ZenRelations.RelSchema import ToMany
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.AdvancedQuery import Eq, Not, And
 from .ComponentOrganizer import (
     ComponentOrganizer,
@@ -48,7 +48,8 @@ class ComponentGroup(ComponentOrganizer):
         return [comp.primaryAq() for comp in self.components()]
 
     def getSubComponents(self):
-        cat = ICatalogTool(self)
+        cat = IModelCatalogTool(self)
+        # @TODO: Can we avoid NOTs ?
         query = And(Not(Eq('objectImplements', 'Products.ZenModel.ComponentGroup.ComponentGroup')),
                     Not(Eq('objectImplements', 'Products.ZenModel.Device.Device')))
         brains = cat.search(query=query)

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -75,6 +75,7 @@ from Products.ZenEvents.browser.EventPillsAndSummaries import getEventPillME
 from OFS.CopySupport import CopyError # Yuck, a string exception
 from Products.Zuul import getFacade
 from Products.Zuul.catalog.indexable import DeviceIndexable
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenUtils.IpUtil import numbip
 from Products.ZenMessaging.audit import audit
 from Products.ZenModel.interfaces import IExpandedLinkProvider
@@ -546,6 +547,31 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         # otherwise it will not appear in the list of components.
         if len(self.componentSearch):
             self.componentSearch()[0].getObject().index_object()
+
+    def getDeviceComponents_from_model_catalog(self, monitored=None, collector=None, type=None):
+        """
+        Return list of all DeviceComponents on this device extracted from model catalog. not used for now
+
+        @type monitored: boolean
+        @type collector: string
+        @type type: string
+        @permission: ZEN_VIEW
+        @rtype: list
+        """
+        query = {"objectImplements": "Products.ZenModel.DeviceComponent.DeviceComponent"}
+        if collector is not None:
+            query['collectors'] = collector
+        if monitored is not None:
+            query['monitored'] = monitored
+        if type is not None:
+            query['meta_type'] = type
+
+        cat = IModelCatalogTool(self)
+        search_results = cat.search(query=query)
+        results = []
+        if search_results.total > 0:
+            results = [ brain.getObject() for brain in search_results.results ]
+        return results
 
     security.declareProtected(ZEN_VIEW, 'getDeviceComponents')
     def getDeviceComponents(self, monitored=None, collector=None, type=None):

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -31,7 +31,6 @@ from Products.ZenUtils import Time
 from Products.ZenUtils.deprecated import deprecated
 from Products.ZenUtils.IpUtil import checkip, IpAddressError, maskToBits, \
                                      ipunwrap, getHostByName
-from Products.ZenModel.interfaces import IIndexed
 from Products.ZenUtils.guid.interfaces import IGloballyIdentifiable, IGlobalIdentifier
 from Products.PluginIndexes.FieldIndex.FieldIndex import FieldIndex
 # base classes for device
@@ -203,11 +202,11 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
     enabled but maybe this will change.
     """
 
-    implements(IEventView, IIndexed, IGloballyIdentifiable)
+    implements(IEventView, IGloballyIdentifiable)
 
     event_key = portal_type = meta_type = 'Device'
 
-    default_catalog = "deviceSearch" #device ZCatalog
+    default_catalog = ""
 
     relationshipManagerPathRestriction = '/Devices'
     title = ""
@@ -945,7 +944,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
 
             else:
                 self.manageIp = ip
-                self.index_object(idxs=('getDeviceIp',), noips=True)
                 notify(IndexingEvent(self, ('ipAddress',), True))
                 log.info("%s's IP address has been set to %s.",
                          self.id, ip)
@@ -1176,7 +1174,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
             self.setPerformanceMonitor(kwargs["performanceMonitor"])
 
         self.setLastChange()
-        self.index_object()
         notify(IndexingEvent(self))
 
     security.declareProtected(ZEN_CHANGE_DEVICE, 'manage_editDevice')
@@ -1230,7 +1227,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         Changes the title to newTitle and reindexes the object
         """
         super(Device, self).setTitle(newTitle)
-        self.index_object()
         notify(IndexingEvent(self, ('name',), True))
 
     def monitorDevice(self):
@@ -1460,7 +1456,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
             locobj = self.getDmdRoot("Locations").createOrganizer(locationPath)
             self.addRelation("location", locobj)
         self.setAdminLocalRoles()
-        self.index_object()
         notify(IndexingEvent(self, 'path', False))
         if REQUEST:
             action = 'SetLocation' if locationPath else 'RemoveFromLocation'
@@ -1506,7 +1501,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
                                                     performanceMonitor)
         self.addRelation("perfServer", obj)
         self.setLastChange()
-        self.index_object()
         notify(IndexingEvent(self))
 
         if REQUEST:
@@ -1528,7 +1522,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         """
         objGetter = self.getDmdRoot("Groups").createOrganizer
         self._setRelations("groups", objGetter, groupPaths)
-        self.index_object()
         notify(IndexingEvent(self, 'path', False))
 
 
@@ -1561,7 +1554,6 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         """
         objGetter = self.getDmdRoot("Systems").createOrganizer
         self._setRelations("systems", objGetter, systemPaths)
-        self.index_object()
         notify(IndexingEvent(self, 'path', False))
 
 
@@ -1868,33 +1860,12 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
             raise Exception("Device rename failed.")
 
     def index_object(self, idxs=None, noips=False):
-        """
-        Override so ips get indexed on move.
-        """
-        super(Device, self).index_object(idxs)
-        if noips: return
-        for iface in self.os.interfaces():
-            for ip in iface.ipaddresses():
-                ip.index_object()
-
+        """ DEPRECATED """
+        pass
 
     def unindex_object(self):
-        """
-        Override so ips get unindexed as well.
-        """
-        self.unindex_ips()
-        super(Device, self).unindex_object()
-
-
-    def unindex_ips(self):
-        """
-        IpAddresses aren't contained underneath Device, so manage_beforeDelete
-        won't propagate. Thus we must remove those links explicitly.
-        """
-        cat = self.dmd.ZenLinkManager._getCatalog(layer=3)
-        brains = cat(deviceId=self.id)
-        for brain in brains:
-            brain.getObject().unindex_links()
+        """ DEPRECATED """
+        pass
 
     def getUserCommandTargets(self):
         """

--- a/Products/ZenModel/DeviceClass.py
+++ b/Products/ZenModel/DeviceClass.py
@@ -41,7 +41,6 @@ from Products.ZenWidgets import messaging
 from Products.ZenUtils.FakeRequest import FakeRequest
 from Products.Zuul.catalog.events import IndexingEvent
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
-from Products.Zuul.interfaces import ICatalogTool
 from Products.ZenModel.Exceptions import DeviceExistsError
 
 import RRDTemplate
@@ -551,7 +550,7 @@ class DeviceClass(DeviceOrganizer, ZenPackable, TemplateContainer):
         """
         Return generator of components, by meta_type if specified
         """
-        catalog = ICatalogTool(self)
+        catalog = IModelCatalogTool(self)
         COMPONENT = 'Products.ZenModel.DeviceComponent.DeviceComponent'
         monitorq, typeq = None, None
         if monitored:

--- a/Products/ZenModel/IpAddress.py
+++ b/Products/ZenModel/IpAddress.py
@@ -30,8 +30,6 @@ from Products import Zuul
 from Products.Zuul.interfaces import IInfo
 from Products.ZenUtils.jsonutils import json
 from Products.Zuul.utils import allowedRolesAndUsers
-from Products.ZenModel.interfaces import IIndexed
-from Products.ZenModel.Linkable import Layer3Linkable
 from Products.ZenRelations.RelSchema import ToOne, ToMany, ToManyCont
 from Products.ZenUtils.IpUtil import maskToBits, checkip, ipToDecimal, netFromIpAndNet, \
                                      ipwrap, ipunwrap, ipunwrap_strip
@@ -51,13 +49,12 @@ def manage_addIpAddress(context, id, netmask=24, REQUEST = None):
 addIpAddress = DTMLFile('dtml/addIpAddress',globals())
 
 
-class IpAddress(ManagedEntity, Layer3Linkable, IpAddressIndexable):
+class IpAddress(ManagedEntity, IpAddressIndexable):
     """IpAddress object"""
-    zope.interface.implements(IIndexed)
 
     event_key = portal_type = meta_type = 'IpAddress'
 
-    default_catalog = 'ipSearch'
+    default_catalog = ''
 
     version = 4
 
@@ -235,12 +232,12 @@ class IpAddress(ManagedEntity, Layer3Linkable, IpAddressIndexable):
         return None
 
     def index_object(self, idxs=None):
-        super(IpAddress, self).index_object(idxs)
-        self.index_links()
+        """ DEPRECATED """
+        pass
 
     def unindex_object(self):
-        self.unindex_links()
-        super(IpAddress, self).unindex_object()
+        """ DEPRECATED """
+        pass
 
     def deviceId(self):
         """

--- a/Products/ZenModel/IpAddress.py
+++ b/Products/ZenModel/IpAddress.py
@@ -275,4 +275,16 @@ class IpAddress(ManagedEntity, IpAddressIndexable):
             ip = ip.partition('/')[0]
         return str(numbip(ip))
 
+    #------------------------------------------
+    #--    ITreeSpanningComponent methods   --
+
+    def get_indexable_peers(self):
+        """  """
+        peers = []
+        if self.device():
+            peers.append(self.device().primaryAq())
+        if self.interface():
+            peers.append(self.interface().primaryAq())
+        return peers
+
 InitializeClass(IpAddress)

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -279,15 +279,17 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
         return ip, netmask
 
 
-    def addIpAddress(self, ip, netmask=24):
+    def addIpAddress(self, ip, netmask=None):
         """
         Add an ip to the ipaddresses relationship on this interface.
         """
         self._invalidate_ipaddress_cache()
         networks = self.device().getNetworkRoot()
         ip, netmask = self._prepIp(ip, netmask)
-        #see if ip exists already and link it to interface
-        ipobj = networks.findIp(ip)
+        if not netmask:
+            netmask = get_default_netmask(ip)
+
+        ipobj = networks.find_ip(ip, netmask)
         if ipobj:
             dev = ipobj.device()
             if dev and dev != self.device():

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -299,6 +299,8 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
             ipobj = networks.createIp(ip, netmask)
             self.ipaddresses.addRelation(ipobj)
         notify(IndexingEvent(ipobj))
+        if self.device():
+            notify(IndexingEvent(self.device(), idxs=('path')))
         os = self.os()
         notify(ObjectMovedEvent(self, os, self.id, os, self.id))
         self.dmd.getDmdRoot("ZenLinkManager").add_device_network_to_cache(self.device().getId(), ipobj.network().getPrimaryUrlPath())

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -36,12 +36,14 @@ from Products.ZenUtils.IpUtil import *
 from ConfmonPropManager import ConfmonPropManager
 from OSComponent import OSComponent
 from Products.ZenModel.Exceptions import *
-from Products.ZenModel.Linkable import Layer2Linkable
 
 from Products.ZenModel.ZenossSecurity import *
 from Products.Zuul.catalog.events import IndexingEvent
 
 from Products.Zuul.catalog.indexable import IpInterfaceIndexable
+from Products.ZenModel.interfaces import IObjectEventsSubscriber
+from zope.interface import implements
+
 
 _IPADDRESS_CACHE_ATTR = "_v_ipaddresses"
 
@@ -62,10 +64,11 @@ def manage_addIpInterface(context, newId, userCreated, REQUEST = None):
 addIpInterface = DTMLFile('dtml/addIpInterface',globals())
 
 
-class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
+class IpInterface(OSComponent, IpInterfaceIndexable):
     """
     IpInterface object
     """
+    implements(IObjectEventsSubscriber)
 
     portal_type = meta_type = 'IpInterface'
 
@@ -178,7 +181,7 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         else:
             setattr(self,id,value)
             if id == 'macaddress':
-                self.index_object()
+                notify(IndexingEvent(self))
 
     #------------------------------------------
     #--    ITreeSpanningComponent methods   --
@@ -188,42 +191,44 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         return self.ipaddresses()
 
     #------------------------------------------
+    #--    IObjectEventsSubscriber methods   --
 
-    def index_object(self, idxs=None):
-        """
-        Override the default so that links are indexed.
-        """
-        super(IpInterface, self).index_object(idxs)
-        self.index_links()
-        # index our ip addresses if necessary
-        for ip in self.ipaddresses():
-            ip.index_object()
+    def after_object_added_or_moved_handler(self):
         self._invalidate_ipaddress_cache()
-
         device = self.device()
         if self.macaddress and device:
-            if (device.getMacAddressCache().add(self.macaddress)): 
-                notify(IndexingEvent(device, idxs=('macAddresses',), update_metadata=False))
+            if (device.getMacAddressCache().add(self.macaddress) ):
+                notify(IndexingEvent(device, idxs=('macAddresses',), update_metadata=False))  # @TODO Should we remove the macs from the device?
 
-    def unindex_object(self):
-        """
-        Override the default so that links are unindexed.
-        """
-        self.unindex_links()
-        super(IpInterface, self).unindex_object()
-        # index our ip addresses if necessary
-        for ip in self.ipaddresses():
-            ip.index_object()
-
+    def before_object_deleted_handler(self):
         device = self.device()
-
         if device:
             macs = device.getMacAddressCache()
             try: 
                 macs.remove(self.macaddress)
-                notify(IndexingEvent(self.device(), idxs=('macAddresses',), update_metadata=False))
+                notify(IndexingEvent(device, idxs=('macAddresses',), update_metadata=False))
             except KeyError:
                 pass
+
+    def object_added_handler(self):
+        if self.macaddress:
+            device = self.device()
+            if device:
+                device.getMacAddressCache().add(self.macaddress)
+
+    #------------------------------------------
+
+    def index_object(self, idxs=None):
+        """
+        DEPRECATED  -  Override the default so that links are indexed.
+        """
+        super(IpInterface, self).index_object(idxs)
+
+    def unindex_object(self):
+        """
+        DEPRECATED  -  Override the default so that links are unindexed.
+        """
+        super(IpInterface, self).unindex_object()
             
     def manage_deleteComponent(self, REQUEST=None):
         """
@@ -235,7 +240,6 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         super(IpInterface, self).manage_deleteComponent(REQUEST)
         for ip in ips:
             self.dmd.getDmdRoot("ZenLinkManager").remove_device_network_from_cache(device.getId(), ip.network().getPrimaryUrlPath())
-            ip.primaryAq().index_object()
         if device:
             notify(IndexingEvent(device, idxs=["path"])) # We need to delete the iface path from the device
 
@@ -294,7 +298,7 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         else:
             ipobj = networks.createIp(ip, netmask)
             self.ipaddresses.addRelation(ipobj)
-        ipobj.index_object()
+        notify(IndexingEvent(ipobj))
         os = self.os()
         notify(ObjectMovedEvent(self, os, self.id, os, self.id))
         self.dmd.getDmdRoot("ZenLinkManager").add_device_network_to_cache(self.device().getId(), ipobj.network().getPrimaryUrlPath())
@@ -360,7 +364,7 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         for ip in ipids:
             ipobj = self.ipaddresses._getOb(ip)
             self.removeRelation('ipaddresses', ipobj)
-            ipobj.index_object()
+            notify(IndexingEvent(ipobj))
         for ip in localips:
             self._ipAddresses.remove(ip)
 
@@ -372,7 +376,7 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         for ipobj in self.ipaddresses():
             if ipobj.id == ip:
                 self.ipaddresses.removeRelation(ipobj)
-                ipobj.index_object()
+                notify(IndexingEvent(ipobj))
                 return
 
 
@@ -648,7 +652,3 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
 
 InitializeClass(IpInterface)
 
-def beforeDeleteIpInterface(ob, event):
-    if (event.object==ob or event.object==ob.device() or
-        getattr(event.object, "_operation", -1) < 1):
-        ob.unindex_object()

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -180,6 +180,15 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
             if id == 'macaddress':
                 self.index_object()
 
+    #------------------------------------------
+    #--    ITreeSpanningComponent methods   --
+
+    def get_indexable_peers(self):
+        """  """
+        return self.ipaddresses()
+
+    #------------------------------------------
+
     def index_object(self, idxs=None):
         """
         Override the default so that links are indexed.
@@ -227,6 +236,8 @@ class IpInterface(OSComponent, Layer2Linkable, IpInterfaceIndexable):
         for ip in ips:
             self.dmd.getDmdRoot("ZenLinkManager").remove_device_network_from_cache(device.getId(), ip.network().getPrimaryUrlPath())
             ip.primaryAq().index_object()
+        if device:
+            notify(IndexingEvent(device, idxs=["path"])) # We need to delete the iface path from the device
 
     def manage_editProperties(self, REQUEST):
         """

--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -288,7 +288,7 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         if result.total > 0:
             # networks found. if more than network is found, return the one
             # whose lastDecimalIp - firstDecimalIp is the smallest
-            net_brains_tuples = [ ( net_brain, net_brain.lastDecimalIp - net_brain.firstDecimalIp ) for net_brain in result.results ]
+            net_brains_tuples = [ ( net_brain, long(net_brain.lastDecimalIp) - long(net_brain.firstDecimalIp) ) for net_brain in result.results ]
             net_brain_tuple = min(net_brains_tuples, key=lambda x: x[1])
             net = net_brain_tuple[0].getObject()
         return net

--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -22,17 +22,19 @@ log = logging.getLogger('zen')
 
 from ipaddr import IPAddress, IPNetwork
 
+from BTrees.OOBTree import OOBTree
+
 from Globals import DTMLFile
 from Globals import InitializeClass
 from Acquisition import aq_base
 from AccessControl import ClassSecurityInfo
 from AccessControl import Permissions as permissions
 from Products.ZenModel.ZenossSecurity import *
+from Products.ZenModel.interfaces import IObjectEventsSubscriber
 
 from Products.ZenUtils.IpUtil import *
 from Products.ZenRelations.RelSchema import *
-from Products.ZenUtils.Search import makeCaseInsensitiveFieldIndex, makeMultiPathIndex, makeCaseSensitiveKeywordIndex\
-    , makeCaseSensitiveFieldIndex
+
 from IpAddress import IpAddress
 from DeviceOrganizer import DeviceOrganizer
 
@@ -47,9 +49,125 @@ from Products.Jobber.jobs import SubprocessJob
 from Products.ZenWidgets import messaging
 
 from zope.event import notify
+from zope.interface import implements
+
 from Products.Zuul.catalog.events import IndexingEvent
 from Products.Zuul.catalog.indexable import IpNetworkIndexable
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
+
+
+class NetworkCache(object):
+    """
+        We need to be able to quickly find if a network is already in Zenoss. Searching in the
+        zcatalogs or solr decreases modeling performance. To work around this, we will have a
+        network cache per Network root (by default dmd.Networks and dmd.IPv6Networks
+        unless multirealm is installed). This cache will be an OOBtree with the following structure:
+
+        OOBTree   { key: decimal net ip   value: { Network paths starting at the decimal ip } }
+
+        When searching IpAddresses we will also use the network cache.
+        If an Ip exists in Zenoss its network will have to exist, and then we will traverse
+        the ipaddresses of the network (if it exists)
+    """
+
+    def __init__(self):
+        self.cache = OOBTree()
+
+    def get_key(self, netip, netmask):
+        ip = netFromIpAndNet(netip, netmask)
+        return ipToDecimal(ip)
+
+    def _get_netmask_range(self, ip):
+        netmask_range = range(8, 30+1)
+        if get_ip_version(ip) == 6:
+            netmask_range = range(48, 64+1)
+        return netmask_range
+
+    def _get_net(self, netip, netmask, context):
+        net_obj = None
+        key = self.get_key(netip, netmask)
+        net_paths = self.cache.get(key)
+        if net_paths:
+            for net_path in net_paths:
+                try:
+                    net = context.dmd.unrestrictedTraverse(net_path)
+                    if net.netmask == netmask:
+                        net_obj = net
+                        break
+                except KeyError:
+                    self.delete_net(key, net_path)
+                    net_obj = None
+        return net_obj
+
+    def get_net(self, netip, netmask, context):
+        net_obj = None
+        if netmask:
+            net_obj = self._get_net(netip, netmask, context)
+        else:
+            netmask_range = self._get_netmask_range(netip)
+            for mask in sorted(netmask_range, reverse=True):
+                net_obj = self._get_net(netip, mask, context)
+                if net_obj:
+                    break
+        return net_obj
+
+    def add_net(self, net_obj):
+        if net_obj:
+            net_key = self.get_key(net_obj.id, net_obj.netmask)
+            net_value = "/".join(net_obj.getPrimaryPath())
+            nets = self.cache.get(net_key, set())
+            nets.add(net_value)
+            self.cache[net_key] = nets
+
+    def delete_net(self, net_key, net_path):
+        if self.cache.has_key(net_key):
+            nets = self.cache.get(net_key)
+            if net_path in nets:
+                nets.remove(net_path)
+                self.cache[net_key] = nets
+
+    def delete_net_obj(self, net_obj):
+        net_key = self.get_key(net_obj.id, net_obj.netmask)
+        net_path = "/".join(net_obj.getPrimaryPath())
+        self.delete_net(net_key, net_path)
+
+    def _get_ip(self, ip, netmask, context):
+        ip_obj = None
+        # Lets check if the network exists first.
+        net_ip = netFromIpAndNet(ip, netmask)
+        net_obj = self.get_net(net_ip, netmask, context=context)
+        if net_obj is not None: # Network does not exist so neither does the ip
+            for existing_ip in net_obj.ipaddresses(): # traverse ip addresses looking for the one
+                if existing_ip.id == ip:
+                    ip_obj = existing_ip
+                    break
+        return ip_obj
+
+    def get_ip(self, ip, netmask, context):
+        """ Returns IpAddress object for ip if found, else None """
+        ip_obj = None
+        if netmask:
+            ip_obj = self._get_ip(ip, netmask, context)
+        else:
+            netmask_range = self._get_netmask_range(ip)
+            for mask in sorted(netmask_range, reverse=True):
+                ip_obj = self._get_ip(ip, mask, context)
+                if ip_obj:
+                    break
+        return ip_obj
+
+    def get_subnets_paths(self, net_obj):
+        """
+        returns net_obj's subnets
+        """
+        subnets = []
+        if net_obj:
+            net = IPNetwork(ipunwrap(net_obj.id))
+            first_decimal_ip = long(int(net.network))
+            last_decimal_ip = long(first_decimal_ip + math.pow(2, net.max_prefixlen - net_obj.netmask) - 1)
+            for net_uids in self.cache.values(min=first_decimal_ip, max=last_decimal_ip, excludemin=True, excludemax=True):
+                subnets.extend(list(net_uids))
+        return subnets
 
 
 def manage_addIpNetwork(context, id, netmask=24, REQUEST = None, version=4):
@@ -60,6 +178,7 @@ def manage_addIpNetwork(context, id, netmask=24, REQUEST = None, version=4):
         net = context._getOb(net.id)
         net.dmdRootName = id
         net.buildZProperties()
+        net.initialize_network_cache(net)
         #manage_addZDeviceDiscoverer(context)
     if REQUEST is not None:
         REQUEST['RESPONSE'].redirect(context.absolute_url_path()+'/manage_main')
@@ -72,8 +191,11 @@ addIpNetwork = DTMLFile('dtml/addIpNetwork',globals())
 # into class A->B->C network tree
 defaultNetworkTree = (32,)
 
+
 class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
     """IpNetwork object"""
+
+    implements(IObjectEventsSubscriber)
 
     isInTree = True
 
@@ -127,6 +249,7 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
 
     security = ClassSecurityInfo()
 
+    NETWORK_CACHE_ATTR = "network_cache"
 
     def __init__(self, id, netmask=24, description='', version=4):
         if id.find("/") > -1: id, netmask = id.split("/",1)
@@ -140,6 +263,51 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         self.dmdRootName = "Networks"
         if version == 6:
             self.dmdRootName = "IPv6Networks"
+
+    #----------------------------------------------------------
+    #    Methods related to network cache
+    #----------------------------------------------------------
+
+    def initialize_network_cache(self, network_root):
+        if hasattr(network_root, self.NETWORK_CACHE_ATTR):
+            setattr(network_root, self.NETWORK_CACHE_ATTR, None)
+        network_cache = NetworkCache()
+        setattr(network_root, self.NETWORK_CACHE_ATTR, network_cache)
+        for net in network_root.getSubNetworks():
+            network_cache.add_net(net)
+
+    def create_network_caches(self):
+        """
+        We will have a network cache per Network root (by default
+        dmd.Networks and dmd.IPv6Networks unless multirealm is installed)
+        { key: decimal net ip   value: [ Network paths starting at the decimal ip }
+        """
+        # ipv4 tree
+        ip4_networks = self.getNetworkRoot(4)
+        self.initialize_network_cache(ip4_networks)
+        # ipv6 tree
+        ip6_networks = self.getNetworkRoot(6)
+        self.initialize_network_cache(ip6_networks)
+
+    def get_network_cache(self):
+        if not hasattr(self.getNetworkRoot(), self.NETWORK_CACHE_ATTR):
+            self.initialize_network_cache(self.getNetworkRoot())
+        return getattr(self.getNetworkRoot(), self.NETWORK_CACHE_ATTR)
+
+    #----------------------------------------------------------
+    #    IObjectEventsSubscriber Methods
+    #----------------------------------------------------------
+
+    def before_object_deleted_handler(self):
+        self.get_network_cache().delete_net_obj(self)
+
+    def after_object_added_or_moved_handler(self):
+        self.get_network_cache().add_net(self)
+
+    def object_added_handler(self):
+        pass
+
+    #----------------------------------------------------------
 
     security.declareProtected('Change Network', 'manage_addIpNetwork')
     def manage_addIpNetwork(self, newPath, REQUEST=None):
@@ -156,7 +324,6 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         if id.find("/") > -1: id, netmask = id.split("/",1)
         return super(IpNetwork, self).checkValidId(id, prep_id)
 
-
     def getNetworkRoot(self, version=None):
         """This is a hook method do not remove!"""
         if not isinstance(version, int):
@@ -165,21 +332,57 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
             return self.dmd.getDmdRoot("IPv6Networks")
         return self.dmd.getDmdRoot("Networks")
 
+    def _get_smallest_mask(self, version):
+        smallest_netmask = 8
+        if version == 6:
+            smallest_netmask = 48
+        return smallest_netmask
 
-    def createNet(self, netip, netmask=24):
+    def _find_parent(self, net_ip, netmask):
         """
-        Return and create if necessary network.  netip is in the form
-        1.1.1.0/24 or with netmask passed as parameter.  Subnetworks created
-        based on the zParameter zDefaulNetworkTree.
-        Called by IpNetwork.createIp and IpRouteEntry.setTarget
-        If the netmask is invalid, then a netmask of 24 is assumed.
+        Search for an existing network that is a supernet of netip/netmask
+        """
+        smallest_netmask = self._get_smallest_mask(self.version)
+        parent = None
+        for mask in xrange(netmask-1, smallest_netmask - 1, -1):
+            parent_net_ip = netFromIpAndNet(net_ip, mask)
+            netobj = self.get_network_cache().get_net(parent_net_ip, mask, context=self)
+            if netobj: # We found a parent!
+                parent = netobj
+                break
+        return parent
 
-        @param netip: network IP address start
-        @type netip: string
-        @param netmask: network mask
-        @type netmask: integer
-        @todo: investigate IPv6 issues
+    def _get_default_network_tree(self, netip, netmask):
         """
+        return the network tree to create based on 'zDefaultNetworkTree'
+
+        'zDefaultNetworkTree' : list of netmask numbers to use when creating network containers.
+                                Default is 24, 32 which will make /24 networks at the top level 
+                                of the networks tree if a network is smaller than /24
+
+        Example: If zDefaultNetworkTree is (24, 32) any net we need to create with netmask >=24
+                 needs to be a child of the net/24
+                 example_net: 10.10.10.128/25 will create the following net tree
+                                10.10.10.0/24
+                                    10.10.10.128/25
+        """
+        network_tree = []
+        net_ip_obj = IPAddress(ipunwrap_strip(netip))
+        if net_ip_obj.version == 4:
+            for mask in getattr(self, 'zDefaultNetworkTree', defaultNetworkTree):
+                network_tree.append(int(mask))
+        else:
+            # ISPs are supposed to provide the 48-bit prefix to orgs (RFC 3177)
+            network_tree.append(48)
+
+        if net_ip_obj.max_prefixlen not in network_tree:
+            network_tree.append(net_ip_obj.max_prefixlen)
+
+        return list(set(network_tree)) # just in case user gave duplicates
+
+
+    def _parse_netip_and_netmask(self, netip, netmask):
+        """ validates net ip and network """
         if '/' in  netip:
             netip, netmask = netip.split("/",1)
 
@@ -188,91 +391,111 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         try:
             netmask = int(netmask)
         except (TypeError, ValueError):
-            netmask = 24
-        netmask = netmask if netmask < ipobj.max_prefixlen else 24
+            netmask = None
+        netmask = netmask if netmask < ipobj.max_prefixlen else None
+        return netip, netmask
 
-        #hook method do not remove!
-        netroot = self.getNetworkRoot(ipobj.version)
-        netobj = netroot.getNet(netip)
-        if netmask == 0:
-            raise ValueError("netip '%s' without netmask" % netip)
-        if netobj and netobj.netmask >= netmask: # Network already exists.
-            return netobj
 
-        ipNetObj = IPNetwork(netip)
-        if ipNetObj.version == 4:
-            netip = getnetstr(netip, netmask)
-            netTree = getattr(self, 'zDefaultNetworkTree', defaultNetworkTree)
-            netTree = map(int, netTree)
-            if ipobj.max_prefixlen not in netTree:
-                netTree.append(ipobj.max_prefixlen)
-        else:
-            # IPv6 doesn't use subnet masks the same way
-            netip = getnetstr(netip, 64)
-            netmask = 64
-            # ISPs are supposed to provide the 48-bit prefix to orgs (RFC 3177)
-            netTree = (48,)
+    def createNet(self, netip, netmask=None):
+        """
+        Return and create if necessary network.  netip is in the form
+        1.1.1.0/24 or with netmask passed as parameter.  Subnetworks created
+        based on the zParameter zDefaulNetworkTree.
+        Called by IpNetwork.createIp
+        If the netmask is invalid, then a netmask of 24 is assumed.
 
-        if netobj:
-            # strip irrelevant values from netTree if we're not starting at /0
-            netTree = [ m for m in netTree if m > netobj.netmask ]
-        else:
-            # start at /Networks if no containing network was found
-            netobj = netroot
+        @param netip: network IP address start
+        @type netip: string
+        @param netmask: network mask
+        @type netmask: integer
+        @todo: investigate IPv6 issues
+        """
+        netip, netmask = self._parse_netip_and_netmask(netip, netmask)
 
-        for treemask in netTree:
-            if treemask >= netmask:
-                netobjParent = netobj
-                netobj = netobj.addSubNetwork(netip, netmask)
-                self.rebalance(netobjParent, netobj)
-                break
+        # if netmask is None it will look for the net in all possible nets
+        #
+        netobj = self.get_network_cache().get_net(netip, netmask, context=self)
+
+        if netobj is None:
+            # Network does not exist. Create a new network
+            if not netmask:
+                netmask = get_default_netmask(ip)
+
+            # Let's find a parent of the new net
+            parent_mask = -1
+            parent_net = self._find_parent(netip, netmask)
+            if parent_net is None:
+                parent_net = self.getNetworkRoot()
             else:
-                supnetip = getnetstr(netip, treemask)
-                netobjParent = netobj
-                netobj = netobj.addSubNetwork(supnetip, treemask)
-                self.rebalance(netobjParent, netobj)
+                parent_mask = parent_net.netmask
+
+            # For netmasks greater than a config parameter we need to also create
+            # the super networks. Ex for netmasks >= 24 we need to create the net with netmask
+            # 24 and then a subnetwork of it with the requested netmask
+            #
+            default_net_tree = self._get_default_network_tree(netip, netmask)
+
+            # filter net tree to create, we only need masks greater than the parent's 
+            # and smaller than the the one we want to add
+            network_tree = sorted(filter(lambda m: m > parent_mask and m < netmask, default_net_tree))
+            network_tree.append(netmask)
+
+            # We need to create the networks with masks in network_tree which
+            # includes the net we wanted to create in the first place
+            #
+            for mask in network_tree:
+                subnet_ip = netFromIpAndNet(netip, mask)
+                subnet = parent_net.addSubNetwork(subnet_ip, mask)
+                self.get_network_cache().add_net(subnet) # update the cache
+
+                # check if any of the existing subnets of parent_net
+                # is a subnet of the new net subnet. If so, move appropriately
+                self.rebalance(parent_net, subnet)
+                parent_net = netobj = subnet # prepare for next iteration
 
         return netobj
 
-
     def rebalance(self, netobjParent, netobj):
         """
-        Look for children of the netobj at this level and move them to the
-        right spot.
+        Look for children of netobjParent that could be subnets of the newly added net netobj
+        and move them to the right place in the network tree
         """
-        moveList = []
-        for subnetOrIp in netobjParent.children():
-            if subnetOrIp == netobj:
-                continue
-            if netobj.hasIp(subnetOrIp.id):
-                moveList.append(subnetOrIp.id)
-        if moveList:
-            netobjPath = netobj.getOrganizerName()[1:]
-            netobjParent.moveOrganizer(netobjPath, moveList)
 
-    def findNet(self, netip, netmask=0):
+        # Who can be a subnet of netobj ? networks whose decimal ip is between within netobj
+        # ip range get all the nets that are a subnet of netobj
+        all_subnets_paths = self.get_network_cache().get_subnets_paths(netobj)
+
+        # keep only the ones that are at the same level as netobj
+        parent_path = "/".join(netobjParent.getPrimaryPath())
+        netobj_depth = len(netobj.getPrimaryPath())
+
+        same_level_subnets_ids = []
+        for subnet_path in all_subnets_paths:
+            splitted = subnet_path.split("/")
+            if len(splitted) == netobj_depth and parent_path in subnet_path:
+                subnet_id = splitted[-1]
+                same_level_subnets_ids.append(subnet_id)
+
+        if same_level_subnets_ids:
+            netobjPath = netobj.getOrganizerName()[1:]
+            netobjParent.moveOrganizer(netobjPath, same_level_subnets_ids)
+
+    def findNet(self, netip, netmask=None):
         """
         Find and return the subnet of this IpNetwork that matches the requested
         netip and netmask.
         """
-        if netip.find("/") >= 0:
-            netip, netmask = netip.split("/", 1)
-            netmask = int(netmask)
-        for subnet in [self] + self.getSubNetworks():
-            if netmask == 0 and subnet.id == netip:
-                return subnet
-            if subnet.id == netip and subnet.netmask == netmask:
-                return subnet
-        return None
+        netip, netmask = self._parse_netip_and_netmask(netip, netmask)
+        return self.get_net_from_cache(ipunwrap(netip), netmask)
 
+    def getNet(self, ip, netmask=None):
+        """ Return the net starting form the Networks root for ip. """
+        return self.get_net_from_cache(ipunwrap(ip), netmask)
 
-    def getNet(self, ip):
-        """Return the net starting form the Networks root for ip.
-        """
-        return self._getNet(ipunwrap(ip))
+    def get_net_from_cache(self, netip):
+        return self.get_network_cache().get_net(netip, None, context=self)
 
-
-    def _getNet(self, ip):
+    def get_net_from_catalog(self, ip):
         """
         Search in the network tree the IpNetwork ip belongs to.
         return None if the network is not found
@@ -293,17 +516,22 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
             net = net_brain_tuple[0].getObject()
         return net
 
-
-    def createIp(self, ip, netmask=24):
-        """Return an ip and create if nessesary in a hierarchy of
+    def createIp(self, ip, netmask=None):
+        """
+        Return an ip and create if nessesary in a hierarchy of
         subnetworks based on the zParameter zDefaulNetworkTree.
         """
-        ipobj = self.findIp(ip)
-        if ipobj: return ipobj
-        netobj = self.createNet(ip, netmask)
-        ipobj = netobj.addIpAddress(ip,netmask)
-        return ipobj
+        network_cache = self.get_network_cache()
 
+        ip_obj = network_cache.get_ip(ip, netmask, context=self)
+        if not ip_obj: # Ip does not exists
+            if not netmask:
+                netmask = get_default_netmask(ip)
+            net_obj = network_cache.get_net(ip, netmask, context=self)
+            if net_obj is None: # Network does not exist
+                net_obj = self.createNet(ip, netmask)
+            ip_obj = net_obj.addIpAddress(ip, netmask)
+        return ip_obj
 
     def freeIps(self):
         """Number of free Ips left in this network.
@@ -385,9 +613,19 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         """Return and add if nessesary subnetwork to this network.
         """
         netobj = self.getSubNetwork(ip)
+        ip_id = ipwrap(ip)
         if not netobj:
-            net = IpNetwork(ipwrap(ip), netmask=netmask, version=self.version)
-            self._setObject(ipwrap(ip), net)
+            net = IpNetwork(ip_id, netmask=netmask, version=self.version)
+            self._setObject(ip_id, net)
+        elif netobj.netmask > netmask: # ex 10.1.0.0/12 exists and we need to add 10.0.0.0/8
+            self._operation = 1 # Do we need this?
+            self._delObject(ip_id) # remove ref to old net with greater mask
+            new_net = IpNetwork(ip_id, netmask=netmask, version=self.version)
+            self._setObject(ip_id, new_net)
+            new_net = self._getOb(ip_id)
+            netobj = aq_base(netobj)
+            new_net._setObject(ip_id, netobj)
+
         return self.getSubNetwork(ip)
 
 
@@ -490,9 +728,10 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
         search_result = cat.search(query=query)
         return [ brain for brain in search_result.results ]
 
-
     def findIp(self, ip):
-        """Find an ipAddress.
+        """
+        Looks for the ipaddress in the catalog.
+        Avoid calling this method during modeling if possible
         """
         brains = self._search_ip_in_catalog(ip)
         ip_obj = None
@@ -503,6 +742,12 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
                 raise IpAddressConflict( "IP address conflict for IP: %s" % ip )
         return ip_obj
 
+    def find_ip(self, ip, netmask):
+        """
+        Search for the ip in the network cache.
+        Use this method for modeling if possible
+        """
+        return self.get_network_cache().get_ip(ip, netmask, context=self)
 
     def buildZProperties(self):
         if self.version == 6:

--- a/Products/ZenModel/IpRouteEntry.py
+++ b/Products/ZenModel/IpRouteEntry.py
@@ -177,20 +177,10 @@ class IpRouteEntry(OSComponent):
         If the nexthop is a 127. or 0. address store locally
         else link to it in the network hierarchy
         """
-        if localIpCheck(self, nextHopIp) or not nextHopIp:
-            self._nexthop = nextHopIp
-        else:
-            networks = self.device().getNetworkRoot()
-            ip = networks.findIp(nextHopIp)
-            if not ip: 
-                netmask = 24
-                int = self.interface()
-                if int: 
-                    intip = int.getIpAddressObj()
-                    if intip: netmask = intip.netmask
-                ip = networks.createIp(nextHopIp, netmask)
-            self.addRelation('nexthop', ip)
-      
+        self._nexthop = nextHopIp
+        # We dont want to add an IpAddress object for this. We should
+        # probably stop modeling this
+
 
     def matchTarget(self, ip):
         """
@@ -251,7 +241,7 @@ class IpRouteEntry(OSComponent):
         else:
             int = None
         if int: self.interface.addRelation(int)
-        else: log.warn("interface index:%s not found", ifindex)
+        #else: log.warn("interface index:%s not found", ifindex)
 
 
     def getInterfaceIndex(self):

--- a/Products/ZenModel/LinkManager.py
+++ b/Products/ZenModel/LinkManager.py
@@ -21,12 +21,12 @@ from BTrees.OOBTree import OOBTree
 from json import dumps
 from Products.AdvancedQuery import Eq
 from Products.CMFCore.utils import getToolByName
-from Products.ZCatalog.ZCatalog import manage_addZCatalog
 from Products.ZenModel.Device import Device
 from Products.ZenUtils.Search import makeCaseInsensitiveFieldIndex
 from Products.ZenUtils.NetworkTree import NetworkLink
-from Products.Zuul import getFacade
 from Products.ZenEvents.events2.processing import Manager
+from Products.Zuul import getFacade
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from zenoss.protocols.protobufs.zep_pb2 import (SEVERITY_CRITICAL, SEVERITY_ERROR,
                                                 SEVERITY_WARNING, SEVERITY_INFO,
                                                 SEVERITY_DEBUG, SEVERITY_CLEAR)
@@ -58,32 +58,6 @@ def manage_addLinkManager(context, id="ZenLinkManager"):
     mgr = LinkManager(id)
     context._setObject(mgr.id, mgr)
     mgr = context._getOb(id)
-    _create_catalogs(mgr)
-
-
-def _create_layer2_catalog(mgr):
-    layer_2_indices = (
-        ('lanId', makeCaseInsensitiveFieldIndex),
-        ('macaddress', makeCaseInsensitiveFieldIndex),
-        ('deviceId', makeCaseInsensitiveFieldIndex),
-        ('interfaceId', makeCaseInsensitiveFieldIndex)
-    )
-    mgr._addLinkCatalog('layer2_catalog', layer_2_indices)
-
-
-def _create_layer3_catalog(mgr):
-    layer_3_indices = (
-        ('networkId', makeCaseInsensitiveFieldIndex),
-        ('ipAddressId', makeCaseInsensitiveFieldIndex),
-        ('deviceId', makeCaseInsensitiveFieldIndex),
-        ('interfaceId', makeCaseInsensitiveFieldIndex)
-    )
-    mgr._addLinkCatalog('layer3_catalog', layer_3_indices)
-
-
-def _create_catalogs(mgr):
-    _create_layer2_catalog(mgr)
-    _create_layer3_catalog(mgr)
 
 
 class Layer3Link(object):
@@ -213,43 +187,61 @@ class LinkManager(Folder):
         self.networks_per_device_cache = DeviceNetworksCache()
 
     def _getCatalog(self, layer=3):
+        # @TODO REMOVE Whenever all catalogs are migrated to solr
         try: 
             return getToolByName(self, 'layer%d_catalog' % layer)
         except AttributeError:
             return None
 
-    def _addLinkCatalog(self, id, indices):
-        manage_addZCatalog(self, id, id)
-        zcat = self._getOb(id)
-        cat = zcat._catalog
-        for index, factory in indices:
-            cat.addIndex(index, factory(index))
-            zcat.addColumn(index)
+    def _get_brains(self, layer, attr, value):
+        """
+        hack to make getLinkedNodes's awful code work with as little changes as possible
+        """
+        model_catalog = IModelCatalogTool(self.dmd)
+        query = {}
+        if layer == 3:
+            meta_type = "IpAddress"
+            query["deviceId"] = "*"  # We only are interested in assigned ips
+        else:
+            meta_type = "IpInterface"
+        query["meta_type"] = meta_type
+        if isinstance(value, basestring):
+            value = "*{0}".format(value)
+        query[attr] = value
+        search_results = model_catalog.search(query=query)
+        return [ brain for brain in search_results.results ]
 
-    def getLinkedNodes(self, meta_type, id, layer=3, visited=None):
-        cat = self._getCatalog(layer)
+    def getLinkedNodes(self, meta_type, ids, layer=3, visited=None):
         col = NODE_IDS['layer_%d' % layer][meta_type]
         nextcol = _getComplement(col, layer)
-        brains = cat(**{col:id})
+        brains = self._get_brains(layer, col, ids)
         gen1ids = set(getattr(brain, nextcol) for brain in brains)
         if visited:
             gen1ids = gen1ids - visited # Don't go places we've been!
-        gen2 = cat(**{nextcol:list(gen1ids)})
+        gen2 = self._get_brains(layer, nextcol, list(gen1ids))
         return gen2, gen1ids
-    
+
+    def _get_devices_under_path(self, path):
+        """ Returnd device's brains """
+        model_catalog = IModelCatalogTool(self.dmd.Devices)
+        query = {}
+        query["objectImplements"] = "Products.ZenModel.Device.Device"
+        query["path"] = "{0}/*".format(path)
+        result = model_catalog.search(query=query)
+        return result.results
+
     # Deprecated. Left for testing purposes to compare perf and results with the new version
     def getChildLinks_old(self, organizer):
-        catalog = getToolByName(self.dmd.Devices, 'deviceSearch')
         result = {}
         locs = organizer.children()
         locpaths = sorted(('/'.join(loc.getPrimaryPath()) for loc in locs), reverse=True)
         path = '/'.join(organizer.getPhysicalPath())
-        subdevs = catalog(path=path)
-        subids = dict((x.id, x.path) for x in subdevs)
+        subdevs = self._get_devices_under_path(path)
+        subids = dict((x.uid, x.path) for x in subdevs)
 
         def _whichorg(brain):
             for path in locpaths:
-                _matchpath = lambda x: '/'.join(x).startswith(path)
+                _matchpath = lambda x: x.startswith(path)
                 brainpath = subids.get(brain.deviceId, [])
                 if any(ifilter(_matchpath, brainpath)):
                     return path
@@ -280,6 +272,7 @@ class LinkManager(Folder):
             if _drawMapLinks(net):
                 bynet[net].append(link)
 
+
         # Build the links (if found)
         linkobs = []
         for devs in bynet.itervalues():
@@ -294,13 +287,22 @@ class LinkManager(Folder):
                 linkobs.extend(Layer3Link(self.dmd, dict(l)) for l in links)
         return dumps([(x.getUids(), x.getStatus()) for x in linkobs])
 
+    def _get_ip_brains_belonging_to_network(self, net):
+        """ returns IpAddress brains """
+        model_catalog = IModelCatalogTool(self.dmd)
+        query = {}
+        query["objectImplements"] = "Products.ZenModel.IpAddress.IpAddress"
+        query["networkId"] = net
+        result = model_catalog.search(query=query)
+        return result.results
+
+
     def getChildLinks(self, organizer):
         """
         Find networks that are in more than one location,
         build links between connected locations and
         get the link status
         """
-        catalog = getToolByName(self.dmd.Devices, 'deviceSearch')
 
         root_location_path_tuple = organizer.getPhysicalPath()
         root_location_path = '/'.join(root_location_path_tuple)
@@ -314,7 +316,7 @@ class LinkManager(Folder):
         devices_per_location = defaultdict(set)   # { location: set( device_id ) }
         locations_per_network = defaultdict(set)  # { network:  set( location ) }
 
-        devices_search = catalog(path=root_location_path)
+        devices_search = self._get_devices_under_path(root_location_path)
 
         for device_result in devices_search:
             device_id = device_result.id

--- a/Products/ZenModel/LinkManager.py
+++ b/Products/ZenModel/LinkManager.py
@@ -321,7 +321,8 @@ class LinkManager(Folder):
         for device_result in devices_search:
             device_id = device_result.id
             # get the the parent location the device belongs to
-            device_location_full_path_tuple = next(ifilter(lambda x: 'Locations' in x, device_result.path))
+            device_location_full_path = next(ifilter(lambda x: 'Locations' in x, device_result.path))
+            device_location_full_path_tuple = device_location_full_path.split('/')
             location_search_key = device_location_full_path_tuple[len(root_location_path_tuple)]
             device_parent_location = locations.get(location_search_key)
             if device_parent_location:

--- a/Products/ZenModel/Linkable.py
+++ b/Products/ZenModel/Linkable.py
@@ -25,15 +25,12 @@ class Linkable:
             return None
 
     def index_links(self):
-        notify(IndexingEvent(self))  # For model catalog
-        cat = self._getLinkCatalog()
-        if cat is not None:
-            cat.catalog_object(self, self.getPrimaryId())
+        # DEPRECATED. THIS FILE WILL BE REMOVED
+        pass
 
     def unindex_links(self):
-        cat = self._getLinkCatalog()
-        if cat is not None:
-            cat.uncatalog_object(self.getPrimaryId())
+        # DEPRECATED. THIS FILE WILL BE REMOVED
+        pass
 
 
 class Layer2Linkable(Linkable):

--- a/Products/ZenModel/ZenModelRM.py
+++ b/Products/ZenModel/ZenModelRM.py
@@ -34,6 +34,7 @@ from Products.ZenRelations.RelationshipManager import RelationshipManager
 from Products.ZenModel.ZenossSecurity import *
 
 from Products.Zuul.catalog.indexable import BaseIndexable
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 class ZenModelRM(ZenModelBase, RelationshipManager, Historical, ZenPacker, BaseIndexable):
     """
@@ -56,8 +57,7 @@ class ZenModelRM(ZenModelBase, RelationshipManager, Historical, ZenPacker, BaseI
 
     def setTitle(self, title):
         self.title = title
-        from Products.Zuul.interfaces import ICatalogTool
-        ICatalogTool(self).update(self)
+        IModelCatalogTool(self).update(self)
 
     security.declareProtected('Manage DMD', 'rename')
     def rename(self, newId, REQUEST=None):

--- a/Products/ZenModel/ZentinelPortal.py
+++ b/Products/ZenModel/ZentinelPortal.py
@@ -92,22 +92,7 @@ class ZentinelPortal ( PortalObjectBase ):
         search on the list of devices.
         """
         # TODO: Remove. Not used anymore in Zenoss code --Ian
-        zcatalog = self.dmd.Devices.deviceSearch
-        glob = queryString.rstrip('*') + '*'
-        idGlob = MatchGlob('id', glob)
-        titleGlob = MatchGlob('titleOrId', glob)
-        idOrTitleQuery = Or(idGlob,titleGlob)
-        query = Or(idOrTitleQuery, Eq('getDeviceIp', queryString))
-        additionalQuery = self._additionalQuery()
-        if additionalQuery:
-            query = And( query, additionalQuery )
-        brains = zcatalog.evalAdvancedQuery(query)
-        if REQUEST and len(brains) == 1:
-            raise Redirect(urllib.quote(brains[0].getPrimaryId))
-        if additionalQuery:
-            idGlob = And( idGlob, additionalQuery )
-        brains += self.dmd.Networks.ipSearch.evalAdvancedQuery(idGlob)
-        return [ b.getObject() for b in brains ]
+        return []
 
     security.declareProtected(ZEN_COMMON, 'searchComponents')
     @deprecated
@@ -116,23 +101,7 @@ class ZentinelPortal ( PortalObjectBase ):
         Redirect to the component of a device. Hopefully.
         """
         # TODO: Remove. Not used anymore in Zenoss code --Ian
-        catalog = self.dmd.Devices.componentSearch
-        brains = []
-        if device and component:
-            brains = catalog(getParentDeviceName=device)
-        matchingBrains = []
-        if brains:
-            component = prepId(component)
-            for brain in brains:
-                if brain.getPath().split('/')[-1]==component:
-                    if REQUEST:
-                        raise Redirect(urllib.quote(
-                            brain.getPath()+'/viewEvents'))
-                    else:
-                        matchingBrains.append(brain)
-            if REQUEST and len(matchingBrains) == 0:
-                return self.searchDevices(device, REQUEST)
-        return [b.getObject() for b in matchingBrains]
+        return []
 
     security.declareProtected(ZEN_COMMON, 'dotNetProxy')
     def dotNetProxy(self, path='', params={}, REQUEST=None):

--- a/Products/ZenModel/ZentinelPortal.py
+++ b/Products/ZenModel/ZentinelPortal.py
@@ -28,7 +28,6 @@ from Products.BeakerSessionDataManager.sessiondata import addBeakerSessionDataMa
 from Products.CMFCore.PortalObject import PortalObjectBase
 from Products.CMFCore.utils import getToolByName
 
-from Products.Zuul.interfaces import ICatalogTool
 from Products.ZenUtils import Security, Time
 from Products.ZenUtils.Utils import prepId
 from Products.ZenUtils.deprecated import deprecated

--- a/Products/ZenModel/configure.zcml
+++ b/Products/ZenModel/configure.zcml
@@ -59,6 +59,4 @@
          instances are as well -->
     <subscriber handler=".OSProcessClass.onProcessClassRemoved"/>
     <subscriber handler=".ServiceClass.onServiceClassRemoved"/>
-    <subscriber handler=".subscribers.onInterfaceRemoved" />
-    <subscriber handler=".subscribers.onInterfaceAdded" />
 </configure>

--- a/Products/ZenModel/indexing.zcml
+++ b/Products/ZenModel/indexing.zcml
@@ -18,4 +18,27 @@
         handler=".subscribers.unindexBeforeDelete"
         />
 
+    <!--
+    New handlers, once model catalog is implemented for all ZCatalog
+    the above handlers will be removed
+    -->
+
+    <subscriber
+        for=".interfaces.IObjectEventsSubscriber
+             zope.container.interfaces.IObjectMovedEvent"
+        handler=".subscribers.onAfterObjectAddedOrMoved"
+        />
+
+    <subscriber
+        for=".interfaces.IObjectEventsSubscriber
+             OFS.interfaces.IObjectWillBeMovedEvent"
+        handler=".subscribers.onBeforeObjectDeleted"
+        />
+
+    <subscriber
+        for=".interfaces.IObjectEventsSubscriber
+             zope.container.interfaces.IObjectAddedEvent"
+        handler=".subscribers.onObjectAdded"
+        />
+
 </configure>

--- a/Products/ZenModel/interfaces.py
+++ b/Products/ZenModel/interfaces.py
@@ -42,6 +42,20 @@ class IIndexed(Interface):
         pass
 
 
+class IObjectEventsSubscriber(Interface):
+    """
+    Interface for objects that need to hook to zope object events
+    """
+    def before_object_deleted_handler():
+        pass
+
+    def after_object_added_or_moved_handler():
+        pass
+
+    def object_added_handler():
+        pass
+
+
 class IDataRoot(Interface):
     """
     Marker interface for the DMD, so it can be looked up as a global utility.

--- a/Products/ZenModel/migrate/RemoveIgnoreParametersFromOsProcessClass.py
+++ b/Products/ZenModel/migrate/RemoveIgnoreParametersFromOsProcessClass.py
@@ -14,7 +14,7 @@ import Globals
 import logging
 import Migrate
 from Products.ZenEvents.ZenEventClasses import Debug, Error
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenModel.OSProcessClass import OSProcessClass
 
 log = logging.getLogger("zen.migrate")
@@ -27,7 +27,7 @@ class RemoveIgnoreParametersFromOsProcessClass(Migrate.Step):
     def cutover(self, dmd):
         log.info("Removing ignoreParameters and ignoreParametersWhenModeling from all OSProcessClass objects")
         try:
-            for brain in ICatalogTool(dmd).search(OSProcessClass):
+            for brain in IModelCatalogTool(dmd).search(OSProcessClass):
                 try:
                     pc = brain.getObject()
                 except:

--- a/Products/ZenModel/migrate/clearUserSettings.py
+++ b/Products/ZenModel/migrate/clearUserSettings.py
@@ -17,10 +17,8 @@ script removes them all.
 
 import Migrate
 import logging
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 log = logging.getLogger('zen.migrate')
-
-
 
 
 class ClearUserSettings(Migrate.Step):
@@ -28,7 +26,7 @@ class ClearUserSettings(Migrate.Step):
 
     def cutover(self, dmd):
         if not hasattr(dmd, '_clearedUserSettingsExtJs4'):
-            for brain in ICatalogTool(dmd).search('Products.ZenModel.UserSettings.UserSettings'):
+            for brain in IModelCatalogTool(dmd).search('Products.ZenModel.UserSettings.UserSettings'):
                 user = brain.getObject()
                 if hasattr(user, '_browser_state'):
                     del brain.getObject()._browser_state

--- a/Products/ZenModel/migrate/fixIpv6NetworkOrganizers.py
+++ b/Products/ZenModel/migrate/fixIpv6NetworkOrganizers.py
@@ -14,7 +14,7 @@ Add an IPv6 network model for tracking IPv6 networks.
 """
 
 import Migrate
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenModel.IpNetwork import IpNetwork
 from Products.Zuul.utils import safe_hasattr as hasattr
 
@@ -23,7 +23,7 @@ class fixIpv6Network(Migrate.Step):
 
     def cutover(self, dmd):
         if hasattr(dmd, 'IPv6Networks'):
-            for brain in ICatalogTool(dmd.IPv6Networks).search(IpNetwork):
+            for brain in IModelCatalogTool(dmd.IPv6Networks).search(IpNetwork):
                 try:
                     org = brain.getObject()
                     org.version = 6

--- a/Products/ZenModel/migrate/jobmanager_jobs_delete.py
+++ b/Products/ZenModel/migrate/jobmanager_jobs_delete.py
@@ -9,7 +9,8 @@
 
 
 import Migrate
-from Products.Zuul.interfaces.tree import ICatalogTool
+from zope.component import getUtility
+from Products.Zuul.catalog.interfaces import IModelCatalog, IModelCatalogTool
 from Products.Zuul.utils import safe_hasattr as hasattr
 import logging
 log = logging.getLogger('zen.migrate')
@@ -20,13 +21,14 @@ class JobsDelete(Migrate.Step):
     def cutover(self, dmd):
         jmgr = getattr(dmd, 'JobManager', None)
         if jmgr:
+            model_catalog = getUtility(IModelCatalog).get_client(dmd)
             log.info("Removing old job records")
-            for ob in ICatalogTool(dmd.JobManager).search():
+            for brain in IModelCatalogTool(dmd.JobManager).search():
                 try:
-                    if ob.getPath() != '/zport/dmd/JobManager':
-                        dmd.global_catalog._catalog.uncatalogObject(ob.getPath())
+                    if brain.getPath() != '/zport/dmd/JobManager':
+                        model_catalog.uncatalog_object(brain.getObject())
                 except Exception:
-                    log.warn("Error removing %s", ob.getPath())
+                    log.warn("Error removing %s", brain.getPath())
             log.info("Removing old job relationship")
             if hasattr(jmgr, 'jobs'):
                 jmgr._delOb('jobs')

--- a/Products/ZenModel/migrate/processCountThreshold.py
+++ b/Products/ZenModel/migrate/processCountThreshold.py
@@ -10,13 +10,13 @@
 import Migrate
 from Products.AdvancedQuery import Eq
 from Products.ZenModel.MinMaxThreshold import MinMaxThreshold
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 class ProcessCountThreshold(Migrate.Step):
     version = Migrate.Version(4, 2, 4)
 
     def cutover(self, dmd):
-        templates = ICatalogTool(dmd).search("Products.ZenModel.RRDTemplate.RRDTemplate",
+        templates = IModelCatalogTool(dmd).search("Products.ZenModel.RRDTemplate.RRDTemplate",
                                              query=Eq("name", "OSProcess"))
         for t in templates:
             template = t.getObject()

--- a/Products/ZenModel/migrate/removeModificationsMenuItems.py
+++ b/Products/ZenModel/migrate/removeModificationsMenuItems.py
@@ -15,13 +15,13 @@ Remove Modifications menu items.
 $Id:$
 '''
 import Migrate
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 class RemoveModificationsMenuItems(Migrate.Step):
     version = Migrate.Version(4, 2, 0)
 
     def cutover(self, dmd):
-        items = ICatalogTool(dmd).search('Products.ZenModel.ZenMenuItem.ZenMenuItem')
+        items = IModelCatalogTool(dmd).search('Products.ZenModel.ZenMenuItem.ZenMenuItem')
         for brain in items:
             menuitem = brain.getObject()
             action = menuitem.action

--- a/Products/ZenModel/subscribers.py
+++ b/Products/ZenModel/subscribers.py
@@ -13,6 +13,7 @@ from OFS.interfaces import IObjectWillBeMovedEvent, IObjectWillBeAddedEvent
 
 from Products.ZenModel.IpInterface import IpInterface, beforeDeleteIpInterface
 
+
 def unindexBeforeDelete(ob, event):
     """
     Multisubscriber for IIndexed + IObjectWillBeMovedEvent
@@ -30,28 +31,26 @@ def indexAfterAddOrMove(ob, event):
     if not IObjectRemovedEvent.providedBy(event):
         ob.index_object()
 
-@adapter(IpInterface, IObjectWillBeMovedEvent)
-def onInterfaceRemoved(ob, event):
-    """
-    Unindex
-    """
 
+"""
+    New handlers, once model catalog is implemented for all ZCatalogs
+    the above handlers will be removed
+"""
+
+
+def onBeforeObjectDeleted(ob, event):
+    """ Subscriber for IObjectEventsSubscriber + IObjectWillBeMovedEvent """
     if not IObjectWillBeAddedEvent.providedBy(event):
-        device = ob.device()
-        if device:
-            macs = device.getMacAddressCache()
-            if ob.macaddress in macs:
-                macs.remove(ob.macaddress)
+        ob.before_object_deleted_handler()
 
 
-@adapter(IpInterface, IObjectAddedEvent)
-def onInterfaceAdded(ob, event):
-    """
-    Simple subscriber that fires the indexing event for all indices.
-    """
+def onAfterObjectAddedOrMoved(ob, event):
+    """ Subscriber for IObjectEventsSubscriber + IObjectMovedEvent """
+    if not IObjectRemovedEvent.providedBy(event):
+        ob.after_object_added_or_moved_handler()
 
-    if ob.macaddress:
-        device = ob.device()
-        if device:
-            device.getMacAddressCache().add(ob.macaddress)
+
+def onObjectAdded(ob, event):
+    """ """
+    ob.object_added_handler()
 

--- a/Products/ZenModel/subscribers.py
+++ b/Products/ZenModel/subscribers.py
@@ -11,18 +11,13 @@ from zope.component import adapter
 from zope.container.interfaces import IObjectAddedEvent, IObjectRemovedEvent
 from OFS.interfaces import IObjectWillBeMovedEvent, IObjectWillBeAddedEvent
 
-from Products.ZenModel.IpInterface import IpInterface, beforeDeleteIpInterface
-
 
 def unindexBeforeDelete(ob, event):
     """
     Multisubscriber for IIndexed + IObjectWillBeMovedEvent
     """
     if not IObjectWillBeAddedEvent.providedBy(event):
-        if isinstance(ob, IpInterface):
-            beforeDeleteIpInterface(ob, event)
-        else:
-            ob.unindex_object()
+        ob.unindex_object()
 
 def indexAfterAddOrMove(ob, event):
     """

--- a/Products/ZenReports/Utilization.py
+++ b/Products/ZenReports/Utilization.py
@@ -10,7 +10,7 @@
 import logging
 
 from Products.ZenUtils import Time
-from Products.Zuul.interfaces.tree import  ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.AdvancedQuery import MatchGlob, And
 
 log = logging.getLogger("zen.Utilization")
@@ -56,7 +56,7 @@ def filteredDevices(context, args, *types):
 
     query = And(*filter) if filter else None
 
-    results = ICatalogTool(context).search(types, paths=organizer,
+    results = IModelCatalogTool(context).search(types, paths=organizer,
         query=query)
 
     for brain in results:

--- a/Products/ZenReports/plugins/monitoredcomponents.py
+++ b/Products/ZenReports/plugins/monitoredcomponents.py
@@ -9,7 +9,7 @@
 
 import transaction
 from Products.AdvancedQuery import Eq
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenReports.AliasPlugin import AliasPlugin
 from Products.ZenReports import Utils
 
@@ -23,7 +23,7 @@ class monitoredcomponents(AliasPlugin):
 
     def getSubComponents(self, dmd):
         i = 0
-        catalog = ICatalogTool(dmd.Devices)
+        catalog = IModelCatalogTool(dmd.Devices)
         COMPONENT = 'Products.ZenModel.DeviceComponent.DeviceComponent'
         query = Eq('monitored', '1')
         for brain in catalog.search(COMPONENT, query=query):

--- a/Products/ZenUtils/IpUtil.py
+++ b/Products/ZenUtils/IpUtil.py
@@ -582,3 +582,9 @@ def isRemotelyReachable(ip):
         return not ip_address.is_link_local and not ip_address.is_loopback
     except ValueError:
         return False
+
+def get_default_netmask(ip):
+    netmask = 24
+    if get_ip_version(ip) == 6:
+        netmask = 48
+    return netmask

--- a/Products/ZenUtils/Utils.py
+++ b/Products/ZenUtils/Utils.py
@@ -1747,6 +1747,20 @@ def getObjectsFromCatalog(catalog, query=None, log=None):
                 log.warn("Stale %s record: %s", catalog.id, brain.getPath())
 
 
+def getObjectsFromModelCatalog(catalog, query=None, log=None):
+    """
+    Generator that can be used to load objects out model catalog and skip
+    any objects that are no longer able to be loaded.
+    """
+    for brain in catalog.search(query=query):
+        try:
+            ob = brain.getObject()
+            yield ob
+        except (NotFound, KeyError, AttributeError):
+            if log:
+                log.warn("Stale record in Model Catalog: %s", brain.getPath())
+
+
 _LOADED_CONFIGS = set()
 
 

--- a/Products/Zuul/catalog/configure.zcml
+++ b/Products/Zuul/catalog/configure.zcml
@@ -48,6 +48,12 @@
         />
 
     <adapter
+        factory = ".paths.IpAddressPathReporter"
+        for = "Products.ZenModel.IpAddress.IpAddress"
+        provides = ".interfaces.IPathReporter"
+        />
+
+    <adapter
         factory = ".paths.ProcessPathReporter"
         for = "Products.ZenModel.OSProcess.OSProcess"
         provides = ".interfaces.IPathReporter"

--- a/Products/Zuul/catalog/configure.zcml
+++ b/Products/Zuul/catalog/configure.zcml
@@ -82,6 +82,10 @@
         class="Products.ZenModel.OSProcess.OSProcess"/>
 
     <five:implements
+        interface=".interfaces.ITreeSpanningComponent"
+        class="Products.ZenModel.IpAddress.IpAddress"/>
+
+    <five:implements
         interface=".interfaces.IDeviceOrganizer"
         class="Products.ZenModel.DeviceGroup.DeviceGroup"/>
 

--- a/Products/Zuul/catalog/events.py
+++ b/Products/Zuul/catalog/events.py
@@ -110,58 +110,47 @@ def onOrganizerBeforeDelete(ob, event):
         # from the indexes
         for device in ob.devices.objectValuesGen():
             notify(IndexingEvent(device, idxs=['path']))
-        
+
+
+#-------------------------------------------------------------
+#    Methods to deal with tree spanning components.
+#    When a tree spanning component is updated, we need
+#    to make sure that the object the component is linked
+#    to in the other tree is updated if needed
+#-------------------------------------------------------------
+
+
+class ObjectsAffectedBySpanningComponent(object):
+
+    def __init__(self, component):
+        self.component = component
+        self.peers = self._set_component_peers(component)
+
+    def _set_component_peers(self, component):
+        peers = []
+        if hasattr(component, "get_indexable_peers"):
+            peers = component.get_indexable_peers()
+            if not hasattr(peers, '__iter__'):
+                peers = [ peers ]
+        return peers
+
+    def index_affected_objects(self):
+        for peer in self.peers:
+            notify(IndexingEvent(peer))
+
 
 @adapter(ITreeSpanningComponent, IObjectWillBeMovedEvent)
 def onTreeSpanningComponentBeforeDelete(ob, event):
-    """
-    When a component that links a device to another tree is going to
-    be removed, update the device's paths.
-    """
+    """ Before tree spanning component is deleted """
     if not IObjectWillBeAddedEvent.providedBy(event):
-        component = ob
-        try:
-            catalog = ob.getPhysicalRoot().zport.global_catalog
-        except (KeyError, AttributeError):
-            # Migrate script hasn't run yet; ignore indexing
-            return
-        device = component.device()
-        if not device:
-            # OS relation has already been broken; get by path
-            path = component.getPrimaryPath()
-            try:
-                devpath = path[:path.index('devices')+2]
-                device = component.unrestrictedTraverse(devpath)
-            except ValueError:
-                # We've done our best. Give up.
-                return
-        if device:
-            oldpaths = devicePathsFromComponent(component)
-            catalog.unindex_object_from_paths(device, oldpaths)
-            # @TODO This wont work until we implement atomic updates
-            getUtility(IModelCatalog).unindex_object_from_paths(device, oldpaths)
+        ppath = "/".join(ob.getPrimaryPath())
+        affected_objects = ObjectsAffectedBySpanningComponent(ob)
+        affected_objects.index_affected_objects()
 
 
 @adapter(ITreeSpanningComponent, IObjectMovedEvent)
 def onTreeSpanningComponentAfterAddOrMove(ob, event):
+    """ When tree spanning component is added or moved """
     if not IObjectRemovedEvent.providedBy(event):
-        component = ob
-        try:
-            catalog = ob.getPhysicalRoot().zport.global_catalog
-        except (KeyError, AttributeError):
-            # Migrate script hasn't run yet; ignore indexing
-            return
-        device = component.device()
-        if not device:
-            # OS relation has been broken or doesn't exist yet; get by path
-            path = component.getPrimaryPath()
-            try:
-                devpath = path[:path.index('devices')+2]
-                device = component.unrestrictedTraverse(devpath)
-            except ValueError:
-                # We've done our best. Give up.
-                return
-        if device:
-            newpaths = devicePathsFromComponent(component)
-            catalog.index_object_under_paths(device, newpaths)
-            getUtility(IModelCatalog).index_object_under_paths(device, newpaths)
+        affected_objects = ObjectsAffectedBySpanningComponent(ob)
+        affected_objects.index_affected_objects()

--- a/Products/Zuul/catalog/indexable.py
+++ b/Products/Zuul/catalog/indexable.py
@@ -86,33 +86,33 @@ from zope.interface import ro
 
         IpInterfaceIndexable:
 
-            --------------------------------------------------------------------------------------------------------------
-            |  ATTR_NAME                         |  ATTR_QUERY_NAME                |  FIELD NAME     | INDEXED |  STORED |
-            --------------------------------------------------------------------------------------------------------------
-            |  idx_interfaceId                   |   interfaceId                   |                 |         |         |
-            |  idx_iface_decimal_ipAddress       |   iface_decimal_ipAddress       |                 |         |         |
-            |  idx_text_ipAddress                |   text_ipAddress                |                 |         |         |
-            |  idx_macAddresses                  |   macAddresses                  |                 |         |         |
-            |  idx_lanId                         |   lanId                         |                 |         |         |
-            |  idx_macaddress                    |   macaddress                    |                 |         |         |
-            |  idx_component_searchKeywords      |   NOINDEX_TYPE                  | DISABLE SUPERCLASS SPEC FIELD       |
-            |  idx_ipInterface_searchKeywords    |   searchKeywords                |                 |         |         |
-            |  idx_compoment_searchExcerpt       |   NOINDEX_TYPE                  | DISABLE SUPERCLASS SPEC FIELD       |
-            |  idx_ipInterface_searchExcerpt     |   searchExcerpt                 |                 |         |         |
-            --------------------------------------------------------------------------------------------------------------
+            -----------------------------------------------------------------------------------------------
+            |  ATTR_NAME                      |  ATTR_QUERY_NAME    |  FIELD NAME     | INDEXED |  STORED |
+            -----------------------------------------------------------------------------------------------
+            |  idx_interfaceId                |   interfaceId       |                 |         |         |
+            |  idx_decimal_ipAddress          |   decimal_ipAddress |                 |         |         |
+            |  idx_text_ipAddress             |   text_ipAddress    |                 |         |         |
+            |  idx_macAddresses               |   macAddresses      |                 |         |         |
+            |  idx_lanId                      |   lanId             |                 |         |         |
+            |  idx_macaddress                 |   macaddress        |                 |         |         |
+            |  idx_component_searchKeywords   |   NOINDEX_TYPE      | DISABLE SUPERCLASS SPEC FIELD       |
+            |  idx_ipInterface_searchKeywords |   searchKeywords    |                 |         |         |
+            |  idx_compoment_searchExcerpt    |   NOINDEX_TYPE      | DISABLE SUPERCLASS SPEC FIELD       |
+            |  idx_ipInterface_searchExcerpt  |   searchExcerpt     |                 |         |         |
+            -----------------------------------------------------------------------------------------------
 
         IpAddressIndexable:
 
-            ----------------------------------------------------------------------------------------------
-            |  ATTR_NAME                 |  ATTR_QUERY_NAME        |  FIELD NAME     | INDEXED |  STORED |
-            ----------------------------------------------------------------------------------------------
-            |   idx_interfaceId          |   interfaceId           |                 |         |         |
-            |   idx_ipAddressId          |   ipAddressId           |                 |         |         |
-            |   idx_networkId            |   networkId             |                 |         |         |
-            |   idx_deviceId             |   deviceId              |                 |         |         |
-            |   idx_ip_decimal_ipAddress |   ip_decimal_ipAddress  |                 |         |         |
-            |   idx_ipAddressAsText      |   ipAddressAsText       |                 |         |         |
-            ----------------------------------------------------------------------------------------------
+            -----------------------------------------------------------------------------------------
+            |  ATTR_NAME               |  ATTR_QUERY_NAME     |  FIELD NAME     | INDEXED |  STORED |
+            -----------------------------------------------------------------------------------------
+            |   idx_interfaceId        |   interfaceId        |                 |         |         |
+            |   idx_ipAddressId        |   ipAddressId        |                 |         |         |
+            |   idx_networkId          |   networkId          |                 |         |         |
+            |   idx_deviceId           |   deviceId           |                 |         |         |
+            |   idx_decimal_ipAddress  |   decimal_ipAddress  |                 |         |         |
+            |   idx_ipAddressAsText    |   ipAddressAsText    |                 |         |         |
+            -----------------------------------------------------------------------------------------
 
         IpNetworkIndexable:
 
@@ -380,8 +380,8 @@ class IpInterfaceIndexable(ComponentIndexable): # IpInterface inherits from this
         else:
             return None
 
-    @indexed(StringFieldType(stored=True, formatter=decimal_ipAddress_formatter), attr_query_name="iface_decimal_ipAddress") # Ip address as number
-    def idx_iface_decimal_ipAddress(self):
+    @indexed(StringFieldType(stored=True, formatter=decimal_ipAddress_formatter), attr_query_name="decimal_ipAddress") # Ip address as number
+    def idx_decimal_ipAddress(self):
         ip = self._idx_get_ip()
         if ip:
             return str(ipToDecimal(ip))
@@ -464,8 +464,8 @@ class IpAddressIndexable(object):  # IpAddress inherits from this class
 
     """ ipSearch catalog indexes """
 
-    @indexed(StringFieldType(stored=True, formatter=decimal_ipAddress_formatter), attr_query_name="ip_decimal_ipAddress")
-    def idx_ip_decimal_ipAddress(self):
+    @indexed(StringFieldType(stored=True, formatter=decimal_ipAddress_formatter), attr_query_name="decimal_ipAddress")
+    def idx_decimal_ipAddress(self):
         return str(self.ipAddressAsInt())
 
     @indexed(StringFieldType(stored=True), attr_query_name="ipAddressAsText")

--- a/Products/Zuul/catalog/indexable.py
+++ b/Products/Zuul/catalog/indexable.py
@@ -420,7 +420,7 @@ class IpAddressIndexable(object):  # IpAddress inherits from this class
     def idx_interfaceId(self):
         interface_id = None
         if self.interfaceId():
-            interface_id = self.interfaceId()
+            interface_id = self.interface().interfaceId()
         return interface_id
 
     @indexed(StringFieldType(stored=True), attr_query_name="ipAddressId")
@@ -438,6 +438,8 @@ class IpAddressIndexable(object):  # IpAddress inherits from this class
         if self.device():
             device_id = self.device().idx_uid()
         return device_id
+
+    """ ipSearch catalog indexes """
 
     @indexed(LongFieldType(stored=True), attr_query_name="ipAddressAsInt")
     def idx_ipAddressAsInt(self):

--- a/Products/Zuul/catalog/interfaces.py
+++ b/Products/Zuul/catalog/interfaces.py
@@ -33,6 +33,12 @@ class ITreeSpanningComponent(Interface):
         Return the device associated with this component.
         """
 
+    def get_indexable_peers():
+        """
+        return the other tree object/objects that need to be indexed when this
+         spanning component is updated
+        """
+
         
 class IDeviceOrganizer(Interface):
     """

--- a/Products/Zuul/catalog/model_catalog.py
+++ b/Products/Zuul/catalog/model_catalog.py
@@ -200,14 +200,6 @@ class ModelCatalog(object):
         catalog_client = self.get_client(obj)
         catalog_client.uncatalog_object(obj)
 
-    def unindex_object_from_paths(self, obj, paths):
-        # Remove paths from obj's paths
-        self.catalog_object(obj)  # @TODO this is very inefficient. REVISIT
-
-    def index_object_under_paths(self, obj, paths):
-        # Add paths to obj's paths
-        self.catalog_object(obj)  # @TODO this is very inefficient. REVISIT
-
 
 def register_model_catalog():
     """

--- a/Products/Zuul/catalog/model_catalog.py
+++ b/Products/Zuul/catalog/model_catalog.py
@@ -3,8 +3,11 @@ import logging
 import transaction
 import zope.component
 
+from Acquisition import aq_parent, Implicit
 from interfaces import IModelCatalog
 from collections import defaultdict
+from Products.AdvancedQuery import And, Or, Eq
+from Products.ZCatalog.interfaces import ICatalogBrain
 from Products.ZenModel.Software import Software
 from Products.ZenModel.OperatingSystem import OperatingSystem
 from Products.ZenUtils.GlobalConfig import getGlobalConfiguration
@@ -14,56 +17,126 @@ from zenoss.modelindex import indexed, index
 from zenoss.modelindex.field_types import StringFieldType, \
      ListOfStringsFieldType, IntFieldType, DictAsStringsFieldType, LongFieldType
 from zenoss.modelindex.constants import INDEX_UNIQUE_FIELD as UID
-from zenoss.modelindex.exceptions import IndexException
-from zenoss.modelindex.indexer import IndexTask, INDEX, UNINDEX
+from zenoss.modelindex.exceptions import IndexException, SearchException
+from zenoss.modelindex.indexer import ModelUpdate, INDEX, UNINDEX
+from zenoss.modelindex.searcher import SearchParams
 from zope.component import getGlobalSiteManager, getUtility
 from zope.interface import implements
+
+import traceback
 
 log = logging.getLogger("model_catalog")
 
 #logging.getLogger("requests").setLevel(logging.ERROR) # requests can be pretty chatty 
 
 
-class ModelCatalogUnavailableError(Exception):
-    def __init__(self, message = "Model Catalog not available"):
+class ModelCatalogError(Exception):
+    def __init__(self, message=""):
+        if not message:
+            message = "Model Catalog internal error"
+        super(ModelCatalogError, self).__init__(message)
+
+
+class ModelCatalogUnavailableError(ModelCatalogError):
+    def __init__(self, message = ""):
+        if not message:
+            message = "Model Catalog not available"
         super(ModelCatalogUnavailableError, self).__init__(message)
+
+
+class SearchResults(object):
+
+    def __init__(self, results, total, hash_, areBrains=True):
+        self.results = results
+        self.total = total
+        self.hash_ = hash_
+        self.areBrains = areBrains
+
+    def __hash__(self):
+        return self.hash_
+
+    def __iter__(self):
+        return self.results
+
+
+class ModelCatalogBrain(Implicit):
+    implements(ICatalogBrain)
+
+    def __init__(self, result):
+        """
+        Modelindex result wrapper
+        @param result: modelindex.zenoss.modelindex.search.SearchResult
+        """
+        self._result = result
+        for idx in result.idxs:
+            setattr(self, idx, getattr(result, idx, None))
+
+    def has_key(self, key):
+        return self.__contains__(key)
+
+    def __contains__(self, name):
+        return hasattr(self._result, name)
+
+    def getPath(self):
+        """ Get the physical path for this record """
+        uid = str(self._result.uid)
+        if not uid.startswith('/zport/dmd'):
+            uid = '/zport/dmd/' + uid
+        return uid
+
+    def _unrestrictedGetObject(self):
+        """ """
+        return self.getObject()
+
+    def getObject(self):
+        """Return the object for this record
+
+        Will return None if the object cannot be found via its cataloged path
+        (i.e., it was deleted or moved without recataloging), or if the user is
+        not authorized to access the object.
+        """
+        parent = aq_parent(self)
+        obj = None
+        try:
+            obj = parent.unrestrictedTraverse(self.getPath())
+        except:
+            log.error("Unable to get object from brain. Path: {0}. Catalog may be out of sync.".format(self._result.uid))
+        return obj
+
+    def getRID(self):
+        """Return the record ID for this object."""
+        return self._result.uuid
 
 
 class ModelCatalogClient(object):
 
     def __init__(self, solr_url):
-        # @TODO Should we collapse indexer and searcher in a unique connection?
-        # Since we have a client per thread we wont need search and index at the same time
-        self.indexer = zope.component.createObject('ModelIndexer', solr_url)
-        self.searcher = zope.component.createObject('ModelSearcher', solr_url)
-        self.data_manager = ModelCatalogDataManager(self)
+        self._data_manager = ModelCatalogDataManager(solr_url)
 
     def _get_forbidden_classes(self):
         return (Software, OperatingSystem)
 
-    def is_model_catalog_enabled(self):
-        return self.indexer is not None
+    def get_indexes(self):
+        return self._data_manager.get_indexes()
 
-    def getIndexes(): # Do we need to implement it?
-        pass
+    def search(self, search_params, context):
+        return self._data_manager.search(search_params, context)
 
     def catalog_object(self, obj, idxs=None):
-        if self.is_model_catalog_enabled() and \
-           not isinstance(obj, self._get_forbidden_classes()):
+        if not isinstance(obj, self._get_forbidden_classes()):
             try:
-                self.data_manager.add_task(IndexTask(obj, op=INDEX, idxs=idxs))
+                self._data_manager.add_model_update(ModelUpdate(obj, op=INDEX, idxs=idxs))
             except IndexException as e:
                 log.error("EXCEPTION {0} {1}".format(e, e.message))
-                raise ModelCatalogUnavailableError()
+                self._data_manager.raise_model_catalog_error()
 
     def uncatalog_object(self, obj):
-        if self.is_model_catalog_enabled() and \
-           not isinstance(obj, self._get_forbidden_classes()):
+        if not isinstance(obj, self._get_forbidden_classes()):
             try:
-                self.data_manager.add_task(IndexTask(obj, op=UNINDEX))
+                self._data_manager.add_model_update(ModelUpdate(obj, op=UNINDEX))
             except IndexException as e:
                 log.error("EXCEPTION {0} {1}".format(e, e.message))
-                raise ModelCatalogUnavailableError()
+                self._data_manager.raise_model_catalog_error()
 
 
 class NoRollbackSavepoint(object):
@@ -73,35 +146,240 @@ class NoRollbackSavepoint(object):
     def rollback(self):
         pass
 
-class ModelCatalogDataManager(object):
 
-    implements(IDataManager)
+TX_SEPARATOR = "@=@"
 
-    def __init__(self, model_catalog):
-        self.model_catalog = model_catalog
-        self.updated_objects_per_transaction = defaultdict(dict) # {transaction_id: {object_uid: [list of index tasks]  }}
-        # @TODO ^^ Make that an OOBTREE to avoid concurrency issues? I dont think we need it since we have one per thread
 
-    def reset_tx_state(self, tx):
-        tx_id = id(tx)
-        if tx_id in self.updated_objects_per_transaction:
-            del self.updated_objects_per_transaction[tx_id]
+class ModelCatalogTransactionState(object):
+    """ This class stores all the infromation about objects updated during a transaction """
 
-    def add_task(self, task):
-        tx = transaction.get()
-        tx_id = id(tx)
-        if tx_id not in self.updated_objects_per_transaction:
-            tx.join(self)
-
+    def __init__(self, tid):
+        """ """
+        self.tid = tid
         # @TODO For the time being we only have two index operations INDEX and UNINDEX
         # Once we are able to index only certain indexes and use solr
         # atomic updates this will become more complex in order to send as few requests to solr
         # as possible
         #
-        # we overwrite any previous operation since we can only index/unindex the whole object
+        # model_update may become a list of updates when we support more
+        # operations other than INDEX, UNINDEX
         #
-        self.updated_objects_per_transaction[tx_id][task.uid] = task
+        self.pending_updates = {}  # { object_uid :  model_update }
+        self.indexed_updates = {}  # { object_uid :  model_update }
+        # ^^
+        # In indexed_updates we store updates that we indexed mid transaction
+        # because a search came in. Only this transaction should see such changes
+        self.temp_indexed_uids = set() # uids (uid@=@tid) of temporary indexed documents
+        self.commits_metric = []
 
+    def add_model_update(self, update):
+        # When we support atomic updates the logic to combine multiple
+        # atomic updates for an object will be here. For now as we only can
+        # index/unindex the last update overwrites any previous one
+        #
+        self.pending_updates[update.uid]=update
+
+    def get_pending_updates(self):
+        """ return updates that have not been sent to the index """
+        return self.pending_updates.values()
+
+    def get_indexed_updates(self):
+        return self.indexed_updates.values()
+
+    def get_updates_to_finish_transaction(self):
+        #
+        self.commits_metric.append(len(self.pending_updates))
+        # Get all updates
+        final_updates = {}
+        for uid, update in self.indexed_updates.iteritems():
+            # update the uid and tx_state
+            if update.op == INDEX:
+                update.spec.set_field_value("uid", uid)
+                update.spec.set_field_value("tx_state", 0)
+            final_updates[uid] = update
+        # now update overwriting in case we had a new update for any
+        # of the already indexed objects
+        final_updates.update(self.pending_updates)
+        return final_updates.values()
+
+    def are_there_pending_updates(self):
+        return len(self.pending_updates) > 0
+
+    def are_there_indexed_updates(self):
+        return len(self.indexed_updates) > 0
+
+    def mark_pending_updates_as_indexed(self, indexed_uids):
+        """
+        @param indexed_uids: temporary uids we indexed the docs with
+        """
+        self.commits_metric.append(len(self.pending_updates))
+        self.temp_indexed_uids = self.temp_indexed_uids | indexed_uids
+        self.indexed_updates.update(self.pending_updates)
+        self.pending_updates = {} # clear pending updates
+        log.warn("SEARCH TRIGGERED TEMP INDEXING. {0}".format(traceback.format_stack()))   # @TODO TEMP LOGGING
+
+
+class ModelCatalogDataManager(object):
+    """ Class that interfaces with the modelindex package to interact with solr """
+
+    implements(IDataManager)
+
+    def __init__(self, solr_url):
+        # @TODO Should we collapse indexer and searcher in a unique connection?
+        # Since we have a client per thread we wont need search and index at the same time
+        self._indexer = zope.component.createObject('ModelIndexer', solr_url)
+        self._searcher = zope.component.createObject('ModelSearcher', solr_url)
+
+        self._current_transactions = {} # { transaction_id : ModelCatalogTransactionState }
+        # @TODO ^^ Make that an OOBTREE to avoid concurrency issues? I dont think we need it since we have one per thread
+
+    def _get_tid(self, tx=None):
+        if tx is None:
+            tx = transaction.get()
+        return id(tx)
+
+    def _get_tx_state(self, tx=None):
+        tid = self._get_tid(tx)
+        return self._current_transactions.get(tid)
+
+    def ping_index(self):
+        return self._indexer.ping()
+
+    def get_indexes(self): # Do we need to implement it?
+        return self._searcher.get_indexes()
+
+    def _process_pending_updates(self, tx_state):
+        updates = tx_state.get_pending_updates()
+        # we are going to index all pending updates adding
+        # the tid to the uid field and setting tx_state field
+        # to the tid
+        tweaked_updates = []
+        indexed_uids = set()
+        for update in updates:
+            tid = tx_state.tid
+            temp_uid = "{0}{1}{2}".format(update.uid, TX_SEPARATOR, tid)
+
+            # We only unindex docs that have been already modified
+            # unmodified docs marked for removal are not a problem since
+            # we blacklist them from searchs
+            if update.op == UNINDEX:
+                if temp_uid not in tx_state.temp_indexed_uids:
+                    continue
+                else:
+                    update.uid = temp_uid
+            else:
+                # Index the object with a special uid
+                update.spec.set_field_value("uid", temp_uid)
+                update.spec.set_field_value("tx_state", tid)
+                indexed_uids.add(temp_uid)
+            tweaked_updates.append(update)
+
+        # send and commit indexed docs to solr
+        self._indexer.process_model_updates(tweaked_updates)
+        # marked docs as indexed
+        tx_state.mark_pending_updates_as_indexed(indexed_uids)
+
+    def _add_tx_state_query(self, search_params, tx_state):
+        """
+        only interested in docs indexed by committed transactions or
+        in docs temporary committed by the current transaction
+        """
+        values = [ 0 ]  # default tx_state for committed transactions
+        if tx_state:
+            values.append(tx_state.tid)
+        if isinstance(search_params.query, dict):
+            search_params.query["tx_state"] = values
+        else: # We assume it is an AdvancedQuery
+            or_query = [ Eq("tx_state", value) for value in values]
+            search_params.query = And( search_params.query, Or(*or_query) )
+        return search_params
+
+    def raise_model_catalog_error(self, message=""):
+        if not self.ping_index():
+            raise ModelCatalogUnavailableError(message)
+        else:
+            raise ModelCatalogError(message)
+
+    def _parse_catalog_results(self, catalog_results, context):
+        """
+        build brains from model catalog results. It also
+        tweaks the results filtering outdated objects
+        """
+        tx_state = self._get_tx_state()
+        tweak_results = (tx_state and tx_state.are_there_indexed_updates())
+        dirty_uids = temp_indexed_uids = set()
+        if tweak_results:
+            dirty_uids = set(tx_state.indexed_updates.keys())
+            temp_indexed_uids = tx_state.temp_indexed_uids
+        brains = []
+        count = 0
+        for result in catalog_results.results:
+            if tweak_results:
+                if result.uid in dirty_uids:
+                    continue  # outdated result
+                elif result.uid in temp_indexed_uids:
+                    result.uid = result.uid.split(TX_SEPARATOR)[0]
+            brain = ModelCatalogBrain(result)
+            brain = brain.__of__(context.dmd)
+            brains.append(brain)
+            count = count + 1
+        return SearchResults(iter(brains), total=count, hash_=str(count))
+
+    def _do_search(self, search_params, context):
+        """
+        @param  context object to hook brains up to acquisition
+        """
+        try:
+            catalog_results = self._searcher.search(search_params)
+        except SearchException as e:
+            log.error("EXCEPTION: {0}".format(e.message))
+            self.raise_model_catalog_error()
+        return self._parse_catalog_results(catalog_results, context)
+
+    def search(self, search_params, context):
+        """
+        When we do a search mid-transaction and there are objects that have already been modified and not
+        indexed, we need to index and commit them before performing the search.
+        Mid-transaction changes can only be visible by the current transaction until the tx is committed.
+        Hopefully most transactions won't do searches after updating objects so we can minimize the number 
+        of commits to solr
+        """
+        search_results = None
+        tx_state = self._get_tx_state()
+        # Lets add tx_state filters
+        search_params = self._add_tx_state_query(search_params, tx_state)
+        if tx_state and tx_state.are_there_pending_updates():
+            # Temporary index updated objects so the search
+            # is accurate
+            self._process_pending_updates(tx_state)
+
+        return self._do_search(search_params, context)
+
+    # ----- Index related methods  ------
+
+    def reset_tx_state(self, tx):
+        tid = self._get_tid(tx)
+        if tid in self._current_transactions:
+            del self._current_transactions[tid]
+
+    def add_model_update(self, update):
+        tx = transaction.get()
+        tid = self._get_tid(tx)
+        if tid not in self._current_transactions:
+            tx.join(self)
+            self._current_transactions[tid] = ModelCatalogTransactionState(tid)
+        tx_state = self._current_transactions[tid]
+        tx_state.add_model_update(update)
+
+    def _delete_temporary_tx_documents(self):
+        tx_state = self._get_tx_state()
+        if tx_state and tx_state.are_there_indexed_updates():
+            try:
+                query = {"tx_state":tx_state.tid}
+                self._searcher.unindex_search(SearchParams(query))
+            except Exception as e:
+                log.fatal("Exception trying to abort current transaction. {0} / {1}".format(e, e.message))
+                raise ModelCatalogError("Model Catalog error trying to abort transaction")
 
     def abort(self, tx):
         try:
@@ -111,7 +389,7 @@ class ModelCatalogDataManager(object):
                 self._connection = None
                 c.close()
             """
-            pass
+            self._delete_temporary_tx_documents()
         finally:
             self.reset_tx_state(tx)
 
@@ -123,20 +401,23 @@ class ModelCatalogDataManager(object):
 
     def tpc_vote(self, transaction):
         # Check connection to SOLR
-        if not self.model_catalog.indexer.ping():
+        if not self.ping_index():
             raise ModelCatalogUnavailableError()
 
     def tpc_finish(self, transaction):
         try:
-            tx_id = id(transaction)
-            tx_objects = self.updated_objects_per_transaction[tx_id]
-
-            tasks = tx_objects.values()
-            try:
-                self.model_catalog.indexer.process_tasks(tasks)
-            except:
-                self.abort(transaction)
-                raise
+            tx_state = self._get_tx_state(transaction)
+            if tx_state:
+                updates = tx_state.get_updates_to_finish_transaction()
+                dirty_tx = tx_state.are_there_indexed_updates()
+                try:
+                    self._indexer.process_model_updates(updates)
+                    self._delete_temporary_tx_documents()
+                    # @TODO TEMP LOGGING
+                    log.warn("COMMIT_METRIC: {0}. MID-TX COMMITS? {1}".format(tx_state.commits_metric, dirty_tx))
+                except:
+                    self.abort(transaction)
+                    raise
         finally:
             self.reset_tx_state(transaction)
 
@@ -164,7 +445,7 @@ class ModelCatalog(object):
 
     def get_client(self, context):
         """
-        Retrieves/creates the solr client for the zope thread that is trying to index/unindex an object
+        Retrieves/creates the solr client for the zope thread that is trying to access solr
         """
         zodb_conn = context.get("_p_jar")
 

--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -136,8 +136,9 @@ class ModelCatalogTool(object):
 
         # Build query for paths
         if paths is not False:   # When paths is False we dont add any path condition
+            context_path = '/'.join(self.context.getPhysicalPath()) + '*'
             if not paths:
-                paths = ('/'.join(self.context.getPhysicalPath()) + '*', )
+                paths = (context_path, )
             elif isinstance(paths, basestring):
                 paths = (paths,)
 
@@ -148,7 +149,8 @@ class ModelCatalogTool(object):
             paths_query = Generic('path', q)
             """
             paths_query = In('path', paths)
-            partial_queries.append(paths_query)
+            uid_path_query = MatchGlob(UID, context_path)   # Add the context uid as filter
+            partial_queries.append( Or(paths_query, uid_path_query) )
 
         # filter based on permissions
         if filterPermissions and allowedRolesAndGroups(self.context):

--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -277,7 +277,7 @@ class ModelCatalogTool(object):
         query, _ = self._build_query(types=types, paths=(path,), filterPermissions=filterPermissions)
         search_results = self.search_model_catalog(query)
 
-        """ #  OLD CODEEE had some caching stuff
+        """ #  @TODO OLD CODEEE had some caching stuff
         # Check for a cache
         caches = self.catalog._v_caches
         types = (types,) if isinstance(types, basestring) else types
@@ -300,6 +300,9 @@ class ModelCatalogTool(object):
 
     def update(self, obj):
         self.model_catalog.catalog_object(obj)
+
+    def indexes(self):
+        return self.model_catalog.searcher.get_indexes()
 
 
 class ModelCatalogBrain(Implicit):

--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -2,35 +2,19 @@
 
 import logging
 
-from Acquisition import aq_parent, Implicit
+
 from interfaces import IModelCatalog, IModelCatalogTool
-from .model_catalog import ModelCatalogUnavailableError
 from Products.AdvancedQuery import Eq, Or, Generic, And, In, MatchRegexp, MatchGlob
-from Products.ZCatalog.interfaces import ICatalogBrain
+
 from Products.Zuul.catalog.interfaces import IModelCatalog
 from Products.Zuul.utils import dottedname, allowedRolesAndGroups
-from zenoss.modelindex.exceptions import SearchException
 from zenoss.modelindex.searcher import SearchParams
 from zenoss.modelindex.constants import INDEX_UNIQUE_FIELD as UID
 from zope.interface import implements
 from zope.component import getUtility
 
+
 log = logging.getLogger("model_catalog_tool")
-
-
-class SearchResults(object):
-
-    def __init__(self, results, total, hash_, areBrains=True):
-        self.results = results
-        self.total = total
-        self.hash_ = hash_
-        self.areBrains = areBrains
-
-    def __hash__(self):
-        return self.hash_
-
-    def __iter__(self):
-        return self.results
 
 
 class ModelCatalogTool(object):
@@ -40,11 +24,7 @@ class ModelCatalogTool(object):
 
     def __init__(self, context):
         self.context = context
-        self.model_catalog = getUtility(IModelCatalog).get_client(context)
-
-    def is_model_catalog_enabled(self):
-        return self.model_catalog.searcher is not None
-
+        self.model_catalog_client = getUtility(IModelCatalog).get_client(context)
 
     def _parse_user_query(self, query):
         """
@@ -82,7 +62,7 @@ class ModelCatalogTool(object):
 
         @return: tuple (AdvancedQuery query, not indexed filters dict)
         """
-        available_indexes = self.model_catalog.searcher.get_indexes()
+        available_indexes = self.model_catalog_client.get_indexes()
         not_indexed_user_filters = {} # Filters that use not indexed fields
 
         user_filters_query = None
@@ -161,7 +141,6 @@ class ModelCatalogTool(object):
         search_query = And(*partial_queries)
         return (search_query, not_indexed_user_filters)
 
-
     def search_model_catalog(self, query, start=0, limit=None, order_by=None, reverse=False):
         """
         @returns: SearchResults
@@ -170,22 +149,9 @@ class ModelCatalogTool(object):
         brains = []
         count = 0
         search_params = SearchParams(query, start=start, limit=limit, order_by=order_by, reverse=reverse)
-        try:
-            catalog_results = self.model_catalog.searcher.search(search_params)
-        except SearchException as e:
-            log.error("EXCEPTION: {0}".format(e.message))
-            raise ModelCatalogUnavailableError()
-            
-        else:
-            for result in catalog_results.results:
-                brain = ModelCatalogBrain(result)
-                brain = brain.__of__(self.context.dmd)
-                brains.append(brain)
-            count = catalog_results.total_count
+        catalog_results = self.model_catalog_client.search(search_params, self.context)
 
-        """   @TODO  Should we check for user permissions here in case user calls this method ??  """
-        return SearchResults(iter(brains), total=count, hash_=str(count))
-
+        return catalog_results
 
     def search(self, types=(), start=0, limit=None, orderby='name',
                reverse=False, paths=(), depth=None, query=None,
@@ -195,10 +161,7 @@ class ModelCatalogTool(object):
         @param query: Advanced Query query
         @param globFilters: dict {field: value}
         """
-        if not self.is_model_catalog_enabled():
-            return None
-        
-        available_indexes = self.model_catalog.searcher.get_indexes()
+        available_indexes = self.model_catalog_client.get_indexes()
         # if orderby is not an index then query results will be unbrained and sorted
         areBrains = orderby in available_indexes or orderby is None
         queryOrderby = orderby if areBrains else None
@@ -224,9 +187,6 @@ class ModelCatalogTool(object):
         Gets the brain representing the object defined at C{path}.
         The search is done by uid field
         """
-        if not self.is_model_catalog_enabled():
-            return None
-
         if not isinstance(path, (tuple, basestring)):
             path = '/'.join(path.getPhysicalPath())
         elif isinstance(path, tuple):
@@ -266,10 +226,6 @@ class ModelCatalogTool(object):
         @return: The number of children matching.
         @rtype: int
         """
-
-        if not self.is_model_catalog_enabled():
-            return None
-
         if path is None:
             path = '/'.join(self.context.getPhysicalPath())
         if not path.endswith('*'):
@@ -299,56 +255,8 @@ class ModelCatalogTool(object):
         return search_results.total
 
     def update(self, obj):
-        self.model_catalog.catalog_object(obj)
+        self.model_catalog_client.catalog_object(obj)
 
     def indexes(self):
-        return self.model_catalog.searcher.get_indexes()
+        return self.model_catalog_client.get_indexes()
 
-
-class ModelCatalogBrain(Implicit):
-    implements(ICatalogBrain)
-    
-    def __init__(self, result):
-        """
-        Modelindex result wrapper
-        @param result: modelindex.zenoss.modelindex.search.SearchResult
-        """
-        self._result = result
-        for idx in result.idxs:
-            setattr(self, idx, getattr(result, idx, None))
-
-    def has_key(self, key):
-        return self.__contains__(key)
-
-    def __contains__(self, name):
-        return hasattr(self._result, name)
-
-    def getPath(self):
-        """ Get the physical path for this record """
-        uid = str(self._result.uid)
-        if not uid.startswith('/zport/dmd'):
-            uid = '/zport/dmd/' + uid
-        return uid
-
-    def _unrestrictedGetObject(self):
-        """ """
-        return self.getObject()
-
-    def getObject(self):
-        """Return the object for this record
-
-        Will return None if the object cannot be found via its cataloged path
-        (i.e., it was deleted or moved without recataloging), or if the user is
-        not authorized to access the object.
-        """
-        parent = aq_parent(self)
-        obj = None
-        try:
-            obj = parent.unrestrictedTraverse(self.getPath()) 
-        except:
-            log.error("Unable to get object from brain. Path: {0}. Catalog may be out of sync.".format(self._result.uid))
-        return obj
-
-    def getRID(self):
-        """Return the record ID for this object."""
-        return self._result.uuid

--- a/Products/Zuul/catalog/paths.py
+++ b/Products/Zuul/catalog/paths.py
@@ -83,7 +83,10 @@ class InterfacePathReporter(DefaultPathReporter):
 
 class IpAddressPathReporter(DefaultPathReporter):
     def getPaths(self):
-        return [ self.context.getPrimaryPath() ]
+        paths = [ ]
+        if self.context.interface(): 
+            paths.append(self.context.interface().getPrimaryPath() + ('ipaddresses',))
+        return paths
 
 
 class ProcessPathReporter(DefaultPathReporter):

--- a/Products/Zuul/catalog/paths.py
+++ b/Products/Zuul/catalog/paths.py
@@ -33,7 +33,7 @@ def relPath(obj, relname):
 
 def devicePathsFromComponent(comp):
     c_paths = IPathReporter(comp).getPaths()
-    return [path + ('device',) for path in c_paths[1:]]
+    return [path + ('device',) for path in c_paths]
 
 
 class DefaultPathReporter(object):
@@ -79,6 +79,11 @@ class InterfacePathReporter(DefaultPathReporter):
         for ip in self.context.ipaddresses.objectValuesGen():
             paths.extend(relPath(ip, 'network'))
         return paths
+
+
+class IpAddressPathReporter(DefaultPathReporter):
+    def getPaths(self):
+        return [ self.context.getPrimaryPath() ]
 
 
 class ProcessPathReporter(DefaultPathReporter):

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -177,7 +177,7 @@ class TreeFacade(ZuulFacade):
                 else:
                     if numbip(ip):
                         minip, maxip = getSubnetBounds(ip)
-                        qs.append(Between('ipAddress', str(minip), str(maxip)))
+                        qs.append(Between('decimal_ipAddress', str(minip), str(maxip)))
             # ZEN-10057 - move filtering on indexed groups/systems/location from post-filter to query
             elif key in organizersToClass:
                 organizerQuery = self.findMatchingOrganizers(organizersToClass[key], organizersToPath[key], value)

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -13,7 +13,7 @@ Zuul facades are part of the Python API.  The main functions of facades are
 objects representing objects related to the retrieved object, and (2) given an
 info object bind its properties to a ZenModel object and save it. The UID is
 typically an acquisition path, e.g. '/zport/dmd/Devices'. Facades use an
-ICatalogTool to search for the ZenModel object using the UID.
+IModelCatalogTool to search for the ZenModel object using the UID.
 
 Documentation for the classes and methods in this module can be found in the
 definition of the interface that they implement.
@@ -28,10 +28,10 @@ from OFS.ObjectManager import checkValidId
 from zope.interface import implements
 from Products.ZenModel.DeviceOrganizer import DeviceOrganizer
 from Products.ZenModel.ComponentOrganizer import ComponentOrganizer
-from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, Generic
+from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, In
 from Products.Zuul.interfaces import IFacade, ITreeNode
 from Products.Zuul.interfaces import (
-    ITreeFacade, IInfo, ICatalogTool, IOrganizerInfo
+    ITreeFacade, IInfo, IOrganizerInfo
 )
 from Products.Zuul.utils import unbrain, get_dmd, UncataloguedObjectException
 from Products.Zuul.tree import SearchResults
@@ -136,7 +136,7 @@ class TreeFacade(ZuulFacade):
         raise NotImplementedError
 
     def deviceCount(self, uid=None):
-        cat = ICatalogTool(self._getObject(uid))
+        cat = IModelCatalogTool(self._getObject(uid))
         return cat.count('Products.ZenModel.Device.Device')
 
     def validRegex(self, r):
@@ -148,18 +148,18 @@ class TreeFacade(ZuulFacade):
 
     def findMatchingOrganizers(self, organizerClass, organizerPath, userFilter):
         filterRegex = '(?i)^%s.*%s.*' % (organizerPath, userFilter)
+        filterRegex = '/zport/dmd/{0}*{1}*'.format(organizerPath, userFilter)
         if self.validRegex(filterRegex):
             orgquery = (Eq('objectImplements','Products.ZenModel.%s.%s' % (organizerClass, organizerClass)) &
                         MatchRegexp('uid', filterRegex))
-            paths = [b.getPath() for b in ICatalogTool(self._dmd).search(query=orgquery)]
+            paths = [ "{0}/*".format(b.getPath()) for b in IModelCatalogTool(self._dmd).search(query=orgquery)]
             if paths:
-                return Generic('path', {'query':paths})
+                return In('path', paths)
 
     def getDeviceBrains(self, uid=None, start=0, limit=50, sort='name',
                         dir='ASC', params=None, hashcheck=None):
 
-        #cat = ICatalogTool(self._getObject(uid))
-        cat = IModelCatalogTool(self._getObject(uid)) # Lets use solr instead
+        cat = IModelCatalogTool(self._getObject(uid))
 
         reverse = bool(dir == 'DESC')
         qs = []
@@ -222,7 +222,7 @@ class TreeFacade(ZuulFacade):
     def getInstances(self, uid=None, start=0, limit=50, sort='name',
                      dir='ASC', params=None):
         # do the catalog search
-        cat = ICatalogTool(self._getObject(uid))
+        cat = IModelCatalogTool(self._getObject(uid))
         reverse = bool(dir == 'DESC')
         brains = cat.search(self._instanceClass, start=start, limit=limit,
                             orderby=sort, reverse=reverse)

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -154,6 +154,35 @@ class DeviceFacade(TreeFacade):
                 results.append(comp)
         return results
 
+    def _get_component_brains_from_model_catalog(self, uid, meta_type=()):
+        """ """
+        model_catalog = IModelCatalogTool(self.context.dmd)
+        query = {}
+        if meta_type:
+            query["meta_type"] = meta_type
+        query["objectImplements"] = "Products.ZenModel.DeviceComponent.DeviceComponent"
+        query["deviceId"] = uid
+        model_query_results = model_catalog.search(query=query)
+        brains = [ brain for brain in model_query_results.results ]
+        return brains
+
+    def _get_component_brains_from_zcatalog(self, uid, meta_type=()):
+        """ """
+        querySet = []
+        if meta_type:
+            querySet.append(Or(*(Eq('meta_type', t) for t in meta_type)))
+        querySet.append(Generic('getAllPaths', uid))
+        query = And(*querySet)
+        obj = self._getObject(uid)
+        if getattr(aq_base(obj.device()), 'componentSearch', None) is None:
+            obj.device()._create_componentSearch()
+
+        cat = obj.device().componentSearch
+        if 'getAllPaths' not in cat.indexes():
+            obj.device()._createComponentSearchPathIndex()
+        brains = cat.evalAdvancedQuery(query)
+        return brains
+
     def _componentSearch(self, uid=None, types=(), meta_type=(), start=0,
                          limit=None, sort='name', dir='ASC', name=None, keys=()):
         reverse = dir=='DESC'
@@ -161,31 +190,11 @@ class DeviceFacade(TreeFacade):
             types = (types,)
         if isinstance(meta_type, basestring):
             meta_type = (meta_type,)
-        """
-        querySet = []
-        if meta_type:
-            querySet.append(Or(*(Eq('meta_type', t) for t in meta_type)))
-        querySet.append(Generic('getAllPaths', uid))
-        query = And(*querySet)
-        obj = self._getObject(uid)
 
-        cat = obj.device().componentSearch
-        if 'getAllPaths' not in cat.indexes():
-            obj.device()._createComponentSearchPathIndex()
-        brains = cat.evalAdvancedQuery(query)
-        """
-        #--------------------------------------------------------------
-        # Lets use model catalog instead  @TODO remove old code
-        #--------------------------------------------------------------
-        model_catalog = IModelCatalogTool(self.context.dmd)
-        querySet = []
-        if meta_type:
-            querySet.append(Or(*(Eq('meta_type', t) for t in meta_type)))
-        querySet.append(Generic('path', uid))
-        model_query = And(*querySet)
-        model_query_results = model_catalog.search(query=model_query)
-        brains = [ brain for brain in model_query_results.results ]
-        #--------------------------------------------------------------
+        brains = self._get_component_brains_from_zcatalog(uid, meta_type)
+
+        # @TODO Improve this method. Using solr we can pass start, limit etc
+        # so we dont retrieve all the results and then slice/sort them
 
         # unbrain the results
         comps=map(IInfo, map(unbrain, brains))
@@ -258,22 +267,10 @@ class DeviceFacade(TreeFacade):
                 for key, val in record.iteritems():
                     info.setBulkLoadProperty(key, val)
 
-    def getComponentTree(self, uid):
-        from Products.ZenEvents.EventManagerBase import EventManagerBase
+    def _get_component_types_from_model_catalog(self, uid):
+        """ """
         componentTypes = {}
         uuidMap = {}
-
-        """
-        dev = self._getObject(uid)
-        for brain in dev.componentSearch():
-            uuidMap[brain.getUUID] = brain.meta_type
-            compType = componentTypes.setdefault(brain.meta_type, { 'count' : 0, 'severity' : 0 })
-            compType['count'] += 1
-        """
-
-        #------------------------------------------------------------------------------------------
-        # Let's use model catalog instead      @TODO remove old code
-        #------------------------------------------------------------------------------------------
         model_catalog = IModelCatalogTool(self.context.dmd)
         model_query = Eq('objectImplements', "Products.ZenModel.DeviceComponent.DeviceComponent")
         model_query = And(model_query, Eq("deviceId", uid))
@@ -283,8 +280,23 @@ class DeviceFacade(TreeFacade):
             uuidMap[brain.uuid] = brain.meta_type
             compType = componentTypes.setdefault(brain.meta_type, { 'count' : 0, 'severity' : 0 })
             compType['count'] += 1
+        return (componentTypes, uuidMap)
 
-        #------------------------------------------------------------------------------------------
+    def _get_component_types_from_zcatalog(self, uid):
+        """ """
+        componentTypes = {}
+        uuidMap = {}
+        dev = self._getObject(uid)
+        for brain in dev.componentSearch():
+            uuidMap[brain.getUUID] = brain.meta_type
+            compType = componentTypes.setdefault(brain.meta_type, { 'count' : 0, 'severity' : 0 })
+            compType['count'] += 1
+        return (componentTypes, uuidMap)
+
+    def getComponentTree(self, uid):
+        from Products.ZenEvents.EventManagerBase import EventManagerBase
+
+        componentTypes, uuidMap = self._get_component_types_from_zcatalog(uid)
 
         # Do one big lookup of component events and merge back in to type later
         if not uuidMap:

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -22,7 +22,7 @@ from Products.AdvancedQuery import Eq, Or, Generic, And
 from Products.Zuul.decorators import info
 from Products.Zuul.utils import unbrain
 from Products.Zuul.facades import TreeFacade
-from Products.Zuul.interfaces import IDeviceFacade, ICatalogTool, IInfo, ITemplateNode, IMetricServiceGraphDefinition
+from Products.Zuul.interfaces import IDeviceFacade, IInfo, ITemplateNode, IMetricServiceGraphDefinition
 from Products.Jobber.facade import FacadeMethodJob
 from Products.Jobber.jobs import SubprocessJob
 from Products.Zuul.tree import SearchResults
@@ -321,7 +321,7 @@ class DeviceFacade(TreeFacade):
         return result
 
     def getDeviceUids(self, uid):
-        cat = ICatalogTool(self._getObject(uid))
+        cat = IModelCatalogTool(self._getObject(uid))
         return [b.getPath() for b in cat.search('Products.ZenModel.Device.Device')]
 
     def deleteComponents(self, uids):
@@ -877,7 +877,7 @@ class DeviceFacade(TreeFacade):
         This clears the geocode cache by reseting the latlong property of
         all locations.
         """
-        results = ICatalogTool(self._dmd.Locations).search('Products.ZenModel.Location.Location')
+        results = IModelCatalogTool(self._dmd.Locations).search('Products.ZenModel.Location.Location')
         for brain in results:
             try:
                 brain.getObject().latlong = None

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -532,6 +532,7 @@ class DeviceFacade(TreeFacade):
             return self._moveDevices(uids, target)
 
     def getDeviceByIpAddress(self, deviceName, collector="localhost", ipAddress=""):
+
         # convert device name to an ip address
         if not ipAddress:
             if isip(deviceName):
@@ -544,10 +545,11 @@ class DeviceFacade(TreeFacade):
                     return self.context.Devices.findDeviceByIdExact(deviceName)
 
         # find a device with the same ip on the same collector
-        query = Eq('getDeviceIp', ipAddress)
-        cat = self.context.Devices.deviceSearch
-        brains = cat.evalAdvancedQuery(query)
-        for brain in brains:
+        cat = IModelCatalogTool(self.context.Devices)
+        query = Eq('text_ipAddress', ipAddress)
+        search_results = cat.search(query=query)
+
+        for brain in search_results.results:
             if brain.getObject().getPerformanceServerName() == collector:
                 return brain.getObject()
 

--- a/Products/Zuul/facades/networkfacade.py
+++ b/Products/Zuul/facades/networkfacade.py
@@ -16,9 +16,9 @@ from Products.ZenWidgets.messaging import IMessageSender
 from Products.Jobber.jobs import SubprocessJob
 from Products.ZenUtils.Utils import binPath
 from Products.Zuul import getFacade
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.facades import TreeFacade
-from Products.Zuul.interfaces import ITreeFacade, INetworkFacade
-from Products.Zuul.interfaces import IInfo, ICatalogTool
+from Products.Zuul.interfaces import IInfo, ITreeFacade, INetworkFacade
 from Products.Zuul.decorators import info
 from Products.Zuul.utils import unbrain
 from Products.Zuul.tree import SearchResults
@@ -123,7 +123,7 @@ class NetworkFacade(TreeFacade):
     def getIpAddresses(self, limit=0, start=0, sort='ipAddressAsInt', dir='DESC',
               params=None, uid=None, criteria=()):
         infos = []
-        cat = ICatalogTool(self._getObject(uid))
+        cat = IModelCatalogTool(self._getObject(uid))
         reverse = dir=='DESC'
 
         brains = cat.search("Products.ZenModel.IpAddress.IpAddress",

--- a/Products/Zuul/facades/networkfacade.py
+++ b/Products/Zuul/facades/networkfacade.py
@@ -65,16 +65,9 @@ class NetworkFacade(TreeFacade):
             raise TypeError('Netmask must be an integer')
 
         netRoot = self._root.restrictedTraverse(contextUid).getNetworkRoot()
-        foundNet = netRoot.findNet(netip, netmask)
 
-        if foundNet:
-            return foundNet
+        return netRoot.getNet(netip, netmask)
 
-        gotNet = netRoot.getNet(netip)
-        if gotNet and gotNet.netmask == netmask:
-            return gotNet
-
-        return None
 
     def deleteSubnet(self, uid):
         toDel = self._dmd.restrictedTraverse(uid)

--- a/Products/Zuul/facades/servicefacade.py
+++ b/Products/Zuul/facades/servicefacade.py
@@ -11,7 +11,6 @@
 import logging
 import re
 from zope.interface import implements
-from Products.AdvancedQuery import MatchRegexp, And
 from Products.ZenModel.ServiceClass import ServiceClass
 from Products.ZenModel.IpServiceClass import IpServiceClass
 from Products.ZenModel.WinServiceClass import WinServiceClass
@@ -20,8 +19,8 @@ from Products.Zuul.facades import TreeFacade
 from Products.Zuul.utils import unbrain, UncataloguedObjectException
 from Products.Zuul.utils import safe_hasattr
 from Products.Zuul.decorators import info
-from Products.Zuul.interfaces import ITreeFacade, IServiceFacade
-from Products.Zuul.interfaces import IInfo, ICatalogTool
+from Products.Zuul.interfaces import IInfo, ITreeFacade, IServiceFacade
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.infos.service import ServiceOrganizerNode
 from Acquisition import aq_base, aq_parent
 
@@ -76,18 +75,13 @@ class ServiceFacade(TreeFacade):
 
     def _serviceSearch(self, limit=None, start=None, sort='name', dir='ASC',
               params=None, uid=None, criteria=()):
-        cat = ICatalogTool(self._getObject(uid))
+        cat = IModelCatalogTool(self._getObject(uid))
         reverse = dir=='DESC'
-
-        qs = []
-        query = None
+        query = {}
         if params:
-            if 'name' in params:
-                qs.append(MatchRegexp('name', '(?i).*%s.*' % params['name']))
-            if 'port' in params:
-                qs.append(MatchRegexp('port', '(?i).*%s.*' % params['port']))
-        if qs:
-            query = And(*qs)
+            for param in [ 'name', 'port' ]:
+                if params.get(param):
+                    query[param] = "*{0}*".format(params.get(param))
 
         return cat.search("Products.ZenModel.ServiceClass.ServiceClass",
                           start=start, limit=limit, orderby=sort,

--- a/Products/Zuul/facades/templatefacade.py
+++ b/Products/Zuul/facades/templatefacade.py
@@ -15,7 +15,8 @@ from zope.interface import implements
 from Products.AdvancedQuery import Eq
 from Products.ZenUtils.Utils import prepId
 from Products import Zuul
-from Products.Zuul.interfaces import ITemplateFacade, ICatalogTool, ITemplateNode, IRRDDataSourceInfo, \
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
+from Products.Zuul.interfaces import ITemplateFacade, ITemplateNode, IRRDDataSourceInfo, \
     IDataPointInfo, IThresholdInfo, IGraphInfo, IInfo, ITemplateLeaf, IGraphPointInfo
 from Products.Zuul.infos.template import SNMPDataSourceInfo, CommandDataSourceInfo, DeviceClassTemplateNode
 from Products.Zuul.utils import unbrain, safe_hasattr as hasattr, UncataloguedObjectException
@@ -31,7 +32,6 @@ from Products.ZenModel.GraphDefinition import GraphDefinition
 from Products.ZenModel.GraphPoint import GraphPoint
 from Products.ZenModel.DataPointGraphPoint import DataPointGraphPoint
 from Products.ZenModel.DeviceClass import DeviceClass
-
 
 log = logging.getLogger('zen.TemplateFacade')
 
@@ -50,7 +50,7 @@ class TemplateFacade(ZuulFacade):
         for brain in brains:
             if brain.id not in nodes:
                 try:
-                    nodes[brain.id] = ITemplateNode(brain.getObject())
+                    nodes[str(brain.id)] = ITemplateNode(brain.getObject())
                 except UncataloguedObjectException:
                     pass
         for key in sorted(nodes.keys(), key=str.lower):
@@ -91,7 +91,7 @@ class TemplateFacade(ZuulFacade):
         """
         @returns list of targets for our new template
         """
-        cat = ICatalogTool(self._dmd)
+        cat = IModelCatalogTool(self._dmd)
         results = []
         # it can be any device class that we add the template too
         brains = cat.search(types=[DeviceClass])
@@ -408,7 +408,7 @@ class TemplateFacade(ZuulFacade):
         return graph.manage_addDataPointGraphPoints([d.name() for d in datapoints], includeThresholds)
 
     def getCopyTargets(self, uid, query=''):
-        catalog = ICatalogTool(self._dmd)
+        catalog = IModelCatalogTool(self._dmd)
         template = self._getObject(uid)
         types = ['Products.ZenModel.DeviceClass.DeviceClass']
         brains = catalog.search(types=types)
@@ -530,7 +530,7 @@ class TemplateFacade(ZuulFacade):
 
     def _getCatalog(self, uid):
         obj = self._getObject(uid)
-        return ICatalogTool(obj)
+        return IModelCatalogTool(obj)
 
     def _getTemplate(self, uid):
         obj = self._getObject(uid)

--- a/Products/Zuul/facades/zenpackfacade.py
+++ b/Products/Zuul/facades/zenpackfacade.py
@@ -12,7 +12,7 @@ import logging
 from Products.Zuul.facades import ZuulFacade
 from itertools import ifilter
 from itertools import imap
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.interfaces.info import IInfo
 from Products.Zuul.utils import unbrain
 from Products.ZenModel.ZenPack import ZenPack
@@ -22,8 +22,8 @@ log = logging.getLogger('zen.ZenPackFacade')
 
 class ZenPackFacade(ZuulFacade):
 
-    def getDevelopmentZenPacks(self, uid='/zport/dmd/ZenPackManager'): 
-        catalog = ICatalogTool(self._dmd.unrestrictedTraverse(uid))
+    def getDevelopmentZenPacks(self, uid='/zport/dmd/ZenPackManager'):
+        catalog = IModelCatalogTool(self._dmd.unrestrictedTraverse(uid))
         brains = catalog.search(types=ZenPack)
         zenpacks = imap(unbrain, brains)
         return ifilter(lambda zp: zp.isDevelopment(), zenpacks)

--- a/Products/Zuul/infos/event.py
+++ b/Products/Zuul/infos/event.py
@@ -15,7 +15,7 @@ from zenoss.protocols.protobufutil import ProtobufEnum
 from zenoss.protocols.services.zep import EventStatus
 from Products.ZenUtils.Time import isoDateTimeFromMilli
 from Products.ZenEvents.events2.proxy import EventProxy
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenUtils.guid.interfaces import IGUIDManager
 from Products.Zuul.interfaces import IMarshallable
 from lxml.html.clean import clean_html
@@ -65,7 +65,7 @@ class EventCompatInfo(object):
         self._eventOccurrence = event_summary['occurrence'][0]
         self._eventActor = self._eventOccurrence['actor']
         self._eventDetails = self._findDetails(self._eventOccurrence)
-        self._catalog = ICatalogTool(dmd)
+        self._catalog = IModelCatalogTool(dmd)
         self._manager = IGUIDManager(dmd)
 
     @property

--- a/Products/Zuul/infos/mib.py
+++ b/Products/Zuul/infos/mib.py
@@ -16,7 +16,8 @@ from zope.interface import implements
 from Products.Zuul.tree import TreeNode
 from Products.Zuul.infos import InfoBase, ProxyProperty
 from Products.Zuul.interfaces import IMibInfo, IMibOrganizerNode, IMibNode
-from Products.Zuul.interfaces import ICatalogTool, IMibOrganizerInfo, IMibNodeInfo, IMibNotificationInfo
+from Products.Zuul.interfaces import IMibOrganizerInfo, IMibNodeInfo, IMibNotificationInfo
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenModel.MibOrganizer import MibOrganizer
 from Products.ZenModel.MibModule import MibModule
 from Products.ZenModel.MibBase import MibBase
@@ -29,7 +30,7 @@ class MibOrganizerNode(TreeNode):
     @property
     def text(self):
         text = super(MibOrganizerNode, self).text
-        count = ICatalogTool(self._object).count((MibModule,), self.uid)
+        count = IModelCatalogTool(self._object).count((MibModule,), self.uid)
         return {'text': text, 'count': count}
 
     @property

--- a/Products/Zuul/routers/__init__.py
+++ b/Products/Zuul/routers/__init__.py
@@ -14,7 +14,7 @@ Zenoss JSON API
 
 from Products.ZenUtils.Ext import DirectRouter, DirectResponse
 from Products.Zuul.decorators import contextRequire
-from Products.Zuul.interfaces.tree import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.marshalling import Marshaller
 from Products.ZenModel.DeviceClass import DeviceClass
 from Products.ZenModel.System import System
@@ -94,7 +94,7 @@ class TreeRouter(DirectRouter):
         # Trac #29148: When we delete a DeviceClass we also delete its devices
         #     and child device classes and their devices, so audit them all.
         if isinstance(node, DeviceClass):
-            childBrains = ICatalogTool(node).search((
+            childBrains = IModelCatalogTool(node).search((
                 'Products.ZenModel.DeviceClass.DeviceClass',
                 'Products.ZenModel.Device.Device',
             ))

--- a/Products/Zuul/routers/report.py
+++ b/Products/Zuul/routers/report.py
@@ -25,7 +25,7 @@ from Products.Zuul.routers import TreeRouter
 from Products import Zuul
 from Products.ZenModel.ReportClass import ReportClass
 from Products.ZenModel.BaseReport import BaseReport
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 log = logging.getLogger('zen.ReportRouter')
 
@@ -138,7 +138,7 @@ class ReportRouter(TreeRouter):
 
         # Getting all of the child nodes for auditing purposes
         node = self.context.dmd.unrestrictedTraverse(uid)
-        brains = ICatalogTool(node).search((ReportClass,BaseReport))
+        brains = IModelCatalogTool(node).search((ReportClass,BaseReport))
         family = []
         for brain in brains:
             family.append([brain.getPath(), isinstance(brain.getObject(), ReportClass)])

--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -34,7 +34,7 @@ from Products.ZenUtils.deprecated import deprecated
 from Products.Zuul.utils import resolve_context
 from Products.Zuul.utils import ZuulMessageFactory as _t
 from Products.ZenUI3.browser.eventconsole.grid import column_config
-from Products.Zuul.interfaces import ICatalogTool
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.infos.event import EventCompatInfo, EventCompatDetailInfo
 from zenoss.protocols.services import ServiceResponseError
 from lxml.html.clean import clean_html
@@ -200,7 +200,7 @@ class EventsRouter(DirectRouter):
     def __init__(self, context, request):
         super(EventsRouter, self).__init__(context, request)
         self.zep = Zuul.getFacade('zep', context)
-        self.catalog = ICatalogTool(context)
+        self.catalog = IModelCatalogTool(context)
         self.manager = IGUIDManager(context.dmd)
         self._filterParser = _FilterParser(self.zep)
 

--- a/Products/Zuul/tree.py
+++ b/Products/Zuul/tree.py
@@ -17,6 +17,7 @@ from BTrees.OOBTree import OOBTree
 from BTrees.IIBTree import IIBTree
 from Products.AdvancedQuery import Eq, Or, Generic, And, In, MatchRegexp
 from Products.ZCatalog.interfaces import ICatalogBrain
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.interfaces import ITreeNode, ICatalogTool, IInfo
 from Products.Zuul.utils import dottedname, unbrain, allowedRolesAndGroups
 from Products.Zuul.utils import UncataloguedObjectException, PathIndexCache
@@ -42,7 +43,7 @@ class TreeNode(object):
         if getattr(self._root, '_ob_cache', None) is None:
             self._root._ob_cache = {}
         if not ICatalogBrain.providedBy(ob):
-            brain = ICatalogTool(ob).getBrain(ob)
+            brain = IModelCatalogTool(ob).getBrain(ob)
             if brain is None:
                 raise UncataloguedObjectException(ob)
             # We already have the object - cache it here so _get_object doesn't

--- a/Products/Zuul/utils.py
+++ b/Products/Zuul/utils.py
@@ -367,9 +367,9 @@ class PathIndexCache(object):
 
     @classmethod
     def test(self, dmd):
-        from Products.Zuul.interfaces import ICatalogTool
-        results = ICatalogTool(dmd.Devices).search('Products.ZenModel.DeviceOrganizer.DeviceOrganizer')
-        instances = ICatalogTool(dmd.Devices).search('Products.ZenModel.Device.Device')
+        from Products.Zuul.catalog.interfaces import IModelCatalogTool
+        results = IModelCatalogTool(dmd.Devices).search('Products.ZenModel.DeviceOrganizer.DeviceOrganizer')
+        instances = IModelCatalogTool(dmd.Devices).search('Products.ZenModel.Device.Device')
         tree = PathIndexCache(results, instances, 'devices')
         print tree
 

--- a/bin/monitored-datapoints
+++ b/bin/monitored-datapoints
@@ -27,7 +27,8 @@ from Products.ZenModel.Device import Device
 from Products.ZenModel.DeviceComponent import DeviceComponent
 from Products.ZenUtils.ZenScriptBase import ZenScriptBase
 from Products.ZenUtils.Utils import unused
-from Products.Zuul.interfaces import ICatalogTool
+
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 unused(Globals)
 
@@ -172,7 +173,7 @@ class MonitoredDataPointReporter(ZenScriptBase):
         # Connect to ZODB.
         self.connect()
 
-        total = ICatalogTool(self.dmd.Devices).search(
+        total = IModelCatalogTool(self.dmd.Devices).search(
             types=[Device, DeviceComponent]).total
 
         self.log.info("starting: %s total devices and components", total)


### PR DESCRIPTION
- Add method get_indexable_peers to ITreeSpanningComponent. The method returns the objects on the other tree of an ITreeSpanningComponent that must be indexed when the tree spanning component is updated
- Added interface IObjectEventsSubscriber. Objects that need to perform any actions when Zope object events happen will implement this interface instead of adding such actions to the index_object /unindex_object methods
- Fix IpAddresses path being indexed under the path relative to the ip inteface instead of the primary path
- Minor tweaks to model_catalog and model_catalog_tool
- Allow passing basic queries in dict format
- Remove layer3 and ipSearch ZCatalogs
- Remove layer2 ZCatalog
- Added methods to retrieve device components from solr. We will keep using the componentSearch ZCatalog due to better performance
- To store decimal ips as string they need to have the same number of characters for solr to properly make the comparison
- Do not index to global catalog and remove global catalog searches for zenoss core
- Updated data manager to add mid transaction consistency
- Improve Network Tree performance
