### PR TITLE
ZEN-25845 Change ZenModel migration numbering scheme

### DIFF
--- a/Products/ZenModel/data/devices.xml
+++ b/Products/ZenModel/data/devices.xml
@@ -1,190 +1,193 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-03-11 11:26:54.655148
+    Zenoss RelationshipManager export completed on 2016-11-04 20:31:42.523778
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-03-11 11:26:54.655148" zenoss_server="7f52067b9966" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:31:42.523778" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Devices' module='Products.ZenModel.DeviceClass' class='DeviceClass'>
 <property type="lines" id="devtypes" mode="w" >
 []
 </property>
-<property id="zPythonClass" visible="True" type="string" description="Python module used when creating a new device instances." label="Python Class" >
+<property visible="True" label="Python Class" type="string" description="Python module used when creating a new device instances." id="zPythonClass" >
 </property>
-<property id="zProdStateThreshold" visible="True" type="int" description="Production state threshold at which to start monitoring boxes." label="Production State Threshold" >
+<property visible="True" label="Production State Threshold" type="int" description="Production state threshold at which to start monitoring boxes." id="zProdStateThreshold" >
 300
 </property>
-<property id="zIfDescription" visible="True" type="boolean" description="Shows the interface description field in the interface list." label="If Description" >
+<property visible="True" label="If Description" type="boolean" description="Shows the interface description field in the interface list." id="zIfDescription" >
 False
 </property>
-<property id="zSnmpCommunities" visible="True" type="lines" description='Array of SNMP community strings that ZenModeler uses when collecting SNMP information. When you set this property, communities are tried in order; the first in the list that is successful is used as zSnmpCommunity. If none is successful, then the current value of zSnmpCommunity is used. The default value for the entire system is "public."' label="SNMP Communities" >
+<property visible="True" label="SNMP Communities" type="lines" description='Array of SNMP community strings that ZenModeler uses when collecting SNMP information. When you set this property, communities are tried in order; the first in the list that is successful is used as zSnmpCommunity. If none is successful, then the current value of zSnmpCommunity is used. The default value for the entire system is "public."' id="zSnmpCommunities" >
 ['public', 'private']
 </property>
-<property id="zSnmpCommunity" visible="True" type="string" description="Community string to be used when collecting SNMP information. If it is different than what is found by ZenModeler, it will be set on the modeled device." label="SNMP Community String" >
+<property visible="True" label="SNMP Community String" type="string" description="Community string to be used when collecting SNMP information. If it is different than what is found by ZenModeler, it will be set on the modeled device." id="zSnmpCommunity" >
 public
 </property>
-<property id="zSnmpPort" visible="True" type="int" description="Port that the SNMP agent listens on." label="SNMP Port" >
+<property visible="True" label="SNMP Port" type="int" description="Port that the SNMP agent listens on." id="zSnmpPort" >
 161
 </property>
-<property id="zSnmpVer" visible="True" type="string" description="SNMP version used. Valid values are v1, v2c, v3." label="SNMP Version" >
+<property visible="True" label="SNMP Version" type="string" description="SNMP version used. Valid values are v1, v2c, v3." id="zSnmpVer" >
 v2c
 </property>
-<property id="zSnmpTries" visible="True" type="int" description="Amount of tries to collect SNMP data" label="SNMP Tries" >
+<property visible="True" label="SNMP Tries" type="int" description="Amount of tries to collect SNMP data" id="zSnmpTries" >
 6
 </property>
-<property id="zSnmpTimeout" visible="True" type="float" description="Timeout time in seconds for an SNMP request" label="SNMP Timeout" >
+<property visible="True" label="SNMP Timeout" type="float" description="Timeout time in seconds for an SNMP request" id="zSnmpTimeout" >
 1
 </property>
-<property id="zSnmpEngineId" visible="True" type="string" description="Engine ID is the administratively unique identifier for the SNMPv3 engine" label="SNMP Engine ID" >
+<property visible="True" label="SNMP Engine ID" type="string" description="Engine ID is the administratively unique identifier for the SNMPv3 engine" id="zSnmpEngineId" >
 </property>
-<property id="zSnmpSecurityName" visible="True" type="string" description="The Security Name (user) to use when making SNMPv3 requests." label="SNMP Security Name" >
+<property visible="True" label="SNMP Security Name" type="string" description="The Security Name (user) to use when making SNMPv3 requests." id="zSnmpSecurityName" >
 </property>
-<property id="zSnmpAuthPassword" visible="True" type="password" description="The shared private key used for authentication. Must be at least 8 characters long." label="SNMP Auth Password" >
+<property visible="True" label="SNMP Auth Password" type="password" description="The shared private key used for authentication. Must be at least 8 characters long." id="zSnmpAuthPassword" >
 </property>
-<property id="zSnmpPrivPassword" visible="True" type="password" description="The shared private key used for encrypting SNMP requests. Must be at least 8 characters long." label="SNMP Private Password" >
+<property visible="True" label="SNMP Private Password" type="password" description="The shared private key used for encrypting SNMP requests. Must be at least 8 characters long." id="zSnmpPrivPassword" >
 </property>
-<property id="zSnmpAuthType" visible="True" type="string" description='Use "MD5" or "SHA" signatures to authenticate SNMP requests' label="SNMP Auth Type" >
+<property visible="True" label="SNMP Auth Type" type="string" description='Use "MD5" or "SHA" signatures to authenticate SNMP requests' id="zSnmpAuthType" >
 </property>
-<property id="zSnmpPrivType" visible="True" type="string" description='"DES" or "AES" cryptographic algorithms.' label="SNMP Priv Type" >
+<property visible="True" label="SNMP Priv Type" type="string" description='"DES" or "AES" cryptographic algorithms.' id="zSnmpPrivType" >
 </property>
