### PR TITLE
Fix ZEN-23418: fix date range filtering by converting date filter params to UTC

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
@@ -453,12 +453,12 @@
             this.grid.store.proxy.extraParams.params = values;
             // ZEN-23418 Convert firstSeen and lastSeen filter params to UTC before making query request
             if (this.grid.store.proxy.extraParams.params.firstTime) {
-                var timeRange = this.grid.store.proxy.extraParams.params.firstTime;
-                this.grid.store.proxy.extraParams.params.firstTime = moment(timeRange).utc().format("YYYY-MM-DD hh:mm:ss");
+                var timeParam = this.grid.store.proxy.extraParams.params.firstTime;
+                this.grid.store.proxy.extraParams.params.firstTime = moment(timeParam).utc().format("YYYY-MM-DD hh:mm:ss");
             }
             if (this.grid.store.proxy.extraParams.params.lastTime) {
-                var timeRange = this.grid.store.proxy.extraParams.params.lastTime;
-                this.grid.store.proxy.extraParams.params.lastTime = moment(timeRange).utc().format("YYYY-MM-DD hh:mm:ss");
+                var timeParam = this.grid.store.proxy.extraParams.params.lastTime;
+                this.grid.store.proxy.extraParams.params.lastTime = moment(timeParam).utc().format("YYYY-MM-DD hh:mm:ss");
             }
 
             // reset their scrolling when the filters change

--- a/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
@@ -451,6 +451,15 @@
             }
             // this will make sure that all subsequent buffer loads have the parameters
             this.grid.store.proxy.extraParams.params = values;
+            // ZEN-23418 Convert firstSeen and lastSeen filter params to UTC before making query request
+            if (this.grid.store.proxy.extraParams.params.firstTime) {
+                var timeRange = this.grid.store.proxy.extraParams.params.firstTime;
+                this.grid.store.proxy.extraParams.params.firstTime = moment(timeRange).utc().format("YYYY-MM-DD hh:mm:ss");
+            }
+            if (this.grid.store.proxy.extraParams.params.lastTime) {
+                var timeRange = this.grid.store.proxy.extraParams.params.lastTime;
+                this.grid.store.proxy.extraParams.params.lastTime = moment(timeRange).utc().format("YYYY-MM-DD hh:mm:ss");
+            }
 
             // reset their scrolling when the filters change
             this.grid.scrollToTop();


### PR DESCRIPTION
Convert local date string to UTC date string before making a query request `/evconsole_router`.