### PR TITLE
ZEN-26108 When you configure displayed columns in event console 'Create Incident' button disappears

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
@@ -114,7 +114,8 @@ Ext.onReady(function(){
         grid.on('recreateGrid', function (grid) {
             var container_panel = Ext.getCmp('master_panel');
             container_panel.remove(grid.id, true);
-            createEventConsoleGrid();
+            var new_grid = createEventConsoleGrid();
+            new_grid.on('afterrender', master_panel.fireEvent('events_grid_reloaded'));
         });
 
         hideEventDetail();


### PR DESCRIPTION
ZEN-26108 When you configure displayed columns in event console 'Create Incident' button disappears
is a PORT ticket for:
ZEN-23181 When you configure displayed columns in event console "Create Incident" button disappears