### PR TITLE
Remove elasticsearch keepalive task

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/daemons/controller/DetailsController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/daemons/controller/DetailsController.js
@@ -81,26 +81,6 @@
                     }
                 }
             };
-
-            /**
-             * Start a timed task to keep the CC-issued cookie alive
-             **/
-            var logKeepaliveTask = {
-                run: function() {
-                    Ext.Ajax.request({
-                        url: location.protocol + '//' + location.hostname + (location.port ? ":" + location.port : "") + "/api/controlplane/elastic",
-                        // On a 401 response, Flare in the browser and stop the task
-                        failure: function(response) {
-                            if (response.status == 401) {
-                                Zenoss.message.warning("Unable to reach Elastic - log viewing may be impacted.  Refresh your browser.");
-                                Ext.TaskManager.stop(logKeepaliveTask);
-                            }
-                        }
-                    });
-                },
-                interval: 60000
-            };
-            Ext.TaskManager.start(logKeepaliveTask);
         },
         /**
          * This method is responsible for showing the card that


### PR DESCRIPTION
In CC1.2 we simply proxy Kibana, making the keep-alive unnecessary.