-<property id="zSnmpContext" visible="True" type="string" description="Defines the SNMPv3 CONTEXT specified by the -n flag" label="SNMP Context" >
+<property visible="True" label="SNMP Context" type="string" description="Defines the SNMPv3 CONTEXT specified by the -n flag" id="zSnmpContext" >
 </property>
-<property id="zSnmpCollectionInterval" visible="True" type="int" description="Defines, in seconds, how often the system collects performance information for each device." label="SNMP Collection Interval" >
+<property visible="True" label="SNMP Collection Interval" type="int" description="Defines, in seconds, how often the system collects performance information for each device." id="zSnmpCollectionInterval" >
 300
 </property>
-<property id="zRouteMapCollectOnlyLocal" visible="True" type="boolean" description="Only collect local routes. (These usually are manually configured rather than learned through a routing protocol.)" label="Router Map Collect Only (Local)" >
+<property visible="True" label="Router Map Collect Only (Local)" type="boolean" description="Only collect local routes. (These usually are manually configured rather than learned through a routing protocol.)" id="zRouteMapCollectOnlyLocal" >
 False
 </property>
-<property id="zRouteMapCollectOnlyIndirect" visible="True" type="boolean" description="Only collect routes that are directly connected to the device." label="Route Map Collect Only (Indirect)" >
+<property visible="True" label="Route Map Collect Only (Indirect)" type="boolean" description="Only collect routes that are directly connected to the device." id="zRouteMapCollectOnlyIndirect" >
 False
 </property>
-<property id="zRouteMapMaxRoutes" visible="True" type="int" description="Maximum number of routes to model." label="Route Map Max Routes" >
+<property visible="True" label="Route Map Max Routes" type="int" description="Maximum number of routes to model." id="zRouteMapMaxRoutes" >
 500
 </property>
-<property id="zInterfaceMapIgnoreTypes" visible="True" type="string" description="Filters out interface maps that should not be discovered." label="Interface Map Ignore Types" >
+<property visible="True" label="Interface Map Ignore Types" type="string" description="Filters out interface maps that should not be discovered." id="zInterfaceMapIgnoreTypes" >
 </property>
-<property id="zInterfaceMapIgnoreNames" visible="True" type="string" description="Filters out interfaces that should not be discovered." label="Interface Map Ignore Names" >
+<property visible="True" label="Interface Map Ignore Names" type="string" description="Filters out interfaces that should not be discovered." id="zInterfaceMapIgnoreNames" >
 </property>
-<property id="zInterfaceMapIgnoreDescriptions" visible="True" type="string" description="Filters out interfaces based on description." label="Interface Map Ignore Description" >
+<property visible="True" label="Interface Map Ignore Description" type="string" description="Filters out interfaces based on description." id="zInterfaceMapIgnoreDescriptions" >
 </property>
-<property id="zFileSystemMapIgnoreTypes" visible="True" type="lines" description="Do not use." label="File System Map Ignore Types" >
+<property visible="True" label="File System Map Ignore Types" type="lines" description="Do not use." id="zFileSystemMapIgnoreTypes" >
 ['other', 'ram', 'virtualMemory', 'removableDisk', 'floppyDisk', 'compactDisk', 'ramDisk', 'flashMemory', 'networkDisk']
 </property>
-<property id="zFileSystemMapIgnoreNames" visible="True" type="string" description="Sets a regular expression of file system names to ignore." label="File System Map Ignore Names" >
+<property visible="True" label="File System Map Ignore Names" type="string" description="Sets a regular expression of file system names to ignore." id="zFileSystemMapIgnoreNames" >
 </property>
-<property id="zFileSystemSizeOffset" visible="True" type="float" description="SNMP typically reports the total space available to privileged users. Resource Manager (like the df command) reports capacity based on the space available to non-privileged users. The value of zFileSystemSizeOffset should be the fraction of the total space that is available to non-privileged users. The default reserved value is 5% of total space, so zFileSystemSizeOffset is preset to .95. If the reserved portion is different than 5%, then adjust the value of zFileSystemSizeOffset accordingly. The fraction should be set according to the value ( Used + Avail ) / Size when the df -PkH command is run at the command line." label="File System Size Offset" >
+<property visible="True" label="File System Size Offset" type="float" description="SNMP typically reports the total space available to privileged users. Resource Manager (like the df command) reports capacity based on the space available to non-privileged users. The value of zFileSystemSizeOffset should be the fraction of the total space that is available to non-privileged users. The default reserved value is 5% of total space, so zFileSystemSizeOffset is preset to .95. If the reserved portion is different than 5%, then adjust the value of zFileSystemSizeOffset accordingly. The fraction should be set according to the value ( Used + Avail ) / Size when the df -PkH command is run at the command line." id="zFileSystemSizeOffset" >
 1.0
 </property>
-<property id="zHardDiskMapMatch" visible="True" type="string" description="Regular expression that uses the disk ID in the diskstats output to filter disk activity statistics for inclusion in performance monitoring." label="Hard Disk Map Match" >
+<property visible="True" label="Hard Disk Map Match" type="string" description="Regular expression that uses the disk ID in the diskstats output to filter disk activity statistics for inclusion in performance monitoring." id="zHardDiskMapMatch" >
 </property>
-<property id="zSysedgeDiskMapIgnoreNames" visible="True" type="string" description="" label="Sysedge Disk Map Ignore Names" >
+<property visible="True" label="Sysedge Disk Map Ignore Names" type="string" description="" id="zSysedgeDiskMapIgnoreNames" >
 </property>
