### PR TITLE
ZEN-21569 Add log.info to migrations

### DIFF
--- a/Products/ZenModel/migrate/AddEndpointsToZenjobs.py
+++ b/Products/ZenModel/migrate/AddEndpointsToZenjobs.py
@@ -24,7 +24,6 @@ class AddEndpointsToZenjobs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: AddEndpointsToZenjobs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/AddEndpointsToZenjobs.py
+++ b/Products/ZenModel/migrate/AddEndpointsToZenjobs.py
@@ -24,6 +24,7 @@ class AddEndpointsToZenjobs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: AddEndpointsToZenjobs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -50,6 +51,7 @@ class AddEndpointsToZenjobs(Migrate.Step):
         # Get all zenjobs services (normally only 1)
         log.info("Looking for zenjobs services to migrate")
         services = filter(lambda s: s.name == "zenjobs", ctx.services)
+        log.info("Found %i services named 'zenjobs'." % len(services))
 
         # Add the zep endpoint import if it does not exist
         if not services:

--- a/Products/ZenModel/migrate/addCentralQueryGraphConfigs.py
+++ b/Products/ZenModel/migrate/addCentralQueryGraphConfigs.py
@@ -24,7 +24,6 @@ class AddCentralQueryGraphConfigs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: AddCentralQueryGraphConfigs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/addCentralQueryGraphConfigs.py
+++ b/Products/ZenModel/migrate/addCentralQueryGraphConfigs.py
@@ -24,6 +24,7 @@ class AddCentralQueryGraphConfigs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: AddCentralQueryGraphConfigs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -32,12 +33,14 @@ class AddCentralQueryGraphConfigs(Migrate.Step):
 
         # Get all Central Query services.
         services = filter(lambda s: s.name == "CentralQuery", ctx.services)
+        log.info("Found %i services named 'CentralQuery'." % len(services))
 
         # Add graph config to monitoring profile
         commit = False
         for service in services:
             gcs = service.monitoringProfile.graphConfigs
             if not filter(lambda x: x.graphID == "queryRate", gcs):
+                log.info("No queryRate graph found; creating.")
                 commit = True
                 gcs.append(
                     GraphConfig(
@@ -67,6 +70,8 @@ class AddCentralQueryGraphConfigs(Migrate.Step):
                         ]
                     )
                 )
+            else:
+                log.info("QueryRate graph found; skipping.")
 
         # Commit our changes.
         if commit:

