### PR TITLE
ZEN-23181 IncidentManagement ZenPack hook to apply button after EvConsole recreated

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
@@ -114,7 +114,8 @@ Ext.onReady(function(){
         grid.on('recreateGrid', function (grid) {
             var container_panel = Ext.getCmp('master_panel');
             container_panel.remove(grid.id, true);
-            createEventConsoleGrid();
+            var new_grid = createEventConsoleGrid();
+            new_grid.on('afterrender', master_panel.fireEvent('events_grid_reloaded'));
         });
 
         hideEventDetail();


### PR DESCRIPTION
IncidentManagement ZenPack hook to apply button after EvConsole recreated
(Port ticket for: ZEN-23181 When you configure displayed columns in event console "Create Incident" button disappears)