### PR TITLE
ZEN-26459: add listener for Enter Key

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
@@ -313,6 +313,13 @@ Ext.onReady(function() {
                             width: 300,
                             xtype: 'textfield',
                             name: 'message',
+                            listeners: {
+                                specialkey: function(formEl, e){
+                                    if (e.getCharCode() == Ext.EventObject.ENTER) {
+                                        this.up('form').down('button').handler()
+                                    }
+                                }
+                            },
                             hidden: Zenoss.Security.doesNotHavePermission('Manage Events'),
                             id: 'detail-logform-message'
                         },{


### PR DESCRIPTION
When a user typed an entry in an event log
the return key would not add that message.
Add the listener to textfield in the form, that trigger
form when Enter Key is pressed.