--- a/Products/ZenModel/migrate/addMemcachedService.py
+++ b/Products/ZenModel/migrate/addMemcachedService.py
@@ -25,7 +25,6 @@ class AddMemcachedService(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: AddMemcachedService")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/addMemcachedService.py
+++ b/Products/ZenModel/migrate/addMemcachedService.py
@@ -25,6 +25,7 @@ class AddMemcachedService(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: AddMemcachedService")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -33,7 +34,9 @@ class AddMemcachedService(Migrate.Step):
 
         # If the service lacks memcached, add it now.
         memcached = filter(lambda s: s.name == "memcached", ctx.services)
+        log.info("Found %i services named 'memcached'." % len(memcached))
         if not memcached:
+            log.info("No memcached found; creating new service.")
             new_memcached = default_memcached_service()
             infrastructure = ctx.findServices('^[^/]+/Infrastructure$')[0]
             ctx.deployService(json.dumps(new_memcached), infrastructure)

--- a/Products/ZenModel/migrate/addQuiltInstallCommand.py
+++ b/Products/ZenModel/migrate/addQuiltInstallCommand.py
@@ -24,7 +24,6 @@ class AddQuiltInstallCommand(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: AddQuiltInstallCommand")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/addQuiltInstallCommand.py
+++ b/Products/ZenModel/migrate/addQuiltInstallCommand.py
@@ -24,6 +24,7 @@ class AddQuiltInstallCommand(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: AddQuiltInstallCommand")
 
         try:
             ctx = sm.ServiceContext()
@@ -36,11 +37,15 @@ class AddQuiltInstallCommand(Migrate.Step):
                                         commitOnSuccess=False)
 
         zope_services = filter(lambda s: s.name == "Zope", ctx.services)
+        log.info("Found %i services named 'Zope'." % len(zope_services))
 
         for zope_service in zope_services:
             # Add `install-quilt` if it is not already present
             if not filter(lambda c: c.name == 'install-quilt', zope_service.commands):
+                log.info("Added install-quilt command.")
                 zope_service.commands.append(quilt_install_command)
+            else:
+                log.info("Install-quilt command alread present.")
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/addZenMailHealthCheck.py
+++ b/Products/ZenModel/migrate/addZenMailHealthCheck.py
@@ -24,7 +24,6 @@ class AddZenMailHealthCheck(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: AddZenMailHealthCheck")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/addZenMailHealthCheck.py
+++ b/Products/ZenModel/migrate/addZenMailHealthCheck.py
@@ -24,6 +24,7 @@ class AddZenMailHealthCheck(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: AddZenMailHealthCheck")
 
         try:
             ctx = sm.ServiceContext()
@@ -37,9 +38,13 @@ class AddZenMailHealthCheck(Migrate.Step):
             script="echo 'QUIT' | nc -w 10 -C 127.0.0.1 50025 | grep -q '^220 '")
 
         zenmail_services = filter(lambda s: s.name == "zenmail", ctx.services)
+        log.info("Found %i services named 'zenmail'." % len(zenmail_services))
         for zenmail_service in zenmail_services:
             if not filter(lambda c: c.name == 'service_ready', zenmail_service.healthChecks):
+                log.info("Service_ready healthcheck not found; adding.")
                 zenmail_service.healthChecks.append(service_ready_healthcheck)
+            else:
+                log.info("Service_ready healthcheck found; skipping.")
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/collectorDaemonsImportZproxy.py
+++ b/Products/ZenModel/migrate/collectorDaemonsImportZproxy.py
@@ -21,6 +21,7 @@ class CollectorDaemonsImportZproxy(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: CollectorDaemonsImportZproxy")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -29,6 +30,7 @@ class CollectorDaemonsImportZproxy(Migrate.Step):
 
         # Get all services tagged "collector" and "daemon".
         collectorDaemons = filter(lambda s: all(x in s.tags for x in ["collector", "daemon"]), ctx.services)
+        log.info("Found %i services tagged 'collector' or 'daemon'." % len(collectorDaemons))
 
         # Create the endpoint we're importing.
         endpoint = sm.Endpoint(
@@ -46,8 +48,10 @@ class CollectorDaemonsImportZproxy(Migrate.Step):
             # Make sure we're not already importing zproxy.
             zpImports = filter(lambda ep: ep.name == "zproxy" and ep.purpose == "import", daemon.endpoints)
             if len(zpImports) > 0:
+                log.info("Service %s already has a zproxy import endpoint." % daemon.name)
                 continue
 
+            log.info("Adding a zproxy import endpoint to service '%s'." % daemon.name)
             daemon.endpoints.append(endpoint)
 
         # Commit our changes.

--- a/Products/ZenModel/migrate/collectorDaemonsImportZproxy.py
+++ b/Products/ZenModel/migrate/collectorDaemonsImportZproxy.py
@@ -21,7 +21,6 @@ class CollectorDaemonsImportZproxy(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: CollectorDaemonsImportZproxy")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/convertRunsToCommands.py
+++ b/Products/ZenModel/migrate/convertRunsToCommands.py
@@ -23,7 +23,6 @@ class ConvertRunsToCommands(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: ConvertRunsToCommands")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/convertRunsToCommands.py
+++ b/Products/ZenModel/migrate/convertRunsToCommands.py
@@ -23,6 +23,7 @@ class ConvertRunsToCommands(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: ConvertRunsToCommands")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -31,20 +32,26 @@ class ConvertRunsToCommands(Migrate.Step):
 
         # Update the zope service commands.
         zopes = filter(lambda s: s.name == "Zope", ctx.services)
+        log.info("Found %i services named 'Zope'." % len(zopes))
         if len(zopes) == 1:
             temp = commandListDict(zopes[0].commands)
             temp.update(zopeCommands)
             zopes[0].commands = commandDictList(temp)
+            log.info("Updated Zope command list.")
         mariadbModels = filter(lambda s: s.name == "mariadb-model", ctx.services)
+        log.info("Found %i services named 'mariadb-model'." % len(mariadbModels))
         if len(mariadbModels) == 1:
             temp = commandListDict(mariadbModels[0].commands)
             temp.update(mariadbModelCommands)
             mariadbModels[0].commands = commandDictList(temp)
+            log.info("Updated mariadb-model command list.")
         mariadbs = filter(lambda s: s.name == "mariadb", ctx.services)
+        log.info("Found %i services named 'mariadb'." % len(mariadbs))
         if len(mariadbs) == 1:
             temp = commandListDict(mariadbs[0].commands)
             temp.update(mariadbCommands)
             mariadbs[0].commands = commandDictList(temp)
+            log.info("Updated mariadb command list.")
         # Commit our changes.
         ctx.commit()
 

--- a/Products/ZenModel/migrate/duallogchange.py
+++ b/Products/ZenModel/migrate/duallogchange.py
@@ -21,6 +21,7 @@ class DualLogChange(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: DualLogChange")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -31,6 +32,7 @@ class DualLogChange(Migrate.Step):
         for svc in ctx.services:
             if svc.startup and svc.startup.find('--duallog') >= 0:
                 svc.startup = svc.startup.replace('--duallog', '--logfileonly')
+                log.info("Changed startup command for service '%s'." % svc.name)
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/duallogchange.py
+++ b/Products/ZenModel/migrate/duallogchange.py
@@ -21,7 +21,6 @@ class DualLogChange(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: DualLogChange")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/enableCommitonUpgrade.py
+++ b/Products/ZenModel/migrate/enableCommitonUpgrade.py
@@ -23,6 +23,7 @@ class EnableCommitOnUpgrade(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: EnableCommitOnUpgrade")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -37,6 +38,7 @@ class EnableCommitOnUpgrade(Migrate.Step):
         upgrades = filter(lambda c: c.name == "upgrade", zopes[0].commands)
         for command in upgrades:
             command.commitOnSuccess = True
+            log.info("Set commitOnSuccess=True for 'upgrade'.")
         ctx.commit()
 
 

--- a/Products/ZenModel/migrate/enableCommitonUpgrade.py
+++ b/Products/ZenModel/migrate/enableCommitonUpgrade.py
@@ -23,7 +23,6 @@ class EnableCommitOnUpgrade(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: EnableCommitOnUpgrade")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/fixZopeHealthCheck.py
+++ b/Products/ZenModel/migrate/fixZopeHealthCheck.py
@@ -33,7 +33,6 @@ class FixZopeHealthCheck(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: FixZopeHealthCheck")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/makeMemcachedUpdates.py
+++ b/Products/ZenModel/migrate/makeMemcachedUpdates.py
@@ -23,7 +23,6 @@ class MakeMemcachedUpdates(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: MakeMemcachedUpdates")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/makeMemcachedUpdates.py
+++ b/Products/ZenModel/migrate/makeMemcachedUpdates.py
@@ -23,6 +23,7 @@ class MakeMemcachedUpdates(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: MakeMemcachedUpdates")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -30,6 +31,7 @@ class MakeMemcachedUpdates(Migrate.Step):
             return
 
         memcacheds = filter(lambda s: s.name == "memcached", ctx.services)
+        log.info("Found %i services named 'memcached'" % len(memcacheds))
         if not memcacheds:
             log.info("Couldn't find memcached service, skipping.")
             return
@@ -40,6 +42,9 @@ class MakeMemcachedUpdates(Migrate.Step):
             if answering:
                 answering[0].script = "{ echo stats; sleep 1; } | nc 127.0.0.1 11211 | grep -q uptime"
                 commit = True
+                log.info("Updated 'answering' healthcheck.")
+            else:
+                log.info("Could not find 'answering' healthcheck to update.")
 
             # Create /etc/sysconfig/memcached if it doesn't exist
             esm_content = """\
@@ -58,6 +63,7 @@ OPTIONS=""
             )
             if '/etc/sysconfig/memcached' not in [cf.name for cf in memcached.originalConfigs]:
                 memcached.originalConfigs.append(e_s_memcached)
+                log.info("Added '/etc/sysconfig/memcached'")
                 commit = True
 
         if commit:

--- a/Products/ZenModel/migrate/removeEmptyGraphdata.py
+++ b/Products/ZenModel/migrate/removeEmptyGraphdata.py
@@ -24,6 +24,7 @@ class RemoveEmptyGraphData(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: RemoveEmptyGraphData")
 
         try:
             ctx = sm.ServiceContext()
@@ -32,15 +33,22 @@ class RemoveEmptyGraphData(Migrate.Step):
             return
 
         zenmodelers = filter(lambda s: s.name == "zenmodeler", ctx.services)
+        log.info("Found %i services named 'zenmodeler'." % len(zenmodelers))
         remove_metrics = ["dataPoints", "eventCount", "missedRuns", "taskCount"]
         remove_graphs = ["dataPoints", "events", "missedRuns", "tasks"]
         for zenmodeler in zenmodelers:
             for mc in zenmodeler.monitoringProfile.metricConfigs:
+                before = len(mc.metrics)
                 mc.metrics = [m for m in mc.metrics if m.ID not in remove_metrics]
+                after = len(mc.metrics)
+                log.info("Removed %i metrics from zenmodeler." % (before - after))
 
+            before = len(zenmodeler.monitoringProfile.graphConfigs)
             zenmodeler.monitoringProfile.graphConfigs = [
                 gc for gc in zenmodeler.monitoringProfile.graphConfigs
                 if gc.graphID not in remove_graphs]
+            after = len(zenmodeler.monitoringProfile.graphConfigs)
+            log.info("Removed %i graphs from zenmodeler." % (before - after))
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/removeEmptyGraphdata.py
+++ b/Products/ZenModel/migrate/removeEmptyGraphdata.py
@@ -24,7 +24,6 @@ class RemoveEmptyGraphData(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: RemoveEmptyGraphData")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/switchLoggingLevel.py
+++ b/Products/ZenModel/migrate/switchLoggingLevel.py
@@ -24,7 +24,6 @@ class SwitchLoggingLevel(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: SwitchLoggingLevel")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
+++ b/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
@@ -21,7 +21,6 @@ class TemplatizeCollectorEndpoints(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: TemplatizeCollectorEndpoints")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/updateHBaseForNetcat.py
+++ b/Products/ZenModel/migrate/updateHBaseForNetcat.py
@@ -23,6 +23,7 @@ class UpdateHBaseForNetcat(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: UpdateHBaseForNetcat")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -33,33 +34,47 @@ class UpdateHBaseForNetcat(Migrate.Step):
 
         # 1) HMaster's prereq
         hmasters = filter(lambda s: s.name == "HMaster", ctx.services)
+        log.info("Found %i services named 'HMaster'." % len(hmasters))
         for hmaster in hmasters: # Should only be one
             for prereq in filter(lambda p: p.name == 'All ZooKeepers up', hmaster.prereqs): # Should only be one
                 if prereq.script == '{{with $zks := (child (parent .) \"ZooKeeper\").Instances }}{{ range (each $zks) }}echo ruok | nc -q10 zk{{plus 1 .}} 2181 | grep imok {{if ne (plus 1 .) $zks}}&& {{end}}{{end}}{{end}}':
                     prereq.script = '{{with $zks := (child (parent .) \"ZooKeeper\").Instances }}{{ range (each $zks) }}{ echo ruok; sleep 2; } | nc zk{{plus 1 .}} 2181 | grep imok {{if ne (plus 1 .) $zks}}&& {{end}}{{end}}{{end}}'
+                    log.info("Added sleep to 'All ZooKeepers up' prereq.")
                     changes = True
+                else:
+                    log.info("No 'All ZooKeepers up' prereq found; skipping.")
 
         # 2) ZK Healthchecks
         zks = filter(lambda s: s.name == "ZooKeeper", ctx.services)
+        log.info("Found %i services named 'ZooKeeper'." % len(zks))
         for zk in zks:
             answering = filter(lambda hc: hc.name == "answering", zk.healthChecks)
+            log.info("Found %i 'answering' healthchecks." % len(answering))
             if len(answering) != 1:
                 continue
             answering = answering[0]
             if answering.script == 'echo stats | nc -q 1 localhost {{ plus 2181 .InstanceID }} | grep -q Zookeeper':
                 answering.script = '{ echo stats; sleep 1; } | nc 127.0.0.1 {{ plus 2181 .InstanceID }} | grep -q Zookeeper'
+                log.info("Added sleep to 'answering' healthcheck.")
                 changes = True
+            else:
+                log.info("Healthcheck is not as expected; skipping.")
 
         # 3) RegionServer Healthchecks
         regionservers = filter(lambda s: s.name == "RegionServer", ctx.services)
+        log.info("Found %i services named 'RegionServer'." % len(regionservers))
         for rs in regionservers:
             answering = filter(lambda hc: hc.name == "answering", rs.healthChecks)
+            log.info("Found %i 'answering' healthchecks." % len(answering))
             if len(answering) != 1:
                 continue
             answering = answering[0]
             if answering.script == 'nc -z localhost {{ plus 60200 .InstanceID }}':
                 answering.script = 'echo | nc localhost {{ plus 60200 .InstanceID }}'
+                log.info("Added echo to 'answering' healthcheck.")
                 changes = True
+            else:
+                log.info("Healthcheck is not as expected; skipping.")
 
         if changes:
             ctx.commit()

--- a/Products/ZenModel/migrate/updateHBaseForNetcat.py
+++ b/Products/ZenModel/migrate/updateHBaseForNetcat.py
@@ -23,7 +23,6 @@ class UpdateHBaseForNetcat(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: UpdateHBaseForNetcat")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
+++ b/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
@@ -22,7 +22,6 @@ class UpdateOpenTSDBConfigs(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: UpdateOpenTSDBConfigs")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
+++ b/Products/ZenModel/migrate/updateOpenTSDBConfigs.py
@@ -22,6 +22,7 @@ class UpdateOpenTSDBConfigs(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: UpdateOpenTSDBConfigs")
 
         try:
             ctx = sm.ServiceContext()
@@ -30,15 +31,19 @@ class UpdateOpenTSDBConfigs(Migrate.Step):
             return
 
         tsdbs = filter(lambda s: "opentsdb" in ctx.getServicePath(s), ctx.services)
+        log.info("Found %i services with 'opentsdb' in their service path." % len(tsdbs))
         tsdbs = filter(lambda s: "/opt/zenoss/etc/opentsdb/opentsdb.conf" in [i.name for i in s.originalConfigs], tsdbs)
+        log.info("Of those, %i services use /opt/zenoss/etc/opentsdb/opentsdb.conf." % len(tsdbs))
 
         for tsdb in tsdbs:
             cfs = filter(lambda f: f.name == "/opt/zenoss/etc/opentsdb/opentsdb.conf", tsdb.originalConfigs)
+            log.info("Found %i config files named '/opt/zenoss/etc/opentsdb/opentsdb.conf'." % len(cfs))
             for cf in cfs:
                 lines = cf.content.split('\n')
                 for i, line in enumerate(lines):
                     if line.startswith("tsd.storage.hbase.zk_quorum"):
                         lines[i] = line.replace("localhost", "127.0.0.1")
+                        log.info("Changed localhost to 127.0.0.1 on line %i." % i)
                 cf.content = '\n'.join(lines)
 
         # Commit our changes.

--- a/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
+++ b/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
@@ -21,6 +21,7 @@ class UpdateZeneventserverHealthCheck(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: UpdateZeneventserverHealthCheck")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -28,11 +29,14 @@ class UpdateZeneventserverHealthCheck(Migrate.Step):
             return
 
         zeps = filter(lambda s: s.name == "zeneventserver", ctx.services)
+        log.info("Found %i services named 'zeneventserver'." % len(zeps))
         for zep in zeps:
 
             answering = filter(lambda hc: hc.name == "answering", zep.healthChecks)
+            log.info("Found %i 'answering' healthchecks." % len(answering))
             for a in answering:
                 a.script = "curl -f -s http://localhost:8084/zeneventserver/api/1.0/heartbeats/"
+                log.info("Updated 'answering' healthcheck.")
 
         ctx.commit()
 

--- a/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
+++ b/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
@@ -21,7 +21,6 @@ class UpdateZeneventserverHealthCheck(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: UpdateZeneventserverHealthCheck")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/updateZentrapConfigs.py
+++ b/Products/ZenModel/migrate/updateZentrapConfigs.py
@@ -22,6 +22,7 @@ class UpdateZentrapConfigs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: UpdateZentrapConfigs")
 
         try:
             ctx = sm.ServiceContext()
@@ -30,6 +31,7 @@ class UpdateZentrapConfigs(Migrate.Step):
             return
 
         zentraps = filter(lambda s: s.name == "zentrap", ctx.services)
+        log.info("Found %i services named 'zentrap'." % len(zentraps))
 
         cfFilter = sm.ConfigFile (
             name = "/opt/zenoss/etc/zentrap.filter.conf",
@@ -44,9 +46,11 @@ class UpdateZentrapConfigs(Migrate.Step):
             # First update zentrap.conf.
             cf = filter(lambda f: f.name == "/opt/zenoss/etc/zentrap.conf", zentrap.originalConfigs)[0]
             cf.content = open(os.path.join(os.path.dirname(__file__), "config-files", "zentrap.conf"), 'r').read()
+            log.info("Updated '/opt/zenoss/etc/zentrap.conf' contents.")
 
             # Now add zentrap.filter.conf.
             zentrap.originalConfigs.append(cfFilter)
+            log.info("Added '%s'." % cfFilter.name)
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/updateZentrapConfigs.py
+++ b/Products/ZenModel/migrate/updateZentrapConfigs.py
@@ -22,7 +22,6 @@ class UpdateZentrapConfigs(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: UpdateZentrapConfigs")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/updateZookeeperConfigs.py
+++ b/Products/ZenModel/migrate/updateZookeeperConfigs.py
@@ -23,6 +23,7 @@ class UpdateZookeeperConfigs(Migrate.Step):
 
     def cutover(self, dmd):
 
+        log.info("Migration: UpdateZookeeperConfigs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:
@@ -30,17 +31,25 @@ class UpdateZookeeperConfigs(Migrate.Step):
             return
 
         zookeepers = filter(lambda s: s.name == "ZooKeeper", ctx.services)
+        log.info("Found %i services named 'ZooKeeper'" % len(zookeepers))
 
         for zookeeper in zookeepers:
 
             # Update zookeeper.cfg.
             cfs = filter(lambda f: f.name == "/etc/zookeeper.cfg", zookeeper.originalConfigs)
+            log.info("Found %i files named '/etc/zookeeper.cfg' '" % len(cfs))
             for cf in cfs:
                 if cf.content.find("autopurge.snapRetainCount") < 0:
                     cf.content += "\nautopurge.snapRetainCount=3"
+                    log.info("Added autopurge.snapRetainCount=3")
+                else:
+                    log.info("Found previous autopurge.snapRetainCount; not updating.")
 
                 if cf.content.find("autopurge.purgeInterval") < 0:
                     cf.content += "\nautopurge.purgeInterval=1"
+                    log.info("Added autopurge.purgeInterval=1")
+                else:
+                    log.info("Found previous autopurge.purgeInterval; not updating.")
 
 
         # Commit our changes.

--- a/Products/ZenModel/migrate/updateZookeeperConfigs.py
+++ b/Products/ZenModel/migrate/updateZookeeperConfigs.py
@@ -23,7 +23,6 @@ class UpdateZookeeperConfigs(Migrate.Step):
 
     def cutover(self, dmd):
 
-        log.info("Migration: UpdateZookeeperConfigs")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/updateZopeThreadsCount.py
+++ b/Products/ZenModel/migrate/updateZopeThreadsCount.py
@@ -23,7 +23,6 @@ class UpdateZopeThreadsCount(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: UpdateZopeThreadsCount")
 
         try:
             ctx = sm.ServiceContext()

--- a/Products/ZenModel/migrate/updateZopeThreadsCount.py
+++ b/Products/ZenModel/migrate/updateZopeThreadsCount.py
@@ -23,6 +23,7 @@ class UpdateZopeThreadsCount(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: UpdateZopeThreadsCount")
 
         try:
             ctx = sm.ServiceContext()
@@ -31,16 +32,19 @@ class UpdateZopeThreadsCount(Migrate.Step):
             return
 
         zope_services = filter(lambda s: s.name == "Zope", ctx.services)
+        log.info("Found %i services named 'Zope'." % len(zope_services))
 
         for zope_service in zope_services:
 
             # Update zope.conf.
             cfs = filter(lambda f: f.name == "/opt/zenoss/etc/zope.conf", zope_service.originalConfigs)
+            log.info("Found %i config files named '/opt/zenoss/etc/zope.conf'." % len(cfs))
             for cf in cfs:
                 cf.content = re.sub(
                     r'^(\s*zserver-threads\s+1)\s*$',
                     r'\n# Reverted to default value by ZenMigrate\n# \1\n',
                     cf.content, 0, re.MULTILINE)
+                log.info("Reverted zserver-threads count to 1.")
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/useBeakerInZope.py
+++ b/Products/ZenModel/migrate/useBeakerInZope.py
@@ -23,7 +23,6 @@ class UseBeakerInZope(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: UseBeakerInZope")
         try:
             ctx = sm.ServiceContext()
         except sm.ServiceMigrationError:

--- a/Products/ZenModel/migrate/zenmodelerWorkers.py
+++ b/Products/ZenModel/migrate/zenmodelerWorkers.py
@@ -21,7 +21,6 @@ class zenmodelerWorkers(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
-        log.info("Migration: zenmodelerWorkers")
         # Don't apply this migration to core.
         if dmd.getProductName() == "core":
             return

--- a/Products/ZenModel/migrate/zenmodelerWorkers.py
+++ b/Products/ZenModel/migrate/zenmodelerWorkers.py
@@ -21,6 +21,7 @@ class zenmodelerWorkers(Migrate.Step):
     version = Migrate.Version(5,0,70)
 
     def cutover(self, dmd):
+        log.info("Migration: zenmodelerWorkers")
         # Don't apply this migration to core.
         if dmd.getProductName() == "core":
             return
@@ -33,12 +34,14 @@ class zenmodelerWorkers(Migrate.Step):
 
         # Get all zenmodeler services.
         modelers = filter(lambda s: s.name == "zenmodeler", ctx.services)
+        log.info("Found %i services named 'zenmodeler'." % len(modelers))
 
         # Alter their startup command and instanceLimits.
         for modeler in modelers:
             modeler.startup = "su - zenoss -c \"/opt/zenoss/bin/zenmodeler run -c --logfileonly --workers {{.Instances}} --workerid $CONTROLPLANE_INSTANCE_ID --monitor {{(parent .).Name}} \""
             modeler.instanceLimits.minimum = 1
             modeler.instanceLimits.maximum = None
+            log.info("Updated startupcommand, set instance minimum to 1, and instance maximum to None.")
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/zminionViaSupervisord.py
+++ b/Products/ZenModel/migrate/zminionViaSupervisord.py
@@ -21,6 +21,7 @@ class RunZminionViaSupervisord(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
+        log.info("Migration: RunZminionViaSupervisord")
 
         try:
             ctx = sm.ServiceContext()
@@ -29,13 +30,18 @@ class RunZminionViaSupervisord(Migrate.Step):
             return
 
         zminion_services = filter(lambda s: s.name == 'zminion', ctx.services)
+        log.info("Found %i services named 'zminion'." % len(zminion_services))
         for zminion in zminion_services:
             zminion.logConfigs = zminion.logConfigs or []
             logfiles = [z.path for z in zminion.logConfigs]
             log_path = "/opt/zenoss/log/zminion.log"
             if log_path not in logfiles:
+                log.info("Updating zminion startup command to use supervisord.")
                 zminion.startup = 'su - zenoss -c "/bin/supervisord -n -c /opt/zenoss/etc/zminion/supervisord.conf"'
+                log.info("Adding supervisord to logConfigs.")
                 zminion.logConfigs.append(sm.LogConfig(path=log_path, logType="zminion"))
+            else:
+                log.info("Service 'zminion' already has an /opt/zenoss/log/zminion.log; skipping.")
 
         # Commit our changes.
         ctx.commit()

--- a/Products/ZenModel/migrate/zminionViaSupervisord.py
+++ b/Products/ZenModel/migrate/zminionViaSupervisord.py
@@ -21,7 +21,6 @@ class RunZminionViaSupervisord(Migrate.Step):
     version = Migrate.Version(5, 0, 70)
 
     def cutover(self, dmd):
-        log.info("Migration: RunZminionViaSupervisord")
 
         try:
             ctx = sm.ServiceContext()


### PR DESCRIPTION
At minimum, each cutover function logs that it's starting, and how many services are about to be affected.