### PR TITLE
Import zensocket into prodbin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 Products/README.txt
 Products/ZenUI3/browser/resources/js/deploy/
 Products/ZenUI3/node_modules
+bin/zensocket
 #daemons
 bin/runzope
 bin/runzope.bat
@@ -25,3 +26,4 @@ bin/zenvmwareperf
 *.iml
 *.pyc
 *~
+*.tar.gz

--- a/javascript.mk
+++ b/javascript.mk
@@ -43,6 +43,8 @@ JSBUILDER = /opt/zenoss/share/java/sencha_jsbuilder-2/JSBuilder2.jar
 UID := $(shell id -u)
 GID := $(shell id -g)
 
+.PHONY: clean-javascript build-javascript
+
 clean-javascript:
 	-rm -rf $(JS_OUTPUT_DIR)
 

--- a/javascript.mk
+++ b/javascript.mk
@@ -40,9 +40,6 @@ JS_OUTPUT_DIR = $(ZENOSS_JS_BASEDIR)/$(JSB_DEPLOY_DIR)
 # JSBUILDER - the path to the JSBuilder jar in the runtime image
 JSBUILDER = /opt/zenoss/share/java/sencha_jsbuilder-2/JSBuilder2.jar
 
-UID := $(shell id -u)
-GID := $(shell id -g)
-
 .PHONY: clean-javascript build-javascript
 
 clean-javascript:
@@ -50,8 +47,4 @@ clean-javascript:
 
 build-javascript:
 	@echo "Minifying $(ZENOSS_SRC_BASEDIR) -> $(JS_OUTPUT_DIR)/$(JSB_COMPILED_JS_NAME)"
-	docker run --rm \
-		-v $(PWD):/mnt \
-		--user $(UID):$(GID) \
-		$(BUILD_IMAGE_TAG) \
-		/bin/bash -c "cd /mnt && java -jar $(JSBUILDER) -p $(ZENOSS_JSB_FILE) -d $(ZENOSS_JS_BASEDIR) -v"
+	$(DOCKER_RUN) "cd /mnt && java -jar $(JSBUILDER) -p $(ZENOSS_JSB_FILE) -d $(ZENOSS_JS_BASEDIR) -v"

--- a/javascript.mk
+++ b/javascript.mk
@@ -40,21 +40,13 @@ JS_OUTPUT_DIR = $(ZENOSS_JS_BASEDIR)/$(JSB_DEPLOY_DIR)
 # JSBUILDER - the path to the JSBuilder jar in the runtime image
 JSBUILDER = /opt/zenoss/share/java/sencha_jsbuilder-2/JSBuilder2.jar
 
-# Define the name, version and tag name for the docker build image
-# Note that build-tools is derived from zenoss-centos-base which contains JSBuilder
-BUILD_IMAGE = build-tools
-BUILD_VERSION = 0.0.3
-BUILD_IMAGE_TAG = zenoss/$(BUILD_IMAGE):$(BUILD_VERSION)
-
 UID := $(shell id -u)
 GID := $(shell id -g)
 
-.PHONY: clean build
-
-clean:
+clean-javascript:
 	-rm -rf $(JS_OUTPUT_DIR)
 
-build:
+build-javascript:
 	@echo "Minifying $(ZENOSS_SRC_BASEDIR) -> $(JS_OUTPUT_DIR)/$(JSB_COMPILED_JS_NAME)"
 	docker run --rm \
 		-v $(PWD):/mnt \

--- a/legacy/zensocket/README
+++ b/legacy/zensocket/README
@@ -1,0 +1,16 @@
+Zenoss needs to have root permissions to open some sockets, but we
+don't want the zenoss scripts to be a giant security hole. 
+
+Zensocket replaces the use of sudo in zenoss scripts.
+
+Zensocket is run like this:
+
+	  zensocket --listen=<port number> -- command to run
+
+Where "$privilegedSocket" is substituted in the command strings with
+the file descriptor number.
+
+Alternatively, access to a ping socket is available like this:
+
+	  zensocket --ping -- zenping $ARGS --fd=$privilegedSocket
+

