### PR TITLE
Fixes ZEN-24669 by setting status as "New" on Maintentenance Start/Stop events

### DIFF
--- a/Products/ZenEvents/Schedule.py
+++ b/Products/ZenEvents/Schedule.py
@@ -161,7 +161,8 @@ class Schedule:
                     maintenance_devices=devices,
                     device=self.monitor,
                     prodState=prodState,
-                    monitor=self.monitor
+                    monitor=self.monitor,
+                    status="New"
                 ))
                 mw.execute(next,
                            batchSize=self.options.maintenceWindowBatchSize,


### PR DESCRIPTION
Fixes ZEN-24669 by setting status as "New" on Maintenance Start/Stop events so that maintenance window star events show up in the RM event console UI.