### PR TITLE
Revert "For devices modeled with SNMP use SNMP status to determine their status"

### DIFF
--- a/Products/Zuul/infos/device.py
+++ b/Products/Zuul/infos/device.py
@@ -259,10 +259,7 @@ class DeviceInfo(InfoBase, HasEventsInfoMixin, LockableMixin):
 
     @property
     def status(self):
-        if not self.snmpSysName:
-            status = self._object.getPingStatus()
-        else:
-            status = self._object.getSnmpStatus()
+        status = self._object.getPingStatus()
         return None if status is None else status < 1
 
     @property


### PR DESCRIPTION


This reverts commit ff514e434d9db97e4c90a61cace72b0ba2d4de0d.