### PR TITLE
ZEN-25323: getProductionState Traceback when moving devices between o…

### DIFF
--- a/Products/ZenModel/tests/testDeviceClass.py
+++ b/Products/ZenModel/tests/testDeviceClass.py
@@ -156,6 +156,51 @@ class TestDeviceClass(ZenModelBaseTest):
         path = self.dmd.guid_table.get(newguid, None)
         self.assertEqual(path, '/zport/dmd/Devices/Server/devices/testdev')
 
+    def testMoveDevicesRetainsProductionState(self):
+        self.dev._setProductionState(99)
+        self.dev.setPreMWProductionState(98)
+        self.dmd.Devices.moveDevices('/Server', 'testdev')
+        newProdState = self.dmd.Devices.Server.devices.testdev.getProductionState()
+        newPreMWProdState = self.dmd.Devices.Server.devices.testdev.getPreMWProductionState()
+        self.assertEqual(newProdState, 99)
+        self.assertEqual(newPreMWProdState, 98)
+ 
+    def testMoveDevicesRetainsComponentProductionState(self):
+        self.dev._setProductionState(99)
+        self.dev.setPreMWProductionState(98)
+        self.dev.os.addIpInterface('eth0', True)
+        component = self.dev.os.interfaces()[0]
+        component._setProductionState(49)
+        component.setPreMWProductionState(48)
+        self.dmd.Devices.moveDevices('/Server', 'testdev')
+ 
+        component = self.dmd.Devices.Server.devices.testdev.os.interfaces()[0]
+        newProdState = component.getProductionState()
+        newPreMWProdState = component.getPreMWProductionState()
+        self.assertEqual(newProdState, 49)
+        self.assertEqual(newPreMWProdState, 48)
+ 
+    def testMoveDevicesRetainsComponentProductionStateAcquisition(self):
+        self.dev._setProductionState(99)
+        self.dev.setPreMWProductionState(98)
+        self.dev.os.addIpInterface('eth0', True)
+        self.dmd.Devices.moveDevices('/Server', 'testdev')
+         
+        # Component production state is the same (acquired from device)
+        component = self.dmd.Devices.Server.devices.testdev.os.interfaces()[0]
+        newProdState = component.getProductionState()
+        newPreMWProdState = component.getPreMWProductionState()
+        self.assertEqual(newProdState, 99)
+        self.assertEqual(newPreMWProdState, 98)
+ 
+        # Component production state still acquires from device
+        self.dev._setProductionState(59)
+        self.dev.setPreMWProductionState(58)
+        newProdState = component.getProductionState()
+        newPreMWProdState = component.getPreMWProductionState()
+        self.assertEqual(newProdState, 59)
+        self.assertEqual(newPreMWProdState, 58)
+ 
     def testMoveDevicesWithPotentialCaseIssue(self):
         self.dmd.Devices.createInstance( 'TESTDEV' )
         self.dmd.Devices.moveDevices('/Server', 'testdev')

--- a/Products/ZenUtils/tests/test_productionstate.py
+++ b/Products/ZenUtils/tests/test_productionstate.py
@@ -108,6 +108,18 @@ class TestProductionState(BaseTestCase):
         self.assertRaises(ProdStateNotSetError, manager.getProductionState, newob)
         self.assertRaises(ProdStateNotSetError, manager.getPreMWProductionState, newob)
 
+    def test_device_move(self):
+        source = self.dmd.Devices.createOrganizer('source')
+        dest = self.dmd.Devices.createOrganizer('dest')
+        dev = source.createInstance('testdevice')
+        manager = IProdStateManager(self.aq_ob)
+        manager.setProductionState(dev, 1)
+        manager.setPreMWProductionState(dev, 2)
+        source.moveDevices(dest.getOrganizerName(), 'testdevice')
+        newdev = dest.devices.testdevice
+        self.assertEqual(manager.getProductionState(newdev), 1)
+        self.assertEqual(manager.getPreMWProductionState(newdev), 2)
+ 
 
 def test_suite():
     return unittest.makeSuite(TestProductionState)


### PR DESCRIPTION
port: https://github.com/zenoss/zenoss-prodbin/pull/1898/files