### PR TITLE
ZEN-26126: Migration MoveProductionStateToBTree fails if zenpack code is missing

### DIFF
--- a/Products/ZenModel/migrate/moveProductionStateToBTree.py
+++ b/Products/ZenModel/migrate/moveProductionStateToBTree.py
@@ -60,9 +60,14 @@ class MoveProductionStateToBTree(Migrate.Step):
 
             self.migrateObject(device)
 
-            # migrate components
-            for c in device.getDeviceComponents():
-                self.migrateObject(c)
+            # migrate components, if any
+            try:
+                cmps = device.getDeviceComponents()
+            except AttributeError:
+                pass
+            else:
+                for c in cmps:
+                    self.migrateObject(c)
 
         log.info("All devices migrated")
 


### PR DESCRIPTION
Better error handling in production state migration.  This handles a case that really only should occur if you are doing something you shouldn't.