### PR TITLE
ZEN-25506 Use user local time in date pickers

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -710,6 +710,10 @@
                 return;
             }
 
+            if (isAdjusted === undefined) {
+                isAdjusted = true;
+            }
+
             var adjustedTime;
 
             // if someone is using a date object, get
@@ -738,7 +742,7 @@
         getValue: function(){
             // clear any previous offsets and return just the UTC
             // time since epoch
-            return this.value.getTime() - this.TZOffsetMS - this.TZLocalMS;
+            return +moment.tz(this.value, this.displayTZ).utc().toDate();
         },
 
         beforeBlur : function(){


### PR DESCRIPTION
[Jira](https://github.com/zenoss/zenoss-prodbin/compare/ZEN-25506)

We must display user's local time in date pickers, not UTC.