### PR TITLE
ZEN-21297 link installing zenpack fails for certain path descriptions

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -242,6 +242,10 @@ class ZenPackCmd(ZenScriptBase):
             if not self.preInstallCheck(eggInstall):
                 self.stop('%s not installed' % self.options.installPackName)
             if eggInstall:
+                if  self.options.link and not os.path.isdir(self.options.installPackName):
+                    self.stop('--link specified but %s is not a directory' % self.options.installPackName)
+                if  not self.options.link and os.path.isdir(self.options.installPackName):
+                    self.stop('zenpack %s is a directory and requires --link option to install' % self.options.installPackName)
                 return EggPackCmd.InstallEggAndZenPack(
                     self.dmd,
                     self.options.installPackName,


### PR DESCRIPTION
Exit with error on ZenPack install when --link is used but
no directory is provided --OR-- when egg file is provided and
--link option is not specified.