### PR TITLE
ZEN-15410: Cross Site Scripting from Exposed Helper Methods

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -37,7 +37,7 @@ import os
 import sys
 import string
 from Products.ZenMessaging.audit import audit
-from Products.ZenUtils.Utils import zenPath, binPath
+from Products.ZenUtils.Utils import zenPath, binPath, unpublished
 from Products.ZenUtils.jsonutils import json
 from Products.ZenUtils.ZenTales import talesCompile, getEngine
 
@@ -467,6 +467,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
 
 
     #security.declareProtected('View', 'writeExportRows')
+    @unpublished
     def writeExportRows(self, fieldsAndLabels, objects, out=None):
         '''Write out csv rows with the given objects and fields.
         If out is not None then call out.write() with the result and return None

--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -466,7 +466,6 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         return self.errorEmailThankYou()
 
 
-    #security.declareProtected('View', 'writeExportRows')
     @unpublished
     def writeExportRows(self, fieldsAndLabels, objects, out=None):
         '''Write out csv rows with the given objects and fields.

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -64,7 +64,7 @@ from ZenossSecurity import (
   ZEN_DELETE_DEVICE, ZEN_ADMIN_DEVICE, ZEN_MANAGE_DMD,
   ZEN_EDIT_LOCAL_TEMPLATES, ZEN_CHANGE_DEVICE_PRODSTATE,
 )
-from Products.ZenUtils.Utils import edgesToXML
+from Products.ZenUtils.Utils import edgesToXML, unpublished
 from Products.ZenUtils import NetworkTree
 
 from zope.interface import implements
@@ -2093,6 +2093,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         return edgesToXML(edges, start)
 
     security.declareProtected(ZEN_VIEW, 'getPrettyLink')
+    @unpublished
     def getPrettyLink(self, target=None, altHref=""):
         """
         Gets a link to this device, plus an icon

--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -42,7 +42,7 @@ from Products.ZenUtils.Utils import isXmlRpc, setupLoggingHeader, executeCommand
 from Products.ZenUtils.Utils import binPath, clearWebLoggingStream
 from Products.ZenUtils import NetworkTree
 from Products.ZenUtils.Utils import edgesToXML
-from Products.ZenUtils.Utils import unused, zenPath
+from Products.ZenUtils.Utils import unused, zenPath, unpublished
 from Products.Jobber.jobs import SubprocessJob
 from Products.ZenWidgets import messaging
 
@@ -629,6 +629,7 @@ class IpNetwork(DeviceOrganizer):
             return '/zport/dmd/img/icons/noicon.png'
 
 
+    @unpublished
     def urlLink(self, text=None, url=None, attrs={}):
         """
         Return an anchor tag if the user has access to the remote object.

--- a/Products/ZenModel/Organizer.py
+++ b/Products/ZenModel/Organizer.py
@@ -20,7 +20,7 @@ from Products.ZenRelations.RelSchema import *
 from Products.ZenUtils.Exceptions import ZentinelException
 from Products.ZenWidgets import messaging
 from Products.ZenMessaging.audit import audit
-from Products.ZenUtils.Utils import getDisplayType, getDisplayName
+from Products.ZenUtils.Utils import getDisplayType, getDisplayName, unpublished
 
 from EventView import EventView
 from ZenModelRM import ZenModelRM
@@ -56,6 +56,7 @@ class Organizer(ZenModelRM, EventView):
         ZenModelRM.__init__(self, id)
         self.description = description
 
+    @unpublished
     def urlLink(self, text=None, url=None, attrs={}):
         """
         Override urlLink to return a link with the full path of the organizer.

--- a/Products/ZenModel/ZenModelBase.py
+++ b/Products/ZenModel/ZenModelBase.py
@@ -33,7 +33,7 @@ from Acquisition import aq_base, aq_chain
 from Products.ZenModel.interfaces import IZenDocProvider
 from Products.ZenUtils.Utils import zenpathsplit, zenpathjoin, getDisplayType
 from Products.ZenUtils.Utils import createHierarchyObj, getHierarchyObj
-from Products.ZenUtils.Utils import getObjByPath
+from Products.ZenUtils.Utils import getObjByPath, unpublished
 
 from Products.ZenUtils.Utils import prepId as globalPrepId, isXmlRpc
 from Products.ZenWidgets import messaging
@@ -200,6 +200,7 @@ class ZenModelBase(object):
             return screen()
 
 
+    @unpublished
     def zenScreenUrl(self):
         """
         Return the url for the current screen as defined by zenScreenName.
@@ -213,6 +214,7 @@ class ZenModelBase(object):
         return self.getPrimaryUrlPath() + "/" + screenName
 
 
+    @unpublished
     def urlLink(self, text=None, url=None, attrs={}):
         """
         Return an anchor tag if the user has access to the remote object.
@@ -428,6 +430,7 @@ class ZenModelBase(object):
         return '/'+'/'.join(path)
 
 
+    @unpublished
     def zenpathjoin(self, path):
         """
         DEPRECATED Build a Zenoss path based on a list or tuple.
@@ -456,6 +459,7 @@ class ZenModelBase(object):
         return createHierarchyObj(root, name, factory, relpath, alog)
 
 
+    @unpublished
     def getHierarchyObj(self, root, name, relpath):
         """
         DEPRECATED this doesn't seem to be used anywere don't use it!!!

--- a/Products/ZenModel/skins/zenmodel/Dashboard.pt
+++ b/Products/ZenModel/skins/zenmodel/Dashboard.pt
@@ -19,10 +19,10 @@
 <tal:block metal:fill-slot="contentPane">
 <div id="portletContainer"></div>
 <script tal:define="settings python:here.ZenUsers.getUserSettings();
-                    json settings/dashboardState | string:null"
+                    json python:repr(settings.dashboardState)"
     tal:content="string:
     var start_time = '${here/server_time}';
-    var state = '${settings/dashboardState}';
+    var state = ${json};
     if(state) var dashboardState = evalJSON(state);
 "></script>
 <script>

--- a/Products/ZenUtils/Utils.py
+++ b/Products/ZenUtils/Utils.py
@@ -2162,3 +2162,13 @@ def getTranslation(msgId, REQUEST, domain='zenoss'):
         if msg != msgId:
             return msg
     return msg
+
+def unpublished(func):
+    """Makes decorated method unpublished.
+
+    Removes docstring of decorated method thus it will not be
+    published by Zope.
+    """
+    func.__doc__ = None
+    return func
+


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-15410

Zope doesn't publish methods with no docstring set. Added the decorator to remove docstrings.