### PR TITLE
Allow the BRANCH make variable to be overriden from the command line

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 VERSION  ?= 5.2.0
 BUILD_NUMBER ?= DEV
-BRANCH   := develop
+BRANCH   ?= develop
 ARTIFACT := prodbin-$(VERSION)-$(BRANCH).tar.gz
 
 DIST_ROOT := dist


### PR DESCRIPTION
Needed for Metis release process - ZEN-26069

Will be used in the Jenkins job [zenoss-prodbin-merge-support-52x](http://jenkins.zendev.org/view/zenoss-prodbin/job/zenoss-prodbin-merge-support-52x) to run a command like:
```
BRANCH=support-5.2.x make clean build
```
Which will produce an artifact with a name like `prodbin-5.2.0-support-5.2.x.tar.gz`