### PR TITLE
Fix permission checks so that they fall through correctly

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/Action.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Action.js
@@ -19,8 +19,8 @@
             this.setDisabled(this.checkDisabled());
         },
         checkDisabled: function() {
-            if (this.permitted) {
-                return false;
+            if (!this.permitted) {
+                return true;
             }
             if (this.externallyDisabled) {
                 return true;

--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -18,8 +18,10 @@ Ext.ns('Zenoss.extensions');
 var EXTENSIONS_adddevice = Zenoss.extensions.adddevice instanceof Array ?
                            Zenoss.extensions.adddevice : [];
 Zenoss.env.treesm = null;
+
 // page level variables
 var REMOTE = Zenoss.remote.DeviceRouter;
+var deviceButtonsDisabled = false;
 
 Zenoss.env.initProductionStates();
 Zenoss.env.initPriorities();
@@ -141,6 +143,8 @@ var deviceClassCombo = {
 };
 
 function setDeviceButtonsDisabled(bool){
+    // Save the flag so we can enable/disable these on permission change.
+    deviceButtonsDisabled = bool;
     // must also check permissions before enable/disable the
     // 'deleteDevices' button
     Zenoss.devices.deleteDevices.setDisabled(bool ||
@@ -1527,15 +1531,17 @@ Zenoss.Security.onPermissionsChange(function(){
     if (btn) {
         btn.setDisabled(Zenoss.Security.doesNotHavePermission('Manage DMD'));
     }
-    Ext.getCmp('commands-menu').setDisabled(Zenoss.Security.doesNotHavePermission('Run Commands'));
     Ext.getCmp('addsingledevice-item').setDisabled(Zenoss.Security.doesNotHavePermission('Manage DMD'));
-    Ext.getCmp('actions-menu').setDisabled(Zenoss.Security.doesNotHavePermission('Change Device'));
     Ext.getCmp('footer_add_button').setVisible(Zenoss.Security.hasPermission('Manage DMD'));
     Ext.getCmp('footer_delete_button').setVisible(Zenoss.Security.hasPermission('Manage DMD'));
     Ext.getCmp('master_panel').details.setDisabled(Zenoss.Security.doesNotHavePermission('View'));
     Ext.getCmp("context-configure-menu").setVisible(Zenoss.Security.hasPermission('Manage DMD'));
     Ext.getCmp('context-configure-menu').setDisabled(Zenoss.Security.doesNotHavePermission('Manage DMD'));
-    //Ext.getCmp('organizer_events').setVisible();
+    
+    // The commands-menu and actions-menu are enabled/disabled based on both selection and
+    // granted permissions.  When permission changes, we'll reevaluate this using the last
+    // flag given.
+    setDeviceButtonsDisabled(deviceButtonsDisabled);
 });
 
 var createEventsGrid = function(re_attach_to_container) {


### PR DESCRIPTION
If role based permissions granted access to a button, the
button was always enabled.  This change allows other states
(like no devices being selected) to disable controls even
if the role has access to the function.  This check-in also
fixes a permission error for the action and commands dropdown
menus so they get disabled properly when permissions change.