### PR TITLE
ZEN-25826 Add date format to user settings

### DIFF
--- a/Products/ZenModel/UserSettings.py
+++ b/Products/ZenModel/UserSettings.py
@@ -610,6 +610,7 @@ class UserSettings(ZenModelRM):
     zenossNetUser = ''
     zenossNetPassword = ''
     timezone = ''
+    dateFormat = ''
 
     _properties = ZenModelRM._properties + (
         {'id':'email', 'type':'string', 'mode':'w'},
@@ -626,6 +627,7 @@ class UserSettings(ZenModelRM):
         {'id':'zenossNetUser', 'type':'string', 'mode':'w'},
         {'id':'zenossNetPassword', 'type':'string', 'mode':'w'},
         {'id':'timezone', 'type':'string', 'mode':'w'},
+        {'id':'dateFormat', 'type':'string', 'mode':'w'},
     )
 
 

--- a/Products/ZenModel/skins/zenmodel/editUserSettings.pt
+++ b/Products/ZenModel/skins/zenmodel/editUserSettings.pt
@@ -218,6 +218,29 @@
             </script>
           </td>
         </tr>
+        <tr>
+          <td class="tableheader" align="left">Date format</td>
+          <td class="tablevalues">
+            <select id="user_settings_dateformat" name="dateFormat"></select>
+            <script tal:content='string:
+                 Zenoss.env.CURRENT_USER_DATE_FORMAT = "${context/dateFormat}" || Zenoss.USER_DATE_FORMAT;
+             '></script>
+            <script>
+              // build a select list with the current date format selected.
+              // Zenoss.data.timeZones comes from moment-timezone-data.js and
+              Ext.onReady(function() {
+                  var select = Ext.get('user_settings_dateformat').dom, formats = ['MM/DD/YY', 'DD/MM/YY', 'YY/MM/DD'], format, i;
+                  for (i = 0; i < formats.length; i++) {
+                      format = formats[i];
+                      select.options[i] = new Option(format, format);
+                      if (format === Zenoss.env.CURRENT_USER_DATE_FORMAT) {
+                          select.options[i].selected = true;
+                      }
+                  }
+             });
+            </script>
+          </td>
+        </tr>
 
         <tr>
             <td style="height:1px;border-bottom:dashed 1px #bbb;" class="tableheader">

--- a/Products/ZenUI3/browser/configure.zcml
+++ b/Products/ZenUI3/browser/configure.zcml
@@ -398,7 +398,8 @@
 
 <browser:viewlet
     name="zenoss_data"
-    manager=".interfaces.IMainSnippetManager"
+    weight="3"
+    manager=".interfaces.IJavaScriptSrcManager"
     class=".javascript.ZenossData"
     permission="zope2.Public"
     />

--- a/Products/ZenUI3/browser/javascript.py
+++ b/Products/ZenUI3/browser/javascript.py
@@ -251,13 +251,19 @@ class ZenossData(JavaScriptSnippet):
         # 3. the timezone of the browser
         user = self.context.dmd.ZenUsers.getUserSettings()
         timezone = user.timezone
+        date_fmt = user.dateFormat
         snippet = """
+          (function(){
+            Ext.namespace('Zenoss.env');
+
             Zenoss.env.COLLECTORS = %r;
             Zenoss.env.priorities = %r;
             Zenoss.env.productionStates = %r;
             Zenoss.USER_TIMEZONE = "%s" || jstz.determine().name();
-        """ % ( collectors, priorities, productionStates, timezone )
-        return snippet
+            Zenoss.USER_DATE_FORMAT = "%s" || "MM/DD/YY";
+          })();
+        """ % ( collectors, priorities, productionStates, timezone, date_fmt )
+        return SCRIPT_TAG_TEMPLATE % snippet
 
 class BrowserState(JavaScriptSnippet):
     """

--- a/Products/ZenUI3/browser/javascript.zcml
+++ b/Products/ZenUI3/browser/javascript.zcml
@@ -65,7 +65,7 @@
 
 <browser:viewlet
         name="timezone-support"
-        weight="4"
+        weight="3"
         manager=".interfaces.IJavaScriptSrcManager"
         permission="zope2.Public"
         class=".javascript.JavaScriptSrcBundleViewlet"


### PR DESCRIPTION
[Jira](https://jira.zenoss.com/browse/ZEN-25826)

In this PR I've added a new setting (on an user level) - user can now specify a date format which will be displayed on graphs.

Also, I've changed order of loading scripts on page - I need to have `ZenossData` JS snippet before `visualization.js` for zenoss/query#264 