### PR TITLE
ZEN-25845 Change ZenModel migration numbering scheme

### DIFF
--- a/Products/ZenModel/migrate/AddZepEndpointToZeneventd.py
+++ b/Products/ZenModel/migrate/AddZepEndpointToZeneventd.py
@@ -21,7 +21,7 @@ sm.require("1.0.0")
 class AddZepEndpointToZeneventd(Migrate.Step):
     "Add zep endpoint to zeneventd services"
 
-    version = Migrate.Version(5, 1, 2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addKibanaRouteInZproxyConf.py
+++ b/Products/ZenModel/migrate/addKibanaRouteInZproxyConf.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 
 class AddKibanaRouteInZproxyConf(Migrate.Step):
 
-    version = Migrate.Version(5,1,9)
+    version = Migrate.Version(105, 0, 0)
 
     KIBANA_NEW_ROUTE_CONFIG = """
 

--- a/Products/ZenModel/migrate/addSnmpV3UserCommand.py
+++ b/Products/ZenModel/migrate/addSnmpV3UserCommand.py
@@ -13,7 +13,7 @@ SNMPV3_COMMAND = ('snmpwalk -${device/zSnmpVer} -l authNoPriv -a ${device/zSnmpA
 
 class AddSnmpV3UserCommand(Migrate.Step):
 
-    version = Migrate.Version(5, 1, 3)
+    version = Migrate.Version(101, 0, 0)
 
     def cutover(self, dmd):
         if SNMPV3_ID not in [d.id for d in dmd.userCommands()]:

--- a/Products/ZenModel/migrate/addTagToImages.py
+++ b/Products/ZenModel/migrate/addTagToImages.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class AddTagToImages(Migrate.Step):
     "Add tag latest to all Images that do not have a tag"
 
-    version = Migrate.Version(5, 1, 5)
+    version = Migrate.Version(103, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
+++ b/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
@@ -18,7 +18,7 @@ import Migrate
 
 class addzCommandUserCommandTimeout(Migrate.Step):
 
-    version = Migrate.Version(5, 1, 2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
         if not hasattr(dmd.Devices, 'zCommandUserCommandTimeout'):

--- a/Products/ZenModel/migrate/beakerHttpOnly.py
+++ b/Products/ZenModel/migrate/beakerHttpOnly.py
@@ -20,7 +20,7 @@ class BeakerHTTPOnly(Migrate.Step):
     Set beaker session.httponly to true in config
     """
 
-    version = Migrate.Version(5, 1, 7)
+    version = Migrate.Version(103, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/changeMemcachedStartup.py
+++ b/Products/ZenModel/migrate/changeMemcachedStartup.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class ChangeMemcachedStartup(Migrate.Step):
     "Change memcached startup to respect config file and update config file"
 
-    version = Migrate.Version(5, 1, 5)
+    version = Migrate.Version(103, 0, 0)
 
     def _update_config(self, config):
         USER_RE = r'USER="\w+"'

--- a/Products/ZenModel/migrate/defaultBeakerToSecure.py
+++ b/Products/ZenModel/migrate/defaultBeakerToSecure.py
@@ -20,7 +20,7 @@ class DefaultBeakerToSecure(Migrate.Step):
     Set beaker session.secure to true in config
     """
 
-    version = Migrate.Version(5, 1, 3)
+    version = Migrate.Version(101, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/disableZproxyAccessLog.py
+++ b/Products/ZenModel/migrate/disableZproxyAccessLog.py
@@ -20,7 +20,7 @@ sm.require("1.0.0")
 class DisableZproxyAccessLog(Migrate.Step):
     "Disable zproxy nginx access logging by default"
 
-    version = Migrate.Version(5,1,2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/fixMariadbHealthCheck.py
+++ b/Products/ZenModel/migrate/fixMariadbHealthCheck.py
@@ -22,7 +22,7 @@ class FixMariadbHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(5,1,3)
+    version = Migrate.Version(101, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/fixZauthHealthCheck.py
+++ b/Products/ZenModel/migrate/fixZauthHealthCheck.py
@@ -22,7 +22,7 @@ class FixZauthHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(5,1,2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/moveProductionStateToBTree.py
+++ b/Products/ZenModel/migrate/moveProductionStateToBTree.py
@@ -24,7 +24,7 @@ from Products.ZCatalog.Catalog import CatalogError
 
 class MoveProductionStateToBTree(Migrate.Step):
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def migrateObject(self, obj):
         obj_unwrapped = aq_base(obj)

--- a/Products/ZenModel/migrate/removeEmptyGraphs.py
+++ b/Products/ZenModel/migrate/removeEmptyGraphs.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RemoveEmptyGraphs(Migrate.Step):
     """Remove some graph datapoints from a few services."""
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/retryZopeHealthCheck.py
+++ b/Products/ZenModel/migrate/retryZopeHealthCheck.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RetryZopeHealthCheck(Migrate.Step):
     "Change 'answering' healthcheck to retry a few times on failture"
 
-    version = Migrate.Version(5, 1, 4)
+    version = Migrate.Version(102, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
+++ b/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class TemplatizeCollectorEndpoints(Migrate.Step):
     "Use templated names for collector endpoints"
 
-    version = Migrate.Version(5,1,2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
+++ b/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
@@ -22,7 +22,7 @@ class UpdateOpenTsdbCreateTables(Migrate.Step):
     See ZEN-22929
     """
 
-    version = Migrate.Version(5, 1, 7)
+    version = Migrate.Version(104, 0, 0)
 
     def cutover(self, dmd):
         try:


### PR DESCRIPTION
Renumbering all migrations at least as young as 5.1.1 because
some releases and appliances had db versions ahead of the migrations
shipped.

Switching to a single-number scheme to reduce confusion and to break
the relation between releases of Zenoss and migrations of ZenModel--
they need not stay in lockstep.

The new scheme is based on 100 to make sure releases as early as 5.1.1
will run all of the necessary migrations, as the db version could be as
far forward as 5.1.70 in some systems.