-<property id="zIpServiceMapMaxPort" visible="True" type="int" description="Specifies the highest port to scan. The default is 1024." label="IP Service Map Max Port" >
+<property visible="True" label="IP Service Map Max Port" type="int" description="Specifies the highest port to scan. The default is 1024." id="zIpServiceMapMaxPort" >
 1024
 </property>
-<property id="zDeviceTemplates" visible="True" type="lines" description="Sets the templates associated with this device. Linked by name." label="Device Templates" >
+<property visible="True" label="Device Templates" type="lines" description="Sets the templates associated with this device. Linked by name." id="zDeviceTemplates" >
 ['Device']
 </property>
-<property id="zLocalIpAddresses" visible="True" type="string" description="" label="Local IP Addresses" >
+<property visible="True" label="Local IP Addresses" type="string" description="" id="zLocalIpAddresses" >
 ^127|^0\.0|^169\.254|^224
 </property>
-<property id="zLocalInterfaceNames" visible="True" type="string" description='Regular expression that uses interface name to determine whether the IP addresses on an interface should be incorporated into the network map. For instance, a loopback interface "lo" might be excluded.' label="Local Interface Names" >
+<property visible="True" label="Local Interface Names" type="string" description='Regular expression that uses interface name to determine whether the IP addresses on an interface should be incorporated into the network map. For instance, a loopback interface "lo" might be excluded.' id="zLocalInterfaceNames" >
 ^lo|^vmnet
 </property>
-<property id="zSnmpMonitorIgnore" visible="True" type="boolean" description="Whether or not to ignore monitoring SNMP on a device." label="Ignore SNMP Monitor?" >
+<property visible="True" label="Ignore SNMP Monitor?" type="boolean" description="Whether or not to ignore monitoring SNMP on a device." id="zSnmpMonitorIgnore" >
 False
 </property>
-<property id="zPingMonitorIgnore" visible="True" type="boolean" description="Whether or not to ping the device." label="Ignore Ping Monitor?" >
+<property visible="True" label="Ignore Ping Monitor?" type="boolean" description="Whether or not to ping the device." id="zPingMonitorIgnore" >
 False
 </property>
-<property id="zStatusConnectTimeout" visible="True" type="float" description="The amount of time that the zenstatus daemon should wait before marking an IP service down." label="Status Connection Timeout (seconds)" >
+<property visible="True" label="Status Connection Timeout (seconds)" type="float" description="The amount of time that the zenstatus daemon should wait before marking an IP service down." id="zStatusConnectTimeout" >
 15.0
 </property>
-<property id="zCollectorPlugins" visible="True" type="lines" description="" label="Collector Plugins" >
+<property visible="True" label="Collector Plugins" type="lines" description="" id="zCollectorPlugins" >
 ('zenoss.snmp.NewDeviceMap', 'zenoss.snmp.DeviceMap', 'zenoss.snmp.InterfaceMap', 'zenoss.snmp.RouteMap', 'zenoss.snmp.SnmpV3EngineIdMap')
 </property>
-<property id="zCollectorClientTimeout" visible="True" type="int" description="Allows you to set the timeout time of the collector client in seconds" label="Collector Client Timeout (seconds)" >
+<property visible="True" label="Collector Client Timeout (seconds)" type="int" description="Allows you to set the timeout time of the collector client in seconds" id="zCollectorClientTimeout" >
 180
 </property>
-<property id="zCollectorDecoding" visible="True" type="string" description="Converts incoming characters to Unicode." label="Collector Decoding" >
+<property visible="True" label="Collector Decoding" type="string" description="Converts incoming characters to Unicode." id="zCollectorDecoding" >
 utf-8
 </property>
-<property id="zCommandUsername" visible="True" type="string" description="Specifies the user name to use when performing command collection and SSH." label="Username" >
+<property visible="True" label="Username" type="string" description="Specifies the user name to use when performing command collection and SSH." id="zCommandUsername" >
 </property>
-<property id="zCommandPassword" visible="True" type="password" description="Specifies the password to use when performing command logins and SSH." label="Password" >
+<property visible="True" label="Password" type="password" description="Specifies the password to use when performing command logins and SSH." id="zCommandPassword" >
 </property>
-<property id="zCommandProtocol" visible="True" type="string" description="Establishes the protocol to use when performing command collection. Possible values are SSH and telnet." label="Command Protocol" >
+<property visible="True" label="Command Protocol" type="string" description="Establishes the protocol to use when performing command collection. Possible values are SSH and telnet." id="zCommandProtocol" >
 ssh
 </property>
-<property id="zCommandPort" visible="True" type="int" description="Specifies the port to connect to when performing command collection." label="Command Port" >
+<property visible="True" label="Command Port" type="int" description="Specifies the port to connect to when performing command collection." id="zCommandPort" >
 22
 </property>
-<property id="zCommandLoginTries" visible="True" type="int" description="Sets the number of times to attempt login." label="Command Login Tries" >
+<property visible="True" label="Command Login Tries" type="int" description="Sets the number of times to attempt login." id="zCommandLoginTries" >
 1
 </property>
-<property id="zCommandLoginTimeout" visible="True" type="float" description="Specifies the time to wait for a login prompt." label="Timeout for Login (seconds)" >
+<property visible="True" label="Timeout for Login (seconds)" type="float" description="Specifies the time to wait for a login prompt." id="zCommandLoginTimeout" >
 10.0
 </property>
-<property id="zCommandCommandTimeout" visible="True" type="float" description="Specifies the time to wait for a command to complete." label="Timeout for Commands (seconds)" >
+<property visible="True" label="Timeout for Commands (seconds)" type="float" description="Specifies the time to wait for a command to complete." id="zCommandCommandTimeout" >
 15.0
 </property>
