### PR TITLE
Bump Zenoss version to 5.2.0

### DIFF
--- a/Products/ZenModel/ZVersion.py
+++ b/Products/ZenModel/ZVersion.py
@@ -7,5 +7,6 @@
 # 
 ##############################################################################
 
-# If you change this, also change inst/zenoss-version/setup.py
-VERSION="5.0.70"
+# If you change this, also change legacy/zenoss-version/setup.py
+#  in the zenoss/platform-build repository.
+VERSION="5.2.0"


### PR DESCRIPTION
Per Ian, we are deliberately abandoning the *.70 version scheme for the develop branch.
Fixes [ZEN-22760](https://jira.zenoss.com/browse/ZEN-22760)
See also https://github.com/zenoss/platform-build/pull/671