### PR TITLE
ZEN-22001 Syntax error in ethernetCsmacd_64 threshold

### DIFF
--- a/Products/ZenModel/data/devices.xml
+++ b/Products/ZenModel/data/devices.xml
@@ -1307,7 +1307,7 @@ True
 False
 </property>
 <property type="string" id="maxval" mode="w" >
-(here.speed or 1e9) / 8 * .75
+(long(here.speed) or 1e9) / 8 * .75
 </property>
 <property type="int" id="escalateCount" mode="w" >
 0
@@ -2133,7 +2133,7 @@ True
 False
 </property>
 <property type="string" id="maxval" mode="w" >
-(here.speed or 1e9) / 8 * .75
+(long(here.speed) or 1e9) / 8 * .75
 </property>
 <property type="int" id="escalateCount" mode="w" >
 0
@@ -11268,7 +11268,7 @@ True
 False
 </property>
 <property type="string" id="maxval" mode="w" >
-here.speed / 8 * .75
+long(here.speed) / 8 * .75
 </property>
 <property type="int" id="escalateCount" mode="w" >
 0


### PR DESCRIPTION
Cast here.speed to a long to prevent a syntax error message while
monitoring this interface.