### PR TITLE
Apply prepId to service organizers.

### DIFF
--- a/Products/ZenModel/Organizer.py
+++ b/Products/ZenModel/Organizer.py
@@ -53,6 +53,7 @@ class Organizer(ZenModelRM, EventView):
         @type description: string
         @rtype: Organizer
         """
+        id = self.prepId(id)
         ZenModelRM.__init__(self, id)
         self.description = description
 
@@ -183,6 +184,7 @@ class Organizer(ZenModelRM, EventView):
         if factory is None:
             factory = self.__class__
         if not newPath: return self.callZenScreen(REQUEST)
+        newPath = self.prepId(newPath)
         try:
             if newPath.startswith("/"):
                 org = self.createOrganizer(newPath)
@@ -355,8 +357,12 @@ class Organizer(ZenModelRM, EventView):
         >>> dmd.Events.Status.getOrganizer('/Events/Status/Snmp')
         <EventClass at /zport/dmd/Events/Status/Snmp>
         """
-        if path.startswith("/"): path = path[1:]
-        return self.getDmdRoot(self.dmdRootName).unrestrictedTraverse(path)
+        path = self.prepId(path)
+        if path.startswith("/"):
+            path = path[1:]
+            return self.getDmdRoot(self.dmdRootName).unrestrictedTraverse(path)
+        else:
+            return self._getOb(path)
 
 
     security.declareProtected(ZEN_COMMON, "getOrganizerName")

--- a/Products/ZenModel/Organizer.py
+++ b/Products/ZenModel/Organizer.py
@@ -184,11 +184,11 @@ class Organizer(ZenModelRM, EventView):
         if factory is None:
             factory = self.__class__
         if not newPath: return self.callZenScreen(REQUEST)
-        newPath = self.prepId(newPath)
         try:
             if newPath.startswith("/"):
                 org = self.createOrganizer(newPath)
             else:
+                newPath = self.prepId(newPath)
                 org = factory(newPath)
                 self._setObject(org.id, org)
         except ZentinelException, e:

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -230,10 +230,7 @@ class TreeFacade(ZuulFacade):
     def addOrganizer(self, contextUid, id, description=''):
         context = self._getObject(contextUid)
         context.manage_addOrganizer(id)
-        if id.startswith("/"):
-            organizer = context.getOrganizer(id)
-        else:
-            organizer = context._getOb(id)
+        organizer = context.getOrganizer(id)
         organizer.description = description
         return IOrganizerInfo(organizer)
 


### PR DESCRIPTION
Service names were sanitized by Products.ZenUtils.Utils.prepId, but
service organizer names were not.