### PR TITLE
ZEN-25294 zenpack create fails in multihost

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -293,6 +293,15 @@ def InstallEgg(dmd, eggPath, link=False):
 
     # Install the egg
     if link:
+        # Wake up NFS before attempting setup.py develop
+        touchcmd = ('touch %s/easy-install.pth' % zenPackDir)
+        p = subprocess.Popen(touchcmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=True,
+                            cwd=eggPath)
+        p.wait()
+
         zenPackDir = varPath('ZenPacks')
         cmd = ('%s setup.py develop ' % binPath('python') +
                 '--site-dirs=%s ' % zenPackDir +


### PR DESCRIPTION
Serviced zenpack create was failing in with the error 'easy-install.pth:
Resource temporarily unavailable'. This commit adds a touch immediately
before the call to setup.py develop to wake up the NFS so the file is
available in time to modify the file.