### PR TITLE
ZEN-22368 Set chart width to fill column

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -166,14 +166,14 @@
             var padding = "padding:5px 5px 5px 0px;";
             // backcompat from graph dimensions from rrd
             // the properties were saved on each graph definition and we want to
-            // both preserve backward compabability
-            // so therefore
+            // preserve backward compabability
             if (config.height === 100 && config.width === 500) {
                 config.height = 500;
-                delete config.width;
             } else if (config.height == undefined) {
                 config.height = 500;
             }
+            // width is not customizable - always fills column
+            delete config.width;
 
             // dynamically adjust the height;
             config.graphPadding = padding;

--- a/Products/ZenUI3/browser/resources/js/zenoss/monitoringTemplates/graph.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/monitoringTemplates/graph.js
@@ -549,11 +549,6 @@ Ext.create('Zenoss.dialog.BaseWindow', {
             name: 'height',
             minValue: 250
         },{
-            xtype: 'numberfield',
-            fieldLabel: _t('Width'),
-            name: 'width',
-            minValue: 0
-        },{
             xtype: 'textfield',
             fieldLabel: _t('Units'),
             name: 'units'


### PR DESCRIPTION
Graphs will now always fill columns. User setting of width is removed. User can still set height.