### PR TITLE
ZEN-23195 Fixed duplicate event detection

### DIFF
--- a/Products/ZenEvents/EventClassInst.py
+++ b/Products/ZenEvents/EventClassInst.py
@@ -411,6 +411,14 @@ class EventClassInst(EventClassPropertyMixin, ZenModelRM, EventView,
         self.explanation = ""
         self.resolution = ""
 
+    def _updateProperty(self, id, value):
+        if id == 'sequence':
+            for mapping in self.sameKey():
+                if mapping.sequence == value:
+                    raise ValueError('EventClass Mapping Instance "%s" '
+                                     'has duplicated sequence' % self.id)
+        super(EventClassInst, self)._updateProperty(id, value)
+
 
     def getStatus(self, **kwargs):
         """Return the status number for this device of class statClass.

--- a/Products/ZenEvents/tests/testEventClassInst.py
+++ b/Products/ZenEvents/tests/testEventClassInst.py
@@ -1,0 +1,49 @@
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2016, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+import Globals
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from Products.ZenEvents.EventClassInst import EventClassInst
+
+
+class testEventClassInst(BaseTestCase):
+    def afterSetUp(self):
+        super(testEventClassInst, self).afterSetUp()
+
+        self.testEvents = [EventClassInst('testEvents')
+                           for i in range(10)]
+        for i, event in enumerate(self.testEvents):
+            event.sequence = i
+            event.sameKey = lambda: self.testEvents
+
+
+    def testUpdatePropertyNoDuplicates(self):
+        for i, event in enumerate(self.testEvents):
+            event.sequence = i
+
+        for i, event in enumerate(self.testEvents):
+            if i == 0:
+                continue
+            self.assertRaises(ValueError,
+                              event._updateProperty, 'sequence', 0)
+
+        for i, event in enumerate(self.testEvents):
+            self.assertEqual(event.sequence, i)
+
+
+    def testUpdateProperty(self):
+        for i, event in enumerate(self.testEvents):
+            event.sequence = i
+
+        for i, event in enumerate(self.testEvents):
+            event._updateProperty('sequence', event.sequence + 100)
+
+        for i, event in enumerate(self.testEvents):
+            self.assertEqual(event.sequence, i + 100)

--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -351,14 +351,6 @@ class ZenPropertyManager(object, PropertyManager):
         the ValueError returned from the field2* converters in the class
         Converters.py
         """
-        if id == 'sequence' and hasattr(self, 'eventClassKey'):
-            for insts in self.dmd.Events.getInstances():
-                if (insts.id == self.id and
-                    insts.sequence == value and
-                        insts.eventClass().getEventClass() !=
-                        self.eventClass().getEventClass()):
-                    raise ValueError('EventClass Mapping Instance "%s" '
-                                     'has duplicated sequence' % self.id)
         try:
             super(ZenPropertyManager, self)._updateProperty(id, value)
         except ValueError:


### PR DESCRIPTION
Changed _updateProperty method in ZenPropertyManager
to compare sequences across results of sameKey
instead of all of Events.getInstances.