### PR TITLE
Always transform ZenPack version for egg file

### DIFF
--- a/Products/ZenUtils/tests/testFindEggs.py
+++ b/Products/ZenUtils/tests/testFindEggs.py
@@ -1,0 +1,84 @@
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+
+import os
+import unittest
+
+from contextlib import contextmanager
+
+from Products.ZenUtils.zenpack import ZenPackCmd
+from Products.ZenUtils.Utils import zenPath
+
+
+@contextmanager
+def mockListdir(name, version):
+    """Replace os.listdir with a mock.
+    """
+    eggname = "%s-%s-py2.7.egg" % (name, version)
+    def listdir(dirname):
+        if dirname.endswith(".ZenPacks"):
+            return [eggname]
+        return []
+    original = os.listdir
+    os.listdir = listdir
+    yield zenPath(".ZenPacks", eggname)
+    os.listdir = original
+
+
+class TestFindEggs(unittest.TestCase):
+    """Test the _findEggs routine."""
+
+    def test001_WrongName(self):
+        """The egg names are different.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test001", "1.0.0") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Looking", "1.0.0")
+            self.assertEquals(result, [])
+
+    def test002_WrongVersion(self):
+        """Same name, different versions.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test002", "1.0.0") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Test002", "1.2.0")
+            self.assertEquals(result, [])
+
+    def test003_Found(self):
+        """The egg is found.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test003", "1.0.0") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Test003", "1.0.0")
+            self.assertEquals(result, [eggPath])
+
+    def test004_DashedVersion(self):
+        """The egg has a dash in its version.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test004", "1.0.0_test") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Test004", "1.0.0-test")
+            self.assertEquals(result, [eggPath])
+
+    def test005_UnderscoreVersion(self):
+        """The egg has an underscore in its version.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test005", "1.0.0_unstable") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Test005", "1.0.0_unstable")
+            self.assertEquals(result, [eggPath])
+
+    def test006_VersionWithText(self):
+        """The egg has text but no dash in its version.
+        """
+        zpc = ZenPackCmd()
+        with mockListdir("ZenPacks.zenoss.Test006", "1.0.0dev") as eggPath:
+            result = zpc._findEggs("ZenPacks.zenoss.Test006", "1.0.0dev")
+            self.assertEquals(result, [eggPath])

--- a/Products/ZenUtils/tests/testFindEggs.py
+++ b/Products/ZenUtils/tests/testFindEggs.py
@@ -9,10 +9,10 @@
 
 
 import os
-import unittest
 
 from contextlib import contextmanager
 
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from Products.ZenUtils.zenpack import ZenPackCmd
 from Products.ZenUtils.Utils import zenPath
 
@@ -32,7 +32,7 @@ def mockListdir(name, version):
     os.listdir = original
 
 
-class TestFindEggs(unittest.TestCase):
+class TestFindEggs(BaseTestCase):
     """Test the _findEggs routine."""
 
     def test001_WrongName(self):

--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -539,6 +539,8 @@ class ZenPackCmd(ZenScriptBase):
             subprocess.check_call(cmd, stdout=fnull, stderr=fnull)
 
     def _findEggs(self, zenpackID, zenpackVersion):
+        # if the version has a dash, replace with an underscore
+        zenpackVersion = zenpackVersion.replace("-", "_", 1)
         eggs = []
         for dirpath in zenPath(".ZenPacks"), zenPath("packs"):
             for f in os.listdir(dirpath):
@@ -562,8 +564,6 @@ class ZenPackCmd(ZenScriptBase):
         return eggs
 
     def _restore(self, zenpackID, zenpackVersion, filesOnly):
-        # if the version has a dash, replace with an underscore
-        zenpackVersion = zenpackVersion.replace("-", "_", 1)
         # look for the egg
         eggs = self._findEggs(zenpackID, zenpackVersion)
         if len(eggs) == 0:


### PR DESCRIPTION
When looking for the egg (or zip) of a ZenPack, the version string must convert its first dash into an underscore to match version string used in the naming of the egg (or zip) file.  This change moves that transform into the method that performs the search rather relying the caller to transform it.

This should finish fixing ZEN-24265.

The version transform issue was discovered while trying to determine the cause of [ZEN-24751](https://jira.zenoss.com/browse/ZEN-24751).  After ensuring that the version string was transformed correctly, the issue disappeared.