### PR TITLE
ZEN-22820 Some Zenpacks missing in UCSPM 2.0.1 upgrade

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -361,12 +361,22 @@ class ZenPackCmd(ZenScriptBase):
         linkedPacks = []
 
         # find any new zenpacks to be installed
+        from_version = self.dmd.version
+        from_version = ' '.join([x for x in from_version.split()
+                                 if x[0].isdigit() and x[-1].isdigit()])
+        from_version = parse_version(from_version)
+        to_version = parse_version(VERSION)
         if os.path.isfile(ZPHISTORY):
+            self.log.info("Scanning %s for new Zenpacks." % (ZPHISTORY))
             try:
                 zphistory = json.load(open(ZPHISTORY))
                 for zp in zphistory:
-                    if parse_version(zphistory[zp]) > parse_version(VERSION):
+                    zp_version = parse_version(zphistory[zp])
+                    if zp_version > from_version and zp_version <= to_version:
+                        self.log.info("Zenpack %s (new since %s) to be installed." % (zp, zp_version))
                         zpsToRestore[zp] = (get_distribution(zp).version, False, ZPSource.disk, False)
+                    else:
+                        self.log.info("Zenpack %s (new since %s) is not new." % (zp, zp_version))
             except:
                 pass
 


### PR DESCRIPTION
Changes the version check during restore so Zenpacks
new since the dmd version and no older than what's in ZVersion
are installed new.