-<property id="zCommandSearchPath" visible="True" type="lines" description="Sets the path to search for any commands." label="Command Search Path" >
+<property visible="True" label="Timeout for User Commands (seconds)" type="float" description="Specifies the time to wait for a user command to complete." id="zCommandUserCommandTimeout" >
+15.0
+</property>
+<property visible="True" label="Command Search Path" type="lines" description="Sets the path to search for any commands." id="zCommandSearchPath" >
 []
 </property>
-<property id="zCommandExistanceTest" visible="True" type="string" description="" label="Command Existance Test" >
+<property visible="True" label="Command Existance Test" type="string" description="" id="zCommandExistanceTest" >
 test -f %s
 </property>
-<property id="zCommandPath" visible="True" type="string" description="Sets the default path where ZenCommand plug-ins are installed on the local Resource Manager box (or on a remote box where SSH is used to run the command)." label="Command Path" >
+<property visible="True" label="Command Path" type="string" description="Sets the default path where ZenCommand plug-ins are installed on the local Resource Manager box (or on a remote box where SSH is used to run the command)." id="zCommandPath" >
 $ZENHOME/libexec
 </property>
-<property id="zTelnetLoginRegex" visible="True" type="string" description="Regular expression to match the login prompt." label="Telnet Login" >
+<property visible="True" label="Telnet Login" type="string" description="Regular expression to match the login prompt." id="zTelnetLoginRegex" >
 ogin:.$
 </property>
-<property id="zTelnetPasswordRegex" visible="True" type="string" description="Regular expression to match the password prompt." label="Telnet Password Regex" >
+<property visible="True" label="Telnet Password Regex" type="string" description="Regular expression to match the password prompt." id="zTelnetPasswordRegex" >
 assword:
 </property>
-<property id="zTelnetSuccessRegexList" visible="True" type="lines" description="List of regular expressions to match the command prompt." label="Telnet Success Regex" >
+<property visible="True" label="Telnet Success Regex" type="lines" description="List of regular expressions to match the command prompt." id="zTelnetSuccessRegexList" >
 ['\\$.$', '\\#.$']
 </property>
-<property id="zTelnetEnable" visible="True" type="boolean" description="When logging into a Cisco device issue the enable command to enable access during command collection." label="Enable Telnet?" >
+<property visible="True" label="Enable Telnet?" type="boolean" description="When logging into a Cisco device issue the enable command to enable access during command collection." id="zTelnetEnable" >
 False
 </property>
-<property id="zTelnetEnableRegex" visible="True" type="string" description="Regular expression to match the enable prompt." label="Telnet Enable Regex" >
+<property visible="True" label="Telnet Enable Regex" type="string" description="Regular expression to match the enable prompt." id="zTelnetEnableRegex" >
 assword:
 </property>
-<property id="zTelnetTermLength" visible="True" type="boolean" description="On a Cisco device, set term length to Zero." label="Telnet Term Length" >
+<property visible="True" label="Telnet Term Length" type="boolean" description="On a Cisco device, set term length to Zero." id="zTelnetTermLength" >
 True
 </property>
-<property id="zTelnetPromptTimeout" visible="True" type="float" description="Time to wait for the telnet prompt to return." label="Telnet Prompt Timeout (seconds)" >
+<property visible="True" label="Telnet Prompt Timeout (seconds)" type="float" description="Time to wait for the telnet prompt to return." id="zTelnetPromptTimeout" >
 10.0
 </property>
-<property id="zKeyPath" visible="True" type="string" description="Sets the path to the SSH key for device access." label="Key Path" >
+<property visible="True" label="Key Path" type="string" description="Sets the path to the SSH key for device access." id="zKeyPath" >
 ~/.ssh/id_dsa
 </property>
-<property id="zMaxOIDPerRequest" visible="True" type="int" description="Sets the maximum number of OIDs to be sent by the SNMP collection daemons when querying information. Some devices have small buffers for handling this information so the number should be lowered." label="Max OID Per Request" >
+<property visible="True" label="Max OID Per Request" type="int" description="Sets the maximum number of OIDs to be sent by the SNMP collection daemons when querying information. Some devices have small buffers for handling this information so the number should be lowered." id="zMaxOIDPerRequest" >
 40
 </property>
-<property id="zLinks" visible="True" type="string" description="Specifies a place to enter any links associated with the device." label="Links" >
+<property visible="True" label="Links" type="string" description="Specifies a place to enter any links associated with the device." id="zLinks" >
 </property>
-<property id="zIcon" visible="True" type="string" description="Specifies the icon to represent the device wherever device icon is shown, such as on the network map and device status page." label="Icon Path" >
+<property visible="True" label="Icon Path" type="string" description="Specifies the icon to represent the device wherever device icon is shown, such as on the network map and device status page." id="zIcon" >
 /zport/dmd/img/icons/noicon.png
 </property>
-<property id="zCollectorLogChanges" visible="True" type="boolean" description="Indicates whether to log changes." label="Log Collector Changes?" >
+<property visible="True" label="Log Collector Changes?" type="boolean" description="Indicates whether to log changes." id="zCollectorLogChanges" >
 False
 </property>
-<property id="zEnablePassword" visible="True" type="password" description="Enable password for Cisco routers" label="Enable Password" >
+<property visible="True" label="Enable Password" type="password" description="Enable password for Cisco routers" id="zEnablePassword" >
 </property>
-<property id="zNmapPortscanOptions" visible="True" type="string" description="Options used on nmap when scanning ports. Used in IpServiceMap" label="Nmap Port Scan Options" >
+<property visible="True" label="Nmap Port Scan Options" type="string" description="Options used on nmap when scanning ports. Used in IpServiceMap" id="zNmapPortscanOptions" >
 -p 1-1024 -sT --open -oG -
 </property>