--- a/legacy/zensocket/zensocket.c
+++ b/legacy/zensocket/zensocket.c
@@ -1,0 +1,344 @@
+/*****************************************************************************
+ *
+ * Copyright (C) Zenoss, Inc. 2007, all rights reserved.
+ *
+ * This content is made available according to terms specified in
+ * License.zenoss under the directory where your Zenoss product is installed.
+ *
+ ****************************************************************************/
+
+
+#include <sys/types.h>
+
+#include <getopt.h>
+#if defined (__SVR4) && defined (__sun)
+/* ifaddrs.h doesn't exist on Sun */
+#else
+#   include <ifaddrs.h>
+#endif
+#include <netdb.h>
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <sys/socket.h>
+
+#include <netinet/in.h>
+
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+
+
+static struct option options[] = {
+    {"ping",   no_argument, 0, 0},
+    {"listen", no_argument, 0, 0},
+    {"proto", required_argument, 0, 0},
+    {"port", required_argument, 0, 0},
+    {"socketOpt", required_argument, 0, 0},
+    { 0, 0, 0, 0 }
+};
+
+#define ZEN_MAX_SO_OPTIONS 32
+struct socket_options_set {
+  int code;
+  int value;
+};
+
+static void error(const char * fmt, ...) {
+    va_list args;
+
+    fprintf(stderr, "ZenSocket Error: ");
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    va_end(args);
+    fprintf(stderr, "\n");
+    exit(EXIT_FAILURE);
+}
+
+static void usage(const char *name) {
+  printf("\n");
+  printf("Usage: %s [options] -- command to run\n", name);
+  printf("\n");
+  printf("Send Options:\n");
+  printf("  --ping                       send ICMP packets\n");
+  printf("\n");
+  printf("Listen Options:\n");
+  printf("  --listen                     listen for incoming packets\n");
+  printf("  --port:[interface:]number    the numerical port to listen on\n");
+  printf("  --proto:[udp|tcp]            protocol to listen for\n");
+  printf("\n");
+  printf("Other Options:\n");
+  printf("  --socketOpt=option:value     set the socket option\n");
+  printf("      *NOTE*: socket options are numerical values from sys/socket.h\n");
+  printf("\n");
+  exit(EXIT_FAILURE);
+}
+
+static in_addr_t getAddress(const char *interface) {
+  int a, b, c, d;
+
+  if (!interface || !*interface) {
+    return INADDR_ANY;
+  }
+
+  if (sscanf(interface, "%d.%d.%d.%d", &a, &b, &c, &d) != 4) {
+    struct addrinfo *res = 0, *p;
+
+    if (getaddrinfo(interface, NULL, NULL, &res) == 0) {
+	    in_addr_t result;
+	    for (p = res; p; p = p->ai_next) {
+        if (p->ai_family == AF_INET) {
+          struct sockaddr_in * in = (struct sockaddr_in *)p->ai_addr;
+          result = in->sin_addr.s_addr;
+          break;
+        }
+	    }
+
+	    freeaddrinfo(res);
+	    if (p) {
+        return result;
+      }
+    }
+
+    fprintf(stderr, "Warning: unable to decode address %s\n", interface);
+    return INADDR_ANY;
+  }
+
+  return htonl( ((a & 0xff) << 24) | ((b & 0xff) << 16) |
+                ((c & 0xff) << 8)  |  (d & 0xff) );
+}
+
+/*
+ * Create an IPv6 socket and bind it to the listen port.
+ */
+static int bind_ipv6_socket(int type, uint16_t port, int *ipv6_socket) {
+  int sock;
+  int v6only_value;
+  int v6only_status;
+  struct sockaddr_in6 address;
+  sock = socket(PF_INET6, type, 0);
+  if (sock == -1) {
+    return -1;
+  }
+  v6only_value = 0;
+  v6only_status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, &v6only_value, sizeof(v6only_value));
+  if (v6only_status == -1) {
+    close(sock);
+    return -1;
+  }
+  address.sin6_family = AF_INET6;
+  address.sin6_port = htons(port);
+  address.sin6_addr = in6addr_any;
+  if (bind(sock, (struct sockaddr *) &address, sizeof(struct sockaddr_in6)) < 0) {
+    close(sock);
+    return -1;
+  }
+  *ipv6_socket = sock;
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  char **args = 0;
+  const char * replace = "$privilegedSocket";
+  int i, c;
+  int ping = 0;
+  int listen = 0;
+  int proto_sock = SOCK_DGRAM;
+  const char * interface = 0;
+  unsigned short port = 0;
+  int sock = -1;
+  char filenoString[10] = "";
+  int so_index = -1; /* Track number of options set */
+  int max_index = -1;
+  struct socket_options_set so_setting[ZEN_MAX_SO_OPTIONS];
+  int bind_ipv6_status;
+
+  if (geteuid() != 0) {
+    error("zensocket needs to be run as root or setuid");
+  }
+
+  if (argc < 2) {
+    usage("zensocket");
+  }
+
+
+  while (1) {
+    int option_index = 0;
+    int c = getopt_long(argc, argv, "", options, &option_index);
+    if (c == -1)
+	    break;
+    switch (c) {
+    case 0:
+      /* ping option */
+	    if (option_index == 0)
+        ping = 1;
+
+      /* listen option */
+	    if (option_index == 1) {
+        listen = 1;
+      }
+
+      /* protocol option */
+      if (option_index == 2) {
+        if (!strcmp(optarg, "tcp")) {
+          proto_sock = SOCK_STREAM;
+        }
+        else if (!strcmp(optarg, "udp")) {
+          proto_sock = SOCK_DGRAM;
+        }
+        else {
+          error("proto should be either tcp or udp");
+        }
+      }
+
+      /* port option */
+      if (option_index == 3) {
+        char * portString = optarg;
+        char * colon = strchr(optarg, ':');
+        if (colon) {
+          *colon = '\0';
+          interface = optarg;
+          portString = colon + 1;
+        }
+
+        port = atol(portString);
+        if (port == 0) {
+          error("Unable to use port number");
+        }
+	    }
+
+      /* socket option */
+      if (option_index == 4) {
+        char * socketString = optarg;
+        char * colon = strchr(optarg, ':');
+        char * optValue = NULL;
+        if (colon) {
+          *colon = '\0';
+          optValue = colon + 1;
+        } else {
+          error("Socket option needs to be of the form #:#");
+        }
+
+        so_index++;
+        if(so_index >= ZEN_MAX_SO_OPTIONS) {
+          error("Too many socket options specified");
+        }
+        so_setting[so_index].code = atol(socketString);
+        so_setting[so_index].value = atol(optValue);
+      }
+	    break;
+
+    default:
+	    usage(argv[0]);
+    }
+  }
+
+  /* --ping and --listen are mutually exclusive - one must be specified */
+  if (ping == listen) {
+    usage(argv[0]);
+  }
+
+  if (ping) {
+    sock = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    if (sock < 0)
+	    error("Unable to create ping socket");
+  }
+  else if (listen) {
+
+    if (interface && strcmp(interface, "ipv6") == 0) {
+
+      bind_ipv6_status = bind_ipv6_socket(proto_sock, port, &sock);
+      if (bind_ipv6_status) {
+        error("Failed to bind IPv6 socket: %s", strerror(errno));
+      }
+
+    } else {
+
+      int reuse_addr = 1;
+      struct sockaddr_in addr;
+      int so_option, so_value;
+
+      sock = socket(AF_INET, proto_sock, 0);
+      if (sock < 0) {
+        error("Unable to create listen socket");
+      }
+
+      memset(&addr, 0, sizeof(addr));
+      addr.sin_family = AF_INET;
+      addr.sin_addr.s_addr = getAddress(interface);
+      addr.sin_port = htons(port);
+      if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &reuse_addr, sizeof(reuse_addr)) < 0) {
+        close(sock);
+        error("Unable to setsockopt SO_REUSEADDR");
+      }
+
+      /* ... Custom socket option values set here ... */
+      max_index = MIN(so_index, ZEN_MAX_SO_OPTIONS);
+      for(i=0; i <= max_index; i++) {
+        so_option = so_setting[i].code;
+        so_value = so_setting[i].value;
+        if(setsockopt(sock, SOL_SOCKET, so_option, &so_value, sizeof(so_value))) {
+          close(sock);
+          error("Unable to setsockopt");
+        }
+      }
+
+      if (bind(sock, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
+        close(sock);
+        error("Unable to bind to listen port (error code %d)", errno);
+      }
+
+    }
+
+  }
+
+  /* No need to be root any more */
+  if (getuid() != 0) {
+      setuid(getuid());
+  } else {
+      error("Unable to find a user to become");
+  }
+
+  if (optind >= argc) {
+    usage(argv[0]);
+  }
+
+  sprintf(filenoString, "%d", sock);
+  if (strlen(filenoString) > strlen(replace)) {
+    error("What are you up to?");
+  }
+  args = (char**)malloc(sizeof(char*)*(argc - optind + 1));
+
+  if (!args) {
+    error("Out of memory");
+  }
+
+  for (i = optind, c = 0; i < argc; i++, c++) {
+    char * p = strstr(argv[i], replace);
+    if (p) {
+      strcpy(p, filenoString);
+      strcpy(p + strlen(filenoString), p + strlen(replace));
+    }
+
+    args[c] = argv[i];
+  }
+
+  args[c] = 0;
+  {
+      char libdir[1000];
+      snprintf(libdir, sizeof(libdir)-1, "LD_LIBRARY_PATH=%s/lib", getenv("ZENHOME"));
+      if (putenv(libdir) != 0) {
+	  perror("Unable to set LD_LIBRARY_PATH");
+      }
+      if (execv(args[0], args) < 0) {
+	perror("exec fails");
+      }
+  }
+
+  free(args);
+  exit(EXIT_SUCCESS);
+
+  return 0;
+}

