### PR TITLE
Fixes ZEN-21972 - Connection refused flare msg in Advanced->Control Center tab

### DIFF
--- a/Products/ZenUtils/controlplane/__init__.py
+++ b/Products/ZenUtils/controlplane/__init__.py
@@ -27,7 +27,7 @@ def getConnectionSettings(options=None):
         }
     # allow these to be set from the global.conf for development but
     # give preference to the environment variables
-    settings["host"] = os.getenv('CONTROLPLANE_HOST_IPS', settings["host"]).split(' ')[0]
+    settings["host"] = os.getenv('SERVICED_MASTER_IP', settings["host"])
     settings["port"] = os.getenv('SERVICED_UI_PORT', settings['port'])
     settings["user"] = os.environ.get('CONTROLPLANE_SYSTEM_USER', settings['user'])
     settings["password"] = os.environ.get('CONTROLPLANE_SYSTEM_PASSWORD', settings['password'])


### PR DESCRIPTION
Changed controlplane to use the correct host IP.  Previously, it was using the IP of the agent's host, instead of the master.  It now attempts to read it from a new environment variable before falling back to global.conf.

The new environment variable is added here:  https://github.com/control-center/serviced/pull/2500