-<property id="zSshConcurrentSessions" visible="True" type="int" description="How many SSH sessions to open up to one device (some SSH servers have a limit)" label="SSH Concurrent Sessions" >
+<property visible="True" label="SSH Concurrent Sessions" type="int" description="How many SSH sessions to open up to one device (some SSH servers have a limit)" id="zSshConcurrentSessions" >
 10
 </property>
-<property id="zCredentialsZProperties" visible="True" type="lines" description="Used by ZenPack authors to denote which zProperties comprise the credentials for this device class." label="Connection Information" >
+<property visible="True" label="Connection Information" type="lines" description="Used by ZenPack authors to denote which zProperties comprise the credentials for this device class." id="zCredentialsZProperties" >
 []
 </property>
 <property visible="True" description="" type="lines" id="zSnmpDiscoveryPorts" label="" >
@@ -192,9 +195,6 @@ False
 </property>
 <property visible="True" type="date" id="cDateTest" >
 1900/01/01 00:00:00 US/Central
-</property>
-<property visible="True" label="Timeout for User Commands (seconds)" type="float" description="Specifies the time to wait for a user command to complete." id="zCommandUserCommandTimeout" >
-15.0
 </property>
 <tomanycont id='zenMenus'>
 <object id='More' module='Products.ZenModel.ZenMenu' class='ZenMenu'>

--- a/Products/ZenModel/data/events.xml
+++ b/Products/ZenModel/data/events.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 19:31:27.704769
+    Zenoss RelationshipManager export completed on 2016-11-04 20:31:57.747394
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-01-05 19:31:27.704769" zenoss_server="196719ab575a" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:31:57.747394" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Events' module='Products.ZenEvents.EventClass' class='EventClass'>
 <property visible="True" type="lines" id="zEventClearClasses" >
 []
