### PR TITLE
ZEN-21978 Unable to remove data source

### DIFF
--- a/Products/Zuul/facades/templatefacade.py
+++ b/Products/Zuul/facades/templatefacade.py
@@ -157,7 +157,8 @@ class TemplateFacade(ZuulFacade):
         template = datapoint.datasource().rrdTemplate()
         for graphDef in template.graphDefs():
             for point in graphDef.graphPoints():
-                if datapoint.name() == point.dpName:
+                if (isinstance(point, DataPointGraphPoint)
+                        and datapoint.name() == point.dpName):
                     self._deleteObject(point.getPrimaryId())
 
     def deleteDataSource(self, uid):


### PR DESCRIPTION
Fixed attribute-not-found error throwing an exception "Attribute not found dpName" by
first checking that the point being deleted is in fact a data point rather than a
ThresholdGraphPoint object.