--- a/makefile
+++ b/makefile
@@ -8,6 +8,15 @@ BUILD_IMAGE = build-tools
 BUILD_VERSION = 0.0.3
 BUILD_IMAGE_TAG = zenoss/$(BUILD_IMAGE):$(BUILD_VERSION)
 
+UID := $(shell id -u)
+GID := $(shell id -g)
+
+DOCKER_RUN := docker run --rm \
+		-v $(PWD):/mnt \
+		--user $(UID):$(GID) \
+		$(BUILD_IMAGE_TAG) \
+		/bin/bash -c
+
 .PHONY: all clean build javascript zensocket
 
 include javascript.mk

--- a/makefile
+++ b/makefile
@@ -2,16 +2,22 @@ VERSION  := 5.2.0
 BRANCH   := develop
 ARTIFACT := prodbin-$(VERSION)-$(BRANCH).tar.gz
 
-.PHONY: all clean build javascript
+# Define the name, version and tag name for the docker build image
+# Note that build-tools is derived from zenoss-centos-base which contains JSBuilder
+BUILD_IMAGE = build-tools
+BUILD_VERSION = 0.0.3
+BUILD_IMAGE_TAG = zenoss/$(BUILD_IMAGE):$(BUILD_VERSION)
+
+.PHONY: all clean build javascript zensocket
+
+include javascript.mk
 
 all: build
 
