### PR TITLE
ZEN-21544: Fix missed import in DataRoot module

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -16,6 +16,7 @@ name space.
 """
 
 import re
+import socket
 from persistent.list import PersistentList
 from zope.interface import implements
 from AccessControl import ClassSecurityInfo


### PR DESCRIPTION
`socket` module used in getDefaultEmailFrom() function but don't imported.