### PR TITLE
Fixes ZEN-21945 "User cannot create maintenance window despite ZenManager privs to the organizer"

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
@@ -808,6 +808,10 @@ Ext.define("Zenoss.devicemanagement.Administration", {
         constructor: function(config) {
             config = config || {};
 
+            Zenoss.Security.onPermissionsChange(function() {
+                this.disableButtons();
+            }, this);
+
             Ext.applyIf(config, {
                 stateId: config.id || 'maintwindow_grid',
                 sm: Ext.create('Zenoss.SingleRowSelectionModel', {}),
@@ -818,6 +822,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'add',
                     tooltip: _t('Set up a new Maintenance Window'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'addButton',
                         handler: function() {
@@ -863,6 +868,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'customize',
                     tooltip: _t('Edit selected Maintenance Window'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'customizeButton',
                         handler: function() {
@@ -882,6 +888,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'suppress',
                     tooltip: _t('Toggle Enable/Disable on selected Maintenance Window'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'disableMaintButton',
                         handler: function() {
@@ -1020,6 +1027,14 @@ Ext.define("Zenoss.devicemanagement.Administration", {
             Zenoss.remote.DeviceManagementRouter.getTimeZone({}, function(response){
                 if(response.success){
                     timeZone = response.data;
+                }
+            });
+        },
+        disableButtons: function() {
+            var btns = this.query("button");
+            Ext.each(btns, function(btn){
+                if(btn.requiredPermission) {
+                    btn.setDisabled(Zenoss.Security.doesNotHavePermission(btn.requiredPermission));    
                 }
             });
         }

--- a/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
@@ -822,8 +822,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'add',
                     tooltip: _t('Set up a new Maintenance Window'),
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Maintenance Windows Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Maintenance Windows Edit'),
                     ref: 'addButton',
                         handler: function() {
                             var grid = Ext.getCmp("maintWindowGrid");
@@ -868,8 +868,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'customize',
                     tooltip: _t('Edit selected Maintenance Window'),
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Maintenance Windows Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Maintenance Windows Edit'),
                     ref: 'customizeButton',
                         handler: function() {
                             var grid = Ext.getCmp("maintWindowGrid"),
@@ -888,8 +888,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'suppress',
                     tooltip: _t('Toggle Enable/Disable on selected Maintenance Window'),
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Maintenance Windows Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Maintenance Windows Edit'),
                     ref: 'disableMaintButton',
                         handler: function() {
                             var grid = Ext.getCmp("maintWindowGrid"),

--- a/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
@@ -809,7 +809,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
             config = config || {};
 
             Zenoss.Security.onPermissionsChange(function() {
-                this.disableButtons();
+                disableButtons(this);
             }, this);
 
             Ext.applyIf(config, {
@@ -1029,14 +1029,6 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     timeZone = response.data;
                 }
             });
-        },
-        disableButtons: function() {
-            var btns = this.query("button");
-            Ext.each(btns, function(btn){
-                if(btn.requiredPermission) {
-                    btn.setDisabled(Zenoss.Security.doesNotHavePermission(btn.requiredPermission));    
-                }
-            });
         }
     });
 
@@ -1047,6 +1039,15 @@ Ext.define("Zenoss.devicemanagement.Administration", {
         }
         return false;
     };
+
+    var disableButtons = function(cmp) {
+        var btns = cmp.query("button");
+        Ext.each(btns, function(btn){
+            if(btn.requiredPermission) {
+                btn.setDisabled(Zenoss.Security.doesNotHavePermission(btn.requiredPermission));
+            }
+        });
+    }
 
 
 // ------------------------------------------------------- Commands:
@@ -1086,6 +1087,10 @@ Ext.define("Zenoss.devicemanagement.Administration", {
         constructor: function(config) {
             config = config || {};
 
+            Zenoss.Security.onPermissionsChange(function() {
+                disableButtons(this);
+            }, this);
+
             Ext.applyIf(config, {
                 stateId: config.id || 'admincommands_grid',
                 sm: Ext.create('Zenoss.SingleRowSelectionModel', {}),
@@ -1096,6 +1101,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'add',
                     tooltip: _t('Add a User Command'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'addButton',
                         handler: function() {
@@ -1141,6 +1147,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'customize',
                     tooltip: _t('Edit selected User Command'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'customizeButton',
                         handler: function() {
@@ -1160,6 +1167,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     iconCls: 'export',
                     tooltip: _t('Add selected User Command to ZenPack'),
                     ref: '../refreshButton',
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     handler: function() {
                         var grid = Ext.getCmp("deviceCommandsGrid");
@@ -1171,6 +1179,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                         xtype: 'button',
                         iconCls: 'acknowledge',
                         tooltip: _t('Run the selected command'),
+                        requiredPermission: 'Manage Device', // change the line below as well
                         disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                         listeners: {
                             afterrender: function(b){
@@ -1284,6 +1293,10 @@ Ext.define("Zenoss.devicemanagement.Administration", {
         constructor: function(config) {
             config = config || {};
 
+            Zenoss.Security.onPermissionsChange(function() {
+                disableButtons(this);
+            }, this);
+
             Ext.applyIf(config, {
                 stateId: config.id || 'admins_grid',
                 sm: Ext.create('Zenoss.SingleRowSelectionModel', {}),
@@ -1294,6 +1307,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'add',
                     tooltip: _t('Add a User'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'addButton',
                         handler: function() {
@@ -1339,6 +1353,7 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'set',
                     tooltip: _t('Edit users on the advanced user account edit page'),
+                    requiredPermission: 'Manage Device', // change the line below as well
                     disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
                     ref: 'editAdminButton',
                         handler: function() {


### PR DESCRIPTION
Permissions were handled appropriately on the back-end, but the UI was not updating the enabled/disabled status of buttons when the context changes.  I added a callback method to update these when the user switches to a different selection in the tree.