@@ -602,7 +602,7 @@ Updated timestamp for job `cron.daily' to 2005-12-13
 defaultmapping
 </property>
 <property type="int" id="sequence" mode="w" >
-5
+6
 </property>
 <property type="string" id="regex" mode="w" >
 message repeated \d+ times
@@ -1208,7 +1208,7 @@ MARK
 defaultmapping
 </property>
 <property type="int" id="sequence" mode="w" >
-4
+5
 </property>
 <property type="string" id="regex" mode="w" >
 -- MARK --
@@ -2440,7 +2440,7 @@ Task ran for 7797 msec (0/0), process = IP SNMP, PC = 80235E3C.
 defaultmapping
 </property>
 <property type="int" id="sequence" mode="w" >
-3
+4
 </property>
 <property type="string" id="rule" mode="w" >
 getattr(evt,'facility',False)=='local7' and evt.summary.find('Traceback')&gt;-1
@@ -5184,7 +5184,7 @@ Archive Eventlog events that have severity == debug(1)
 defaultmapping
 </property>
 <property type="int" id="sequence" mode="w" >
-6
+7
 </property>
 <property type="string" id="rule" mode="w" >
 getattr(evt,"component",False)=="FileMaker Server 7"

--- a/Products/ZenModel/data/exportXml.sh
+++ b/Products/ZenModel/data/exportXml.sh
@@ -34,9 +34,9 @@ fi
 echo 'Dumping Menus...'
 zendmd >/dev/null 2>&1 <<EOF
 fp = open('menus.xml', 'w')
-fp.write('''<?xml version="1.0"?>
-<objects>
-<object id='/zport/dmd' module='Products.ZenModel.DataRoot' class='DataRoot'>
+fp.write('''<?xml version="1.0"?>\
+<objects>\
+<object id='/zport/dmd' module='Products.ZenModel.DataRoot' class='DataRoot'>\
 ''')
 dmd.zenMenus.exportXml(fp)
 fp.write('</object></objects>\n')

--- a/Products/ZenModel/data/manufacturers.xml
+++ b/Products/ZenModel/data/manufacturers.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 19:31:35.316352
+    Zenoss RelationshipManager export completed on 2016-11-04 20:32:01.464374
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-01-05 19:31:35.316352" zenoss_server="196719ab575a" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:32:01.464374" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Manufacturers' module='Products.ZenModel.ManufacturerRoot' class='ManufacturerRoot'>
 <object id='ATI' module='Products.ZenModel.Manufacturer' class='Manufacturer'>
 <property type="string" id="url" mode="w" >

--- a/Products/ZenModel/data/menus.xml
+++ b/Products/ZenModel/data/menus.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0"?>
-<objects>
-<object id='/zport/dmd' module='Products.ZenModel.DataRoot' class='DataRoot'>
-<tomanycont id='zenMenus'>
+<?xml version="1.0"?><objects><object id='/zport/dmd' module='Products.ZenModel.DataRoot' class='DataRoot'><tomanycont id='zenMenus'>
 <object id='Add' module='Products.ZenModel.ZenMenu' class='ZenMenu'>
 <tomanycont id='zenMenuItems'>
 <object id='addFileSystem' module='Products.ZenModel.ZenMenuItem' class='ZenMenuItem'>

--- a/Products/ZenModel/data/monitorTemplate.xml
+++ b/Products/ZenModel/data/monitorTemplate.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 19:31:45.947994
+    Zenoss RelationshipManager export completed on 2016-11-04 20:32:09.392502
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-01-05 19:31:45.947994" zenoss_server="196719ab575a" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:32:09.392502" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Monitors' module='Products.ZenModel.MonitorClass' class='MonitorClass'>
 <property type="string" id="sub_class" mode="w" >
 MonitorClass

--- a/Products/ZenModel/data/osprocesses.xml
+++ b/Products/ZenModel/data/osprocesses.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 19:31:52.966925
+    Zenoss RelationshipManager export completed on 2016-11-04 20:32:12.858240
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-01-05 19:31:52.966925" zenoss_server="196719ab575a" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:32:12.858240" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Processes/Zenoss' module='Products.ZenModel.OSProcessOrganizer' class='OSProcessOrganizer'>
 <property id='zendoc' type='string'>
 Base Zenoss daemons

--- a/Products/ZenModel/data/services.xml
+++ b/Products/ZenModel/data/services.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 
 <!--
-    Zenoss RelationshipManager export completed on 2016-01-05 19:31:14.457314
+    Zenoss RelationshipManager export completed on 2016-11-04 20:31:46.678193
 
     Use ImportRM to import this file.
 
     For more information about Zenoss, go to http://www.zenoss.com
  -->
 
-<objects version="[Zenoss, version 5.0.70]" export_date="2016-01-05 19:31:14.457314" zenoss_server="196719ab575a" >
+<objects version="[Zenoss, version 5.2.0]" export_date="2016-11-04 20:31:46.678193" zenoss_server="ade5488a941d" >
 <object id='/zport/dmd/Services' module='Products.ZenModel.ServiceOrganizer' class='ServiceOrganizer'>
 <property visible="True" type="boolean" id="zMonitor" >
 False

--- a/Products/ZenModel/migrate/AddHMasterRegionServerGraphConfigs.py
+++ b/Products/ZenModel/migrate/AddHMasterRegionServerGraphConfigs.py
@@ -23,7 +23,7 @@ sm.require("1.0.0")
 class AddHMasterRegionServerGraphConfigs(Migrate.Step):
     """ Add GraphConfigs and MetricConfigs to HMaster and RegionServer """
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/FixDatapointsFormat.py
+++ b/Products/ZenModel/migrate/FixDatapointsFormat.py
@@ -17,7 +17,7 @@ sm.require("1.0.0")
 class FixDatapointsFormat(Migrate.Step):
     """ Fix printf format for zenpop3 and zenmail datapoints format """
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addDescriptionToCommands.py
+++ b/Products/ZenModel/migrate/addDescriptionToCommands.py
@@ -20,7 +20,7 @@ sm.require("1.0.0")
 
 class AddDescriptionToCommands(Migrate.Step):
 
-    version = Migrate.Version(5, 1, 70)
+    version = Migrate.Version(106, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addHBaseMetricsConfig.py
+++ b/Products/ZenModel/migrate/addHBaseMetricsConfig.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 
 class AddHBaseMetricsConfig(Migrate.Step):
     """ Set metrics reporting frequency to 15 secs. See ZEN-25317 """
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addSnmpV3UserCommand.py
+++ b/Products/ZenModel/migrate/addSnmpV3UserCommand.py
@@ -13,7 +13,7 @@ SNMPV3_COMMAND = ('snmpwalk -${device/zSnmpVer} -l authNoPriv -a ${device/zSnmpA
 
 class AddSnmpV3UserCommand(Migrate.Step):
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         if SNMPV3_ID not in [d.id for d in dmd.userCommands()]:

--- a/Products/ZenModel/migrate/addTagToImages.py
+++ b/Products/ZenModel/migrate/addTagToImages.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class AddTagToImages(Migrate.Step):
     "Add tag latest to all Images that do not have a tag"
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
+++ b/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
@@ -18,7 +18,7 @@ import Migrate
 
 class addzCommandUserCommandTimeout(Migrate.Step):
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         if not hasattr(dmd.Devices, 'zCommandUserCommandTimeout'):

--- a/Products/ZenModel/migrate/beakerHttpOnly.py
+++ b/Products/ZenModel/migrate/beakerHttpOnly.py
@@ -20,7 +20,7 @@ class BeakerHTTPOnly(Migrate.Step):
     Set beaker session.httponly to true in config
     """
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/changeMemcachedStartup.py
+++ b/Products/ZenModel/migrate/changeMemcachedStartup.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class ChangeMemcachedStartup(Migrate.Step):
     "Change memcached startup to respect config file and update config file"
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def _update_config(self, config):
         USER_RE = r'USER="\w+"'

--- a/Products/ZenModel/migrate/checkHBaseTablesExist.py
+++ b/Products/ZenModel/migrate/checkHBaseTablesExist.py
@@ -21,7 +21,7 @@ class CheckHBaseTablesExist(Migrate.Step):
     See ZEN-24094
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/defaultBeakerToSecure.py
+++ b/Products/ZenModel/migrate/defaultBeakerToSecure.py
@@ -20,7 +20,7 @@ class DefaultBeakerToSecure(Migrate.Step):
     Set beaker session.secure to true in config
     """
 
-    version = Migrate.Version(5, 1, 3)
+    version = Migrate.Version(101, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/disableZproxyAccessLog.py
+++ b/Products/ZenModel/migrate/disableZproxyAccessLog.py
@@ -20,7 +20,7 @@ sm.require("1.0.0")
 class DisableZproxyAccessLog(Migrate.Step):
     "Disable zproxy nginx access logging by default"
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/enableNginxPagespeed.py
+++ b/Products/ZenModel/migrate/enableNginxPagespeed.py
@@ -23,7 +23,7 @@ class EnableNginxPagespeed(Migrate.Step):
     Turn pagespeed in zproxy-nginx.conf
     '''
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/fixDefaultmappingSequences.py
+++ b/Products/ZenModel/migrate/fixDefaultmappingSequences.py
@@ -1,0 +1,60 @@
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2007, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+
+__doc__='''
+This migration script fixes a specific conflict in the base database between sequence numbers for the defaultmapping EventClass instance.
+''' 
+
+__version__ = "$Revision$"[11:-2]
+
+import logging
+log = logging.getLogger("zen.migrate")
+import Migrate
+
+
+# Checks a list of items sorted by sequence for duplicate sequence numbers
+def hasSequenceConflict(items):
+    if len(items) > 1:
+        lastSequence = items[0].sequence
+        for item in items[1:]:
+            if item.sequence == lastSequence:
+                return True
+            lastSequence = item.sequence
+    return False
+
+# Re-sequences a sorted list of items, returns the number of items changed
+def resequence(items):
+    changed = 0
+    for i, item in enumerate(items):
+            if item.sequence != i:
+                item.sequence = i
+                changed = changed + 1
+    return changed
+
+class FixDefaultmappingSequences(Migrate.Step):
+
+    version = Migrate.Version(107,0,0)
+
+    def cutover(self, dmd):
+        changed = 0
+        log.info("Fixing default EventClass instance sequence conflict")
+
+        # This will give us all EventClassInstances that have eventclasskey "defaultmapping", sorted by sequence:
+        defaultmappings = dmd.Events.find('defaultmapping')
+
+        if(hasSequenceConflict(defaultmappings)):
+            changed = resequence(defaultmappings)
+
+
+        log.info("Updated sequence numbers for %d Event class instances" % changed)
+
+
+
+FixDefaultmappingSequences()

--- a/Products/ZenModel/migrate/fixMariadbHealthCheck.py
+++ b/Products/ZenModel/migrate/fixMariadbHealthCheck.py
@@ -22,7 +22,7 @@ class FixMariadbHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/fixZauthHealthCheck.py
+++ b/Products/ZenModel/migrate/fixZauthHealthCheck.py
@@ -22,7 +22,7 @@ class FixZauthHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/moveProductionStateToBTree.py
+++ b/Products/ZenModel/migrate/moveProductionStateToBTree.py
@@ -24,7 +24,7 @@ from Products.ZCatalog.Catalog import CatalogError
 
 class MoveProductionStateToBTree(Migrate.Step):
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def migrateObject(self, obj):
         obj_unwrapped = aq_base(obj)

--- a/Products/ZenModel/migrate/removeEmptyGraphs.py
+++ b/Products/ZenModel/migrate/removeEmptyGraphs.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RemoveEmptyGraphs(Migrate.Step):
     """Remove some graph datapoints from a few services."""
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/removeRegionServerPrereqs.py
+++ b/Products/ZenModel/migrate/removeRegionServerPrereqs.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 
 class RemoveRegionServerPrereqs(Migrate.Step):
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/retryZopeHealthCheck.py
+++ b/Products/ZenModel/migrate/retryZopeHealthCheck.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RetryZopeHealthCheck(Migrate.Step):
     "Change 'answering' healthcheck to retry a few times on failture"
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/setMariaDbConfigDefaults.py
+++ b/Products/ZenModel/migrate/setMariaDbConfigDefaults.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class SetMariaDbConfigDefaults(Migrate.Step):
     """Setting MariaDB buffer pool size default"""
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
+++ b/Products/ZenModel/migrate/templatizeCollectorEndpoints.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class TemplatizeCollectorEndpoints(Migrate.Step):
     "Use templated names for collector endpoints"
 
-    version = Migrate.Version(5,1,2)
+    version = Migrate.Version(100, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateHBaseLogPath.py
+++ b/Products/ZenModel/migrate/updateHBaseLogPath.py
@@ -22,7 +22,7 @@ class UpdateHBaseLogPath(Migrate.Step):
     See ZEN-23724
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateMariaDbPoolAllocations.py
+++ b/Products/ZenModel/migrate/updateMariaDbPoolAllocations.py
@@ -16,7 +16,7 @@ log = logging.getLogger("zen.migrate")
 sm.require("1.0.0")
 
 class UpdateMariaDBPoolAlloc(Migrate.Step):
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateMemcachedMaxObjectSize.py
+++ b/Products/ZenModel/migrate/updateMemcachedMaxObjectSize.py
@@ -20,7 +20,7 @@ class UpdateMemcachedMaxObjectSize(Migrate.Step):
     that memcached clients can send
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     OPTIONS_TEXT = '''{{ $size := (getContext . "global.conf.zodb-cache-max-object-size") }}
 OPTIONS="-v -R 4096 -I {{if $size}} {{$size}} {{else}} 1048576 {{end}}"'''

--- a/Products/ZenModel/migrate/updateMetricsHealthchecks.py
+++ b/Products/ZenModel/migrate/updateMetricsHealthchecks.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 
 
 class UpdateMetricsHealthChecks(Migrate.Step):
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateOpenTSDBConfigRandomUIDEnable.py
+++ b/Products/ZenModel/migrate/updateOpenTSDBConfigRandomUIDEnable.py
@@ -27,7 +27,7 @@ class UpdateOpenTSDBConfigRandomUIDEnable(Migrate.Step):
         - If the paramter already exists then no change is made to the config file.
     """
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         """ This method is called by the migration process and overrides the method

--- a/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
+++ b/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
@@ -22,7 +22,7 @@ class UpdateOpenTsdbCreateTables(Migrate.Step):
     See ZEN-22929
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateZepLogbackConfig.py
+++ b/Products/ZenModel/migrate/updateZepLogbackConfig.py
@@ -10,7 +10,7 @@ class UpdateZepLogbackConfig(Migrate.Step):
     """ 
     Removing zeneventserver metrics logging inside container.
     """
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     UPDATED_LOGBACK_CONFIG = """<?xml version="1.0" encoding="UTF-8"?>
 <!--

--- a/Products/ZenModel/migrate/updateZodbConfigFiles.py
+++ b/Products/ZenModel/migrate/updateZodbConfigFiles.py
@@ -24,7 +24,7 @@ class UpdateZodbConfigFiles(Migrate.Step):
     - For Zauth, we need to update the above files to be built from global.conf
     """
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     ZODB_MAIN_CFG_CONTENT = """
     <mysql>

--- a/Products/ZenModel/migrate/updateZopeAnsweringHealthChecks.py
+++ b/Products/ZenModel/migrate/updateZopeAnsweringHealthChecks.py
@@ -23,7 +23,7 @@ class UpdateZopeAnsweringHealthChecks(Migrate.Step):
     healthcheck script
     """
 
-    version = Migrate.Version(5, 2, 0)
+    version = Migrate.Version(107, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateZproxyPagespeedUpstreams.py
+++ b/Products/ZenModel/migrate/updateZproxyPagespeedUpstreams.py
@@ -190,7 +190,7 @@ http {
 
 class UpdateZproxyPagespeedUpstreams(Migrate.Step):
 
-    version = Migrate.Version(5,2,0)
+    version = Migrate.Version(107, 0, 0)
 
     config_file = "/opt/zenoss/zproxy/conf/zproxy-nginx.conf"
     save_file = "/opt/zenoss/var/ext/zproxy-nginx.conf.orig"

--- a/devimg/zenreload.sh
+++ b/devimg/zenreload.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2007, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+# THIS SCRIPT SHOULD BE RUN ON A CLEAN DATABASE
+# IT WILL BLOW AWAY ALL ZENPACKS AND THEN RELOAD THE BASE DATABASES
+# Use --xml option to this script to rebuild using DmdBuilder and the XML files
+# Default is simply to reload from SQL dump
+
+if [ -z "${ZENHOME}" ]; then
+    if [ -d /opt/zenoss ] ; then
+        ZENHOME=/opt/zenoss
+    else
+        echo "Please define the ZENHOME environment variable"
+        exit 1
+    fi
+fi
+
+zengc=$ZENHOME/bin/zenglobalconf
+
+echo "Deleting Zenpacks"
+rm -rf $ZENHOME/ZenPacks/*
+
+if [ -d $ZENHOME/var/catalogservice ]; then
+    rm -rf $ZENHOME/var/catalogservice
+fi
+
+# Creates the initial user file for zenbuild
+python -m Zope2.utilities.zpasswd -u admin -p zenoss $ZENHOME/inituser
+zenbuild -v 10 -u$admin -p "$adminpass" "$@"
+# truncate daemons.txt file
+cp /dev/null $ZENHOME/etc/daemons.txt

--- a/devimg/zenwipe.sh
+++ b/devimg/zenwipe.sh
@@ -8,10 +8,8 @@
 # 
 ##############################################################################
 
-# THIS SCRIPT WILL BLOW AWAY YOUR DATABASE
-# Use --xml option to this script to rebuild using DmdBuilder and the XML files
-# Default is simply to reload from SQL dump
-
+# THIS SCRIPT WILL BLOW AWAY YOUR DATABASE.  RUN THIS IN THE
+#  MARIADB CONTAINER AND THEN RUN zenreload.sh IN ZOPE or devshell
 if [ -z "${ZENHOME}" ]; then
     if [ -d /opt/zenoss ] ; then
         ZENHOME=/opt/zenoss
@@ -33,17 +31,6 @@ admin=$(${zengc} -p zodb-admin-user)
 adminpass=$(${zengc} -p zodb-admin-password)
 dbname=$(${zengc} -p zodb-db)
 
-# Shut down zenoss if it's running.
-# Faster to check pid files than run the zenoss script.
-for pidfile in $(find $ZENHOME/var -name \*.pid); do
-    pid=$(cat $pidfile)
-    if ps -p $pid >/dev/null; then
-        echo "Stopping Zenoss"
-        $ZENHOME/bin/zenoss stop
-        break
-    fi
-done
-
 # Drop and recreate the ZODB relstorage database
 zeneventserver-create-db --dbtype $dbtype --dbhost $host --dbport $port --dbadminuser $admin --dbadminpass "${adminpass}" --dbuser $user --dbpass "${userpass}" --force --dbname $dbname --schemadir $ZENHOME/Products/ZenUtils/relstorage
 
@@ -52,17 +39,4 @@ zeneventserver-create-db --dbtype $dbtype --dbhost $host --dbport $port --dbadmi
 
 # Drop and recreate the ZEP event database
 zeneventserver-create-db --dbtype $dbtype --dbhost $host --dbport $port --dbadminuser $admin --dbadminpass "${adminpass}" --dbuser $user --dbpass "${userpass}" --force
-
-echo "Deleting Zenpacks"
-rm -rf $ZENHOME/ZenPacks/*
-
-if [ -d $ZENHOME/var/catalogservice ]; then
-    rm -rf $ZENHOME/var/catalogservice
-fi
-
-# Creates the initial user file for zenbuild
-python -m Zope2.utilities.zpasswd -u admin -p zenoss $ZENHOME/inituser
-zenbuild -v 10 -u$admin -p "$adminpass" "$@"
-# truncate daemons.txt file
-cp /dev/null $ZENHOME/etc/daemons.txt
 


### PR DESCRIPTION
Renumbering all migrations at least as young as 5.1.1 because
some releases and appliances had db versions ahead of the migrations
shipped.

Switching to a single-number scheme to reduce confusion and to break
the relation between releases of Zenoss and migrations of ZenModel--
they need not stay in lockstep.

The new scheme is based on 100 to make sure releases as early as 5.1.1
will run all of the necessary migrations, as the db version could be as
far forward as 5.1.70 in some systems.