### PR TITLE
ZEN-22132: User Commands button timeout broken

### DIFF
--- a/Products/ZenModel/data/devices.xml
+++ b/Products/ZenModel/data/devices.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 20:03:31.149820
+    Zenoss RelationshipManager export completed on 2016-03-16 11:42:10.870027
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.1.1]" export_date="2016-01-05 20:03:31.149820" zenoss_server="37fd526bfa96" >
+<objects version="[Zenoss, version 5.1.2]" export_date="2016-03-16 11:42:10.870027" zenoss_server="a60962dcdcb2" >
 <object id='/zport/dmd/Devices' module='Products.ZenModel.DeviceClass' class='DeviceClass'>
 <property type="lines" id="devtypes" mode="w" >
 []
@@ -192,6 +192,9 @@ False
 </property>
 <property visible="True" type="date" id="cDateTest" >
 1900/01/01 00:00:00 US/Central
+</property>
+<property visible="True" label="Timeout for User Commands (seconds)" type="float" description="Specifies the time to wait for a user command to complete." id="zCommandUserCommandTimeout" >
+15.0
 </property>
 <tomanycont id='zenMenus'>
 <object id='More' module='Products.ZenModel.ZenMenu' class='ZenMenu'>

--- a/Products/ZenModel/data/menus.xml
+++ b/Products/ZenModel/data/menus.xml
@@ -4812,42 +4812,6 @@ False
 </object>
 </tomanycont>
 </object>
-<object id='SupportBundleFiles_list' module='Products.ZenModel.ZenMenu' class='ZenMenu'>
-<tomanycont id='zenMenuItems'>
-<object id='deleteSupportBundle' module='Products.ZenModel.ZenMenuItem' class='ZenMenuItem'>
-<property id='zendoc' type='string'>
-Delete Support Bundle...
-</property>
-<property type="text" id="description" mode="w" >
-Delete Support Bundle...
-</property>
-<property type="text" id="action" mode="w" >
-dialog_deleteSupportBundle
-</property>
-<property type="boolean" id="isglobal" mode="w" >
-True
-</property>
-<property type="lines" id="permissions" mode="w" >
-('Change Device',)
-</property>
-<property type="lines" id="banned_classes" mode="w" >
-[]
-</property>
-<property type="lines" id="allowed_classes" mode="w" >
-[]
-</property>
-<property type="lines" id="banned_ids" mode="w" >
-[]
-</property>
-<property type="boolean" id="isdialog" mode="w" >
-True
-</property>
-<property type="float" id="ordering" mode="w" >
-90.5
-</property>
-</object>
-</tomanycont>
-</object>
 <object id='Templates' module='Products.ZenModel.ZenMenu' class='ZenMenu'>
 <tomanycont id='zenMenuItems'>
 <object id='addTemplate' module='Products.ZenModel.ZenMenuItem' class='ZenMenuItem'>

--- a/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
+++ b/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
@@ -18,7 +18,7 @@ import Migrate
 
 class addzCommandUserCommandTimeout(Migrate.Step):
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(5, 1, 2)
 
     def cutover(self, dmd):
         if not hasattr(dmd.Devices, 'zCommandUserCommandTimeout'):

--- a/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
+++ b/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
@@ -1,0 +1,28 @@
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+
+__doc__='''
+Add zCommandUserCommandTimeout z property.  This one is only applied for
+user commands run.
+'''
+
+import Migrate
+
+
+class addzCommandUserCommandTimeout(Migrate.Step):
+
+    version = Migrate.Version(5, 2, 0)
+
+    def cutover(self, dmd):
+        if not hasattr(dmd.Devices, 'zCommandUserCommandTimeout'):
+            dmd.Devices._setProperty('zCommandUserCommandTimeout', 15.0, type='float')
+
+
+addzCommandUserCommandTimeout()

--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -93,6 +93,7 @@ Z_PROPERTIES = [
     ('zCommandLoginTries', 1, 'int', 'Command Login Tries', 'Sets the number of times to attempt login.'),
     ('zCommandLoginTimeout', 10.0, 'float', 'Timeout for Login (seconds)', 'Specifies the time to wait for a login prompt.'),
     ('zCommandCommandTimeout', 10.0, 'float', 'Timeout for Commands (seconds)', 'Specifies the time to wait for a command to complete.'),
+    ('zCommandUserCommandTimeout', 15.0, 'float', 'Timeout for User Commands (seconds)', 'Specifies the time to wait for a user command to complete.'),
     ('zCommandSearchPath', [], 'lines', 'Command Search Path', 'Sets the path to search for any commands.'),
     ('zCommandExistanceTest', 'test -f %s', 'string', 'Command Existance Test', ''),
     ('zCommandPath', '/usr/local/zenoss/libexec', 'string', 'Command Path', 'Sets the default path where ZenCommand plug-ins are installed on the local Resource Manager box (or on a remote box where SSH is used to run the command).'),

--- a/Products/ZenRelations/zPropertyCategory.py
+++ b/Products/ZenRelations/zPropertyCategory.py
@@ -29,6 +29,7 @@ MAPPINGS = {
 # zencommand
 # ----------
 'zCommandCommandTimeout': 'zencommand',
+'zCommandUserCommandTimeout': 'zencommand',
 'zCommandExistanceTest': 'zencommand',
 'zCommandLoginTimeout': 'zencommand',
 'zCommandLoginTries': 'zencommand',

--- a/Products/ZenUI3/browser/command.py
+++ b/Products/ZenUI3/browser/command.py
@@ -68,7 +68,7 @@ class CommandView(StreamingView):
         try:
             compiled = str(self.context.compile(cmd, target))
 
-            timeout = getattr(target, 'zCommandCommandtimeout',
+            timeout = getattr(target, 'zCommandUserCommandTimeout',
                               self.context.defaultTimeout)
             end = time.time() + timeout
             self.write('==== %s ====' % target.titleOrId())
@@ -81,7 +81,7 @@ class CommandView(StreamingView):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT)
             retcode = None
-            while time.time() < end:
+            while time.time() < end or retcode is not None:
                 line = p.stdout.readline()
                 if not line:
                     time.sleep(0.5)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-22132

Port of the https://github.com/zenoss/zenoss-prodbin/pull/1555 to 5.1.x

ZODB dump had incorrect DB version (5.1.70) so I fixed this and reapplied all migrations with version 5.0.70 and above.