### PR TITLE
ZEN-10184: add prod-state flag so it'll be picked in conf

### DIFF
--- a/Products/DataCollector/zendisc.py
+++ b/Products/DataCollector/zendisc.py
@@ -664,6 +664,9 @@ class ZenDisc(ZenModeler):
         self.parser.add_option('--prod_state', dest='productionState',
             default=1000, type='int',
             help="Initial production state for discovered devices")
+        self.parser.add_option('--prod-state', dest='productionState',
+            default=1000, type='int',
+            help="Initial production state for discovered devices")
         self.parser.add_option('--location', dest='location',
             default=None,
             help="Initial location for discovered devices")


### PR DESCRIPTION
ZenUtils.GlobalConfig.configToFlag() replaces underscores with en-dashes, which causes the prod_state confg to not be read from the config file. To fix, I added an alias option to the optparser config for zendisc so that the prod_state can be parsed from the config file.