### PR TITLE
ZEN-20863 More defensive migration scripts

### DIFF
--- a/Products/ZenModel/migrate/addZenMailHealthCheck.py
+++ b/Products/ZenModel/migrate/addZenMailHealthCheck.py
@@ -36,10 +36,10 @@ class AddZenMailHealthCheck(Migrate.Step):
             interval=10.0,
             script="echo 'QUIT' | nc -w 10 -C 127.0.0.1 50025 | grep -q '^220 '")
 
-        zenmail_service = filter(lambda s: s.name == "zenmail", ctx.services)[0]
-
-        if not filter(lambda c: c.name == 'service_ready', zenmail_service.healthChecks):
-            zenmail_service.healthChecks.append(service_ready_healthcheck)
+        zenmail_services = filter(lambda s: s.name == "zenmail", ctx.services)
+        for zenmail_service in zenmail_services:
+            if not filter(lambda c: c.name == 'service_ready', zenmail_service.healthChecks):
+                zenmail_service.healthChecks.append(service_ready_healthcheck)
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/switchLoggingLevel.py
+++ b/Products/ZenModel/migrate/switchLoggingLevel.py
@@ -35,12 +35,13 @@ class SwitchLoggingLevel(Migrate.Step):
             log.info("Found %i services named 'CentralQuery'; skipping.", len(cqs))
             return
 
-        cqconfig = filter(lambda cf: cf.name == '/opt/zenoss/etc/central-query/configuration.yaml', cqs[0].originalConfigs)
-        cqconfig = cqconfig[0]
-        confyaml = yaml.load(cqconfig.content)
-        confyaml['logging']['level'] = 'WARN'
-        confyaml['logging']['loggers']['org.zenoss'] = 'WARN'
-        cqconfig.content = yaml.dump(confyaml)
+        cqconfigs = filter(lambda cf: cf.name == '/opt/zenoss/etc/central-query/configuration.yaml', cqs[0].originalConfigs)
+        for cqconfig in cqconfigs:
+            confyaml = yaml.load(cqconfig.content)
+            confyaml['logging']['level'] = 'WARN'
+            confyaml['logging']['loggers']['org.zenoss'] = 'WARN'
+            cqconfig.content = yaml.dump(confyaml)
+
         ctx.commit()
 
 SwitchLoggingLevel()

--- a/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
+++ b/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
@@ -33,12 +33,13 @@ class UpdateOpenTSDBConfigs(Migrate.Step):
         tsdbs = filter(lambda s: "/opt/zenoss/etc/opentsdb/opentsdb.conf" in [i.name for i in s.originalConfigs], tsdbs)
 
         for tsdb in tsdbs:
-            cf = filter(lambda f: f.name == "/opt/zenoss/etc/opentsdb/opentsdb.conf", tsdb.originalConfigs)[0]
-            lines = cf.content.split('\n')
-            for i, line in enumerate(lines):
-                if line.startswith("tsd.storage.hbase.zk_quorum"):
-                    lines[i] = line.replace("localhost", "127.0.0.1")
-            cf.content = '\n'.join(lines)
+            cfs = filter(lambda f: f.name == "/opt/zenoss/etc/opentsdb/opentsdb.conf", tsdb.originalConfigs)
+            for cf in cfs:
+                lines = cf.content.split('\n')
+                for i, line in enumerate(lines):
+                    if line.startswith("tsd.storage.hbase.zk_quorum"):
+                        lines[i] = line.replace("localhost", "127.0.0.1")
+                cf.content = '\n'.join(lines)
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
+++ b/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
@@ -27,10 +27,12 @@ class UpdateZeneventserverHealthCheck(Migrate.Step):
             log.info("Couldn't generate service context, skipping.")
             return
 
-        zep = filter(lambda s: s.name == "zeneventserver", ctx.services)[0]
+        zeps = filter(lambda s: s.name == "zeneventserver", ctx.services)
+        for zep in zeps:
 
-        answering = filter(lambda hc: hc.name == "answering", zep.healthChecks)[0]
-        answering.script = "curl -f -s http://localhost:8084/zeneventserver/api/1.0/heartbeats/"
+            answering = filter(lambda hc: hc.name == "answering", zep.healthChecks)
+            for a in answering:
+                a.script = "curl -f -s http://localhost:8084/zeneventserver/api/1.0/heartbeats/"
 
         ctx.commit()
 

--- a/Products/ZenModel/migrate/updateZookeeperConfigs.py
+++ b/Products/ZenModel/migrate/updateZookeeperConfigs.py
@@ -34,12 +34,13 @@ class UpdateZookeeperConfigs(Migrate.Step):
         for zookeeper in zookeepers:
 
             # Update zookeeper.cfg.
-            cf = filter(lambda f: f.name == "/etc/zookeeper.cfg", zookeeper.originalConfigs)[0]
-            if cf.content.find("autopurge.snapRetainCount") < 0:
-                cf.content += "\nautopurge.snapRetainCount=3"
+            cfs = filter(lambda f: f.name == "/etc/zookeeper.cfg", zookeeper.originalConfigs)
+            for cf in cfs:
+                if cf.content.find("autopurge.snapRetainCount") < 0:
+                    cf.content += "\nautopurge.snapRetainCount=3"
 
-            if cf.content.find("autopurge.purgeInterval") < 0:
-                cf.content += "\nautopurge.purgeInterval=1"
+                if cf.content.find("autopurge.purgeInterval") < 0:
+                    cf.content += "\nautopurge.purgeInterval=1"
 
 
         # Commit our changes.

--- a/Products/ZenModel/migrate/updateZopeThreadsCount.py
+++ b/Products/ZenModel/migrate/updateZopeThreadsCount.py
@@ -35,12 +35,12 @@ class UpdateZopeThreadsCount(Migrate.Step):
         for zope_service in zope_services:
 
             # Update zope.conf.
-            cf = filter(lambda f: f.name == "/opt/zenoss/etc/zope.conf", zope_service.originalConfigs)[0]
-
-            cf.content = re.sub(
-                r'^(\s*zserver-threads\s+1)\s*$',
-                r'\n# Reverted to default value by ZenMigrate\n# \1\n',
-                cf.content, 0, re.MULTILINE)
+            cfs = filter(lambda f: f.name == "/opt/zenoss/etc/zope.conf", zope_service.originalConfigs)
+            for cf in cfs:
+                cf.content = re.sub(
+                    r'^(\s*zserver-threads\s+1)\s*$',
+                    r'\n# Reverted to default value by ZenMigrate\n# \1\n',
+                    cf.content, 0, re.MULTILINE)
 
         # Commit our changes.
         ctx.commit()


### PR DESCRIPTION
Changed a number of instances of filter(...)[0] to accomodate
for the cases where a filter would result in no elements.

ZEN-20863 mentions one such case; because of the similarity this
patch includes changes to six other migration scripts.