### PR TITLE
ZEN-23880 change the permission for ZenManager

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devicemanagement/Administration.js
@@ -609,7 +609,7 @@ Ext.ns('Zenoss', 'Zenoss.devicemanagement');
             keys: {}
         };
 
-        if (Zenoss.Security.hasPermission('Manage Device')) {
+        if (Zenoss.Security.hasPermission('Define Commands Edit')) {
             dialog = new Zenoss.SmartFormDialog(config);
             dialog.show();
         }else{ return false; }
@@ -1096,8 +1096,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'add',
                     tooltip: _t('Add a User Command'),
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Define Commands Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Define Commands Edit'),
                     ref: 'addButton',
                         handler: function() {
                             var grid = Ext.getCmp("deviceCommandsGrid");
@@ -1107,8 +1107,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                         xtype: 'button',
                         iconCls: 'delete',
                         tooltip: _t('Delete selected User Command'),
-                        requiredPermission: 'Maintenance Windows Edit', // change the line below as well
-                        disabled: Zenoss.Security.doesNotHavePermission('Maintenance Windows Edit'),
+                        requiredPermission: 'Define Commands Edit', // change the line below as well
+                        disabled: Zenoss.Security.doesNotHavePermission('Define Commands Edit'),
                         handler: function() {
                             var grid = Ext.getCmp("deviceCommandsGrid"),
                                 data,
@@ -1144,8 +1144,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     xtype: 'button',
                     iconCls: 'customize',
                     tooltip: _t('Edit selected User Command'),
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Define Commands Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Define Commands Edit'),
                     ref: 'customizeButton',
                         handler: function() {
                             var grid = Ext.getCmp("deviceCommandsGrid"),
@@ -1164,8 +1164,8 @@ Ext.define("Zenoss.devicemanagement.Administration", {
                     iconCls: 'export',
                     tooltip: _t('Add selected User Command to ZenPack'),
                     ref: '../refreshButton',
-                    requiredPermission: 'Manage Device', // change the line below as well
-                    disabled: Zenoss.Security.doesNotHavePermission('Manage Device'),
+                    requiredPermission: 'Define Commands Edit', // change the line below as well
+                    disabled: Zenoss.Security.doesNotHavePermission('Define Commands Edit'),
                     handler: function() {
                         var grid = Ext.getCmp("deviceCommandsGrid");
                         var zp_dialog = Ext.create('Zenoss.AddToZenPackWindow', {});

--- a/Products/Zuul/routers/devicemanagement.py
+++ b/Products/Zuul/routers/devicemanagement.py
@@ -90,7 +90,7 @@ class DeviceManagementRouter(DirectRouter):
         data = facade.getUserCommands(uid)
         return DirectResponse( data=Zuul.marshal(data) )       
 
-    @require('Manage Device')        
+    @require('Define Commands Edit')
     def addUserCommand(self, params):
         """
         add a new user command to devices
@@ -100,7 +100,7 @@ class DeviceManagementRouter(DirectRouter):
         #work in password and not just succeed()
         return DirectResponse.succeed()
         
-    @require('Manage Device')        
+    @require('Define Commands Edit')
     def deleteUserCommand(self, uid, id):
         """
         delete a user command
@@ -109,7 +109,7 @@ class DeviceManagementRouter(DirectRouter):
         data = facade.deleteUserCommand(uid, id)
         return DirectResponse.succeed(data=Zuul.marshal(data))         
 
-    @require('Manage Device')        
+    @require('Define Commands Edit')
     def updateUserCommand(self, params):
         """
         completes or updates an existing user command


### PR DESCRIPTION
ZenManager had access for editing commands, which according to
default setting he shouldn't have.
Changed permissions for editing commands on the UI side and backend
side.