### PR TITLE
Fix ZEN-26021: Restore the old shipper health check

### DIFF
--- a/bin/healthchecks/MetricShipper/store_answering
+++ b/bin/healthchecks/MetricShipper/store_answering
@@ -7,20 +7,6 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-#
-# check if metric_consumer is accessible
-#
-is_ready()
-{
-    status_url=$1
-    timeout 3 curl -w %{http_code} -s -XHEAD ${status_url}
-}
 
-http_code=$(is_ready http://localhost:8080/ping/status/metrics)
-
-if [ "$http_code" != "200" ] 
-then
-    exit 1
-fi
-
-exit 0
+auth=$(/opt/zenoss/bin/python -c "import yaml; import base64; f = open('/opt/zenoss/etc/metricshipper/metricshipper.yaml','r'); y = yaml.load(f); print 'basic '+base64.b64encode(y['username']+':'+y['password'])" 2>/dev/null)
+[ "$auth" != "" ] && curl -s -XPOST --cookie cookies.txt --cookie-jar cookies.txt -H 'Content-Type: application/json' -H "Authorization: $auth" -d '{}' http://localhost:8080/api/metrics/store | grep -q 'may not be null'


### PR DESCRIPTION
Reverts zenoss/zenoss-prodbin#1948, which used a more efficient health check -- that doesn't exist in 5.1.x.