### PR TITLE
Fixes ZEN-24430 zensendevent fails with "500 Internal Server Error"

### DIFF
--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -128,7 +128,7 @@ class AuthXmlRpcService(XmlRpcService):
         @param request: the request for this xmlrpc call.
         @return: NOT_DONE_YET
         """
-        auth = request.received_headers.get('authorization', None)
+        auth = request.getHeader('authorization')
         if not auth:
             self.unauthorized(request)
         else:


### PR DESCRIPTION
use request.getHeader instead of request.received_headers, which no longer exists

ZEN-24430