### PR TITLE
ZEN-24522: Handle NOT operator in event console

### DIFF
--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -647,8 +647,8 @@ class EventsRouter(DirectRouter):
             log.debug('Found specific event ids, adding to params.')
             includeUuids = evids
 
-        includeFilter = self._buildFilter([uid], params, specificEventUuids=includeUuids)
         exclude_params = self._filterParser.findExclusionParams(params)
+        includeFilter = self._buildFilter([uid], params, specificEventUuids=includeUuids)
 
         # the only thing excluded in an event filter is a list of event uuids
         # which are passed as EventTagFilter using the OR operator.


### PR DESCRIPTION
`self._filterParser.findExclusionParams` has a naughty side-affect - it removes some keys from `params`

In develop it is fixed by #1353 

[Jira](https://jira.zenoss.com/browse/ZEN-24522)