### PR TITLE
ZEN-22698 add possibility to set an alternate manageIp for IpService …

### DIFF
--- a/Products/Zuul/infos/component/configure.zcml
+++ b/Products/Zuul/infos/component/configure.zcml
@@ -43,10 +43,6 @@
              factory=".ipservice.IpServiceInfo"
              />
 
-    <utility provides="zope.schema.interfaces.IVocabularyFactory"
-             component=".ipservice.serviceIpAddressesVocabulary"
-             name="serviceIpAddresses"/>
-
     <adapter provides="...interfaces.IWinServiceInfo"
              for="Products.ZenModel.WinService.WinService"
              factory=".winservice.WinServiceInfo"

--- a/Products/Zuul/infos/component/ipservice.py
+++ b/Products/Zuul/infos/component/ipservice.py
@@ -13,10 +13,7 @@ from Products.Zuul.interfaces import IIpServiceInfo
 from Products.Zuul.infos.component import ComponentInfo, ServiceMonitor
 from Products.Zuul.infos import ProxyProperty
 from Products.Zuul.decorators import info
-from zope.schema.vocabulary import SimpleVocabulary
 
-def serviceIpAddressesVocabulary(context):
-    return SimpleVocabulary.fromValues(context.ipaddresses)
 
 class IpServiceInfo(ComponentInfo):
     implements(IIpServiceInfo)

--- a/Products/Zuul/interfaces/component.py
+++ b/Products/Zuul/interfaces/component.py
@@ -176,9 +176,9 @@ class IIpServiceInfo(IComponentInfo):
     port = schema.Int(title=_t(u"Port"), group="Overview")
     protocol = schema.TextLine(title=_t(u"Protocol"), group="Details")
     ipaddresses = schema.List(title=_t(u"IP Addresses"), group="Details")
-    manageIp = schema.Choice(title=_t(u"Management IP Address"),
-                             vocabulary="serviceIpAddresses",
-                             group="Overview")
+    manageIp = schema.TextLine(title=_t(u"Management IP Address"),
+                               group="Overview", alwaysEditable=True,
+                               xtype="ipaddressfield", vtype="ipaddress")
     discoveryAgent = schema.TextLine(title=_t(u"Discovery Agent"), group="Details")
     failSeverity = schema.Int(title=_t(u"Fail Severity"), xtype="severity",
                               group="Details", alwaysEditable=True)


### PR DESCRIPTION
…components.

Fix provides the possibility to set an alternate manageIp for IpService components with validation of inputed data.
Also this was removed serviceIpAddressesVocabulary as needless.
[Jira](https://jira.zenoss.com/browse/ZEN-22698)