-build: javascript
+build: build-javascript
 	tar cvfz $(ARTIFACT) Products bin
 
-javascript:
-	make -f javascript.mk build
-
-clean:
+clean: clean-javascript
 	rm -f $(ARTIFACT)
 	-make -f javascript.mk clean
+

--- a/makefile
+++ b/makefile
@@ -11,13 +11,13 @@ BUILD_IMAGE_TAG = zenoss/$(BUILD_IMAGE):$(BUILD_VERSION)
 .PHONY: all clean build javascript zensocket
 
 include javascript.mk
+include zensocket.mk
 
 all: build
 
-build: build-javascript
+build: build-javascript build-zensocket
 	tar cvfz $(ARTIFACT) Products bin
 
-clean: clean-javascript
+clean: clean-javascript clean-zensocket
 	rm -f $(ARTIFACT)
-	-make -f javascript.mk clean
 

--- a/zensocket.mk
+++ b/zensocket.mk
@@ -10,9 +10,6 @@ LDFLAGS :=
 ZENSOCKET_BINARY := bin/zensocket
 ZENSOCKET_SRC := legacy/zensocket/zensocket.c
 
-UID := $(shell id -u)
-GID := $(shell id -g)
-
 #
 # FIXME: the following logic needs to be somewhere such the file ownership/perms
 #        on the binary looks like:
