### PR TITLE
Don't include port when setting the cookie's domain

### DIFF
--- a/Products/ZenUI3/browser/pages.py
+++ b/Products/ZenUI3/browser/pages.py
@@ -54,7 +54,7 @@ class DaemonsView(BrowserView):
                 name = cookie['name'],
                 value = cookie['value'],
                 quoted = True,
-                domain = self.request.environ['HTTP_HOST'],
+                domain = self.request.environ['HTTP_HOST'].split(':')[0], # Don't include the port
                 path = '/',
                 secure = cookie['secure']
             )


### PR DESCRIPTION
Port of #1691 
Fixes ZEN-23402