### PR TITLE
ZEN-24030: fixed typo in error message

### DIFF
--- a/Products/ZenModel/BatchDeviceLoader.py
+++ b/Products/ZenModel/BatchDeviceLoader.py
@@ -445,7 +445,7 @@ windows_device_3 setTitle="Windows AD Server 1", setHWTag="service-tag-ABCDEF", 
                     self.log.critical("Unknown device loader '%s'", loaderName)
                     sys.exit(1)
                 except Exception:
-                    devName = device_specs.get('device_specs', 'Unkown Device')
+                    devName = device_specs.get('device_specs', 'Unknown Device')
                     msg = "Ignoring device loader issue for %s" % devName
                     self.reportException(msg, devName, specs=str(device_specs))
                     processed['errors'] += 1


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-24030
Fixed spelling error in the 'Unknown Device' error.