@@ -27,9 +24,4 @@ build-zensocket: $(ZENSOCKET_BINARY)
 
 $(ZENSOCKET_BINARY): $(ZENSOCKET_SRC)
 	cd legacy/zensocket && \
-	docker run --rm \
-		-v $(PWD):/mnt \
-		--user $(UID):$(GID) \
-		$(BUILD_IMAGE_TAG) \
-		/bin/bash -c \
-		"cd /mnt && $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(ZENSOCKET_SRC)"
+	$(DOCKER_RUN) "cd /mnt && $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(ZENSOCKET_SRC)"

--- a/zensocket.mk
+++ b/zensocket.mk
@@ -1,0 +1,35 @@
+#
+# Makefile for zensocket
+#
+.PHONY: clean-zensocket build-zensocket
+
+CC      := gcc
+CFLAGS  := -Wall -pedantic -D__GNU_LIBRARY__ -g
+LDFLAGS :=
+
+ZENSOCKET_BINARY := bin/zensocket
+ZENSOCKET_SRC := legacy/zensocket/zensocket.c
+
+UID := $(shell id -u)
+GID := $(shell id -g)
+
+#
+# FIXME: the following logic needs to be somewhere such the file ownership/perms
+#        on the binary looks like:
+#-rwsr-x--- 1 root zenoss <size> <date> /opt/zenoss/bin/zensocket
+#
+# chown root $@; chmod uog+rx,u+ws $@"
+
+clean-zensocket:
+	rm -rf $(ZENSOCKET_BINARY)
+
+build-zensocket: $(ZENSOCKET_BINARY)
+
+$(ZENSOCKET_BINARY): $(ZENSOCKET_SRC)
+	cd legacy/zensocket && \
+	docker run --rm \
+		-v $(PWD):/mnt \
+		--user $(UID):$(GID) \
+		$(BUILD_IMAGE_TAG) \
+		/bin/bash -c \
+		"cd /mnt && $(CC) -o $@ $(CFLAGS) $(LDFLAGS) $(ZENSOCKET_SRC)"

--- a/zensocket.mk
+++ b/zensocket.mk
@@ -10,13 +10,6 @@ LDFLAGS :=
 ZENSOCKET_BINARY := bin/zensocket
 ZENSOCKET_SRC := legacy/zensocket/zensocket.c
 
-#
-# FIXME: the following logic needs to be somewhere such the file ownership/perms
-#        on the binary looks like:
-#-rwsr-x--- 1 root zenoss <size> <date> /opt/zenoss/bin/zensocket
-#
-# chown root $@; chmod uog+rx,u+ws $@"
-
 clean-zensocket:
 	rm -rf $(ZENSOCKET_BINARY)
 


### PR DESCRIPTION
Build zensocket as part of creating the prodbin artifact.

Note that the zensocket executable in /opt/zenoss/bin needs to be SETUID root, but this should be handled in the product-assembly repo somewhere. In the 5.0.x/5.1.x world, these settings where handled by `services/repos/zenoss5x/install-functions.sh` in the platform-build repo.