### PR TITLE
ZEN-21793: RRDDataSource.py needs context added as a key/value to the…

### DIFF
--- a/Products/ZenModel/RRDDataSource.py
+++ b/Products/ZenModel/RRDDataSource.py
@@ -190,6 +190,7 @@ class RRDDataSource(ZenModelRM, ZenPackable):
                    'ds': self,
                    'datasource': self,
                    'here' : context,
+                   'context': context,
                    'zCommandPath' : context.zCommandPath,
                    'nothing' : None,
                    'now' : DateTime() }


### PR DESCRIPTION
port from 4.2.5: https://github.com/zenoss/4.2.5-RPS/pull/653/files