### PR TITLE
Improve speed of loading objects from XML

### DIFF
--- a/Products/ZenModel/ZenPackLoader.py
+++ b/Products/ZenModel/ZenPackLoader.py
@@ -12,6 +12,7 @@ __doc__='Base Classes for loading gunk in a ZenPack'
 
 import Globals
 from Products.ZenReports.ReportLoader import ReportLoader
+from Products.ZenUtils.events import pausedAndOptimizedIndexing
 from Products.ZenUtils.Utils import zenPath, binPath
 from Products.ZenUtils.guid.interfaces import IGUIDManager
 from Products.ZenUtils.config import ConfigFile
@@ -103,9 +104,11 @@ class ZPLObject(ZenPackLoader):
                 ImportRM.endElement(self, name)
         importer = AddToPack(noopts=True, app=app)
         importer.options.noindex = True
-        for f in self.objectFiles(pack):
-            log.info("Loading %s", f)
-            importer.loadObjectFromXML(xmlfile=f)
+        importer.options.chunk_size = 500
+        with pausedAndOptimizedIndexing():
+            for f in self.objectFiles(pack):
+                log.info("Loading %s", f)
+                importer.loadObjectFromXML(xmlfile=f)
 
 
     def parse(self, filename, handler):


### PR DESCRIPTION
This commit makes multiple related changes.

* Fix a bug that resulted in a commit-per-object for ZenPack upgrades

  self.objectnumber in ImportRM would stay at 0. 0 modulo any chunk_size
  evalutates to true. So a commit would happen for every object. There
  was also a less significant case for ZenPack installations that did
  add objects. In these cases self.objectnumber could remain modulu 0 to
  chunk_size even if no further objects were being updated. To address
  this, I added uncommittedObjects to track that number separately from
  objectnumber.

* Wrap all XML object loading in pausedAndOptimizedIndexing

  The main delay in loading objects is round trips to CatalogService
  when commits happen. pausedAndOptimizedIndexing batches all of these
  calls together to reduce round trips.

* Increase object commit chunk size from 100 to 500

  500 objects will still keep transactions at a reasonable size. I
  changed this value mainly because in testing I was seeing a many
  situations where a single-template XML file would have more than 100
  objects in it. So it would commit once when almost complete, and again
  when complete because there's always one commit per file.

I was primarily profiling the following scenario to come to these
changes. Installing the CiscoUCS 2.3.0 ZenPack over itself on a UCS-PM
2 (Zenoss 5.1.0) instance. This means that CatalogService was in use. It
also means that 0 objects were actually being loaded from XML because
they all already existed in the database.

ZPLObject.load() timings (in seconds):

* Baseline: 239.394
* Bugfix only: 26.608
* Bugfix + pausedAndOptimizedIndexing: 15.270

These changes make a big dent in ZEN-22000, but these optimizations only
became apparent because it appears that serviced is adding latency to
zencatalogservice queries, and it adds several minutes of startup time
to the ZenPack install command.

Refs ZEN-22012.

(cherry picked from commit f336561600dbdb357cbf2e07fd94d03f6ba9d8e8)
Signed-off-by: Chet Luther <chet.luther@gmail.com>