### PR TITLE
Feature/zen 24297

### DIFF
--- a/Products/ZenUI3/security/authorization.py
+++ b/Products/ZenUI3/security/authorization.py
@@ -15,6 +15,7 @@ from Products.Zuul.interfaces import IAuthorizationTool
 
 ZAUTH_HEADER_ID = 'X-ZAuth-Token'
 
+
 class Authorization(BrowserView):
     """
     This view acts as a namespace so the client requests are /authorization/login and
@@ -24,11 +25,9 @@ class Authorization(BrowserView):
         if index == "login":
             return Login(self.context, self.request)
         if index == "validate":
-            try:
-                return Validate(self.context, self.request)
-            finally:
-                transaction.abort()
+            return Validate(self.context, self.request)
         raise Exception("Invalid authorization view %s" % index)
+
 
 class Login(BrowserView):
     """

--- a/Products/Zuul/security.py
+++ b/Products/Zuul/security.py
@@ -86,7 +86,7 @@ class AuthorizationTool(object):
     def tokenExpired(self, sessionId):
         token = self.getToken(sessionId)
         if token is None:
-            log.info("Token is None for sessionid %s", sessionId)
+            log.debug("Token is None for sessionid %s", sessionId)
             return True
         log.debug("Token is %s for sessionid %s", token, sessionId)
         newexp = self._getSessionTimeout()


### PR DESCRIPTION
This is to fix ZEN-24297: graphs timing out after 20 minutes.

Fix is twofold: 
* remove abort call in authorization.py. This lets session information get saved when we update it
* in security.py - each time we check the token, refresh the exipration information. This will keep the token current, so the timeouts don't happen.

This fix also addresses a customer issue (zendesk ticket number 118031)