### PR TITLE
Add config value for memcache max object size 

### DIFF
--- a/Products/ZenUtils/MySqlZodbFactory.py
+++ b/Products/ZenUtils/MySqlZodbFactory.py
@@ -9,7 +9,7 @@
 
 """MySqlZodbConnection
 """
-
+import uuid
 import logging
 log = logging.getLogger("zen.MySqlZodbFactory")
 
@@ -25,6 +25,8 @@ import _mysql_exceptions as db_exceptions
 
 from Products.ZenUtils.GlobalConfig import globalConfToDict
 from Products.ZenUtils.ZodbFactory import IZodbFactory
+
+import memcacheClientWrapper
 
 _DEFAULT_MYSQLPORT = 3306
 _DEFAULT_COMMIT_LOCK_TIMEOUT = 30
@@ -81,6 +83,8 @@ def _getDefaults(options=None):
     return settings
 
 
+
+
 class MySqlZodbFactory(object):
     implements(IZodbFactory)
 
@@ -133,8 +137,11 @@ class MySqlZodbFactory(object):
             socket = _ZENDS_CONFIG.get("socket")
         if socket:
             connectionParams['unix_socket'] = socket
+        wrappedModuleName = 'wrappedMemcache-' + str(uuid.uuid4())
+        memcacheClientWrapper.createModule(wrappedModuleName,
+                server_max_value_length = kwargs.get('zodb_cache_max_object_size'))
         relstoreParams = {
-            'cache_module_name':'memcache',
+            'cache_module_name': wrappedModuleName,
             'keep_history': kwargs.get('zodb_keep_history', False),
             'commit_lock_timeout': kwargs.get(
                 'zodb_commit_lock_timeout', _DEFAULT_COMMIT_LOCK_TIMEOUT)
@@ -199,6 +206,8 @@ class MySqlZodbFactory(object):
         group.add_option('--zodb-poll-interval', dest='zodb_poll_interval', default=None, type='int',
                     help='Defer polling the database for the specified maximum time interval, in seconds.'
                     ' This will default to 60 only if --zodb-cacheservers is set.')
+        group.add_option('--zodb-cache-max-object-size', dest='zodb_cache_max_object_size',
+                    default=None, type='int', help='memcached maximum object size in bytes')
         group.add_option(
             '--zodb-commit-lock-timeout',
             dest='zodb_commit_lock_timeout', default=30, type='int',

--- a/Products/ZenUtils/memcacheClientWrapper.py
+++ b/Products/ZenUtils/memcacheClientWrapper.py
@@ -1,0 +1,45 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+"""
+This module allows the override of arguments to the memcache.Client initializer.
+
+The RelStorage initializer allows specification of a module, which is used to
+construct a Client object for the purposes of connection to memcached.  There
+is no mechanism for overriding the arguments to the Client initializer.
+
+The solution is to dynamically create a module which wraps the memcache client
+module, replacing the Client class with one which binds the initializer arguments.
+"""
+
+import memcache
+import sys
+import types
+
+def createModule(moduleName, **kwargs):
+    """
+    Create a module wrapping the memcache module.
+
+    Given a module name and a set of keyword arguments, dynamically create a
+    module with that name which overrides the memcache module's Client
+    initializer arguments with the keyword arguments.
+    """
+    # Prevent overriding an existing module
+    if moduleName in sys.modules:
+        raise ValueError("Duplicate module name", moduleName)
+
+    # Create a subclass of memcache.Client which overrides the __init__ function
+    def init(self, *_args, **_kwargs):
+        _kwargs = dict(kwargs, **_kwargs)
+        memcache.Client.__init__(self, *_args, **_kwargs)
+    clientClass = type('Client', (memcache.Client,), {'__init__': init})
+
+    # Create a new module containing the new Client class
+    module = types.ModuleType(moduleName)
+    module.Client = clientClass
+    sys.modules[moduleName] = module

--- a/Products/ZenUtils/tests/testMemcacheClientWrapper.py
+++ b/Products/ZenUtils/tests/testMemcacheClientWrapper.py
@@ -1,0 +1,100 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import memcache
+import types
+import unittest
+import uuid
+import relstorage.storage
+
+from contextlib import contextmanager
+
+from Products.ZenUtils.memcacheClientWrapper import createModule
+
+@contextmanager
+def mockMemcacheClient():
+    """ Replace memcache.Client class with a mock """
+    class MockClient(object):
+        instances = []
+        def __init__(self, *args, **kwargs):
+            self.initArgs = args
+            self.initKwargs = kwargs
+            MockClient.instances.append(self)
+    original = memcache.Client
+    memcache.Client = MockClient
+    yield MockClient
+    memcache.Client = original
+
+
+class TestMemcacheClientWrapper(unittest.TestCase):
+    """ Tests the memcacheClientWrapper module """
+
+    def testModuleImportStatic(self):
+        moduleName = 'foo'
+        kwargs = {'foo':1, 'bar':2}
+        createModule(moduleName, **kwargs)
+        try:
+            import foo
+        except:
+            self.fail("Could not import module")
+        self.assertTrue(type(foo) is types.ModuleType)
+
+    def testModuleImportDynamic(self):
+        moduleName = str(uuid.uuid4())
+        kwargs = {'foo':1, 'bar':moduleName}
+        createModule(moduleName, **kwargs)
+        module = __import__(moduleName, {}, {}, [])
+        self.assertTrue(type(module) is types.ModuleType)
+        self.assertEqual(module.__name__, moduleName)
+
+    def testModuleContainsClientClass(self):
+        moduleName = str(uuid.uuid4())
+        kwargs = {'foo':1, 'bar':moduleName}
+        createModule(moduleName, **kwargs)
+        module = __import__(moduleName, {}, {}, [])
+        self.assertTrue('Client' in module.__dict__)
+        # module.Client is a class
+        self.assertTrue(type(module.Client) is type)
+
+    def testClientOveridesInitializer(self):
+        moduleName = str(uuid.uuid4())
+        kwargs = {'foo':1, 'bar': moduleName}
+        args = (1,2,'woot')
+        with mockMemcacheClient():
+            createModule(moduleName, **kwargs)
+            module = __import__(moduleName, {}, {}, [])
+            client = module.Client(*args)
+        self.assertEqual(client.initArgs, args)
+        self.assertEqual(client.initKwargs, kwargs)
+
+    def testClientArgOveride(self):
+        moduleName = str(uuid.uuid4())
+        moduleKwargs = {'foo':1, 'bar': moduleName}
+        initializerKwargs = {'foo':11, 'baz':None}
+        with mockMemcacheClient():
+            createModule(moduleName, **moduleKwargs)
+            module = __import__(moduleName, {}, {}, [])
+            client = module.Client(**initializerKwargs)
+        expected = dict(moduleKwargs, **initializerKwargs)
+        self.assertEqual(client.initKwargs, expected)
+
+    def testRelstorageUsesModule(self):
+        """ Constructing a RelStorage object uses the given module's Client """
+        moduleName = str(uuid.uuid4())
+        kwargs = {'foo':1, 'bar': moduleName}
+        relstoreParams = {
+                'cache_module_name': moduleName,
+                'cache_servers': ('localhost:1234',)
+                }
+        with mockMemcacheClient() as mockClientClass:
+            createModule(moduleName, **kwargs)
+            relstorage.storage.RelStorage(None, create=False, **relstoreParams)
+        self.assertEqual(len(mockClientClass.instances), 1)
+        client = mockClientClass.instances[0]
+        self.assertEqual(client.initKwargs, kwargs)


### PR DESCRIPTION
Add zodb-cache-max-object-size config value which controls the server_max_value_length parameter of the initializer of the Client class in the memcache library.  This allows setting the max object size in memcached to a non-default value.

See also https://github.com/zenoss/ZenPacks.zenoss.EnterpriseCollector/pull/27, https://github.com/zenoss/zenoss-service/pull/301

Fixes [ZEN-24145](https://jira.zenoss.com/browse/ZEN-24145)