### PR TITLE
ZEN-26572 Google Map API warning msg

### DIFF
--- a/Products/ZenWidgets/skins/zenui/locationGeoMap.pt
+++ b/Products/ZenWidgets/skins/zenui/locationGeoMap.pt
@@ -12,7 +12,7 @@
         tal:condition="here/dmd/geomapapikey"
         tal:define="apikey here/dmd/geomapapikey"
         tal:attributes="
-            src string:https://maps.googleapis.com/maps/api/js?key=${apikey}&sensor=false;
+            src string:https://maps.googleapis.com/maps/api/js?key=${apikey};
     "></script>
     <script tal:content="string:
         var eventsdb=true,

--- a/Products/ZenWidgets/skins/zenui/simpleLocationGeoMap.pt
+++ b/Products/ZenWidgets/skins/zenui/simpleLocationGeoMap.pt
@@ -20,7 +20,7 @@ v\:* {
         tal:condition="here/dmd/geomapapikey"
         tal:define="apikey here/dmd/geomapapikey"
         tal:attributes="
-            src string:https://maps.googleapis.com/maps/api/js?key=${apikey}&sensor=false"></script>
+            src string:https://maps.googleapis.com/maps/api/js?key=${apikey}"></script>
     <script tal:content="string:
         var eventsdb=true,
             geocodecache = ${here/getGeoCache};


### PR DESCRIPTION
Fixes browser SensorNotRequired warning by removing unneccesary Sensor querystring parameter.