### PR TITLE
ZEN-26635: Tracebacks on upgrade from 5.1.10 to 5.2.1

### DIFF
--- a/Products/ZenModel/migrate/AddHMasterRegionServerGraphConfigs.py
+++ b/Products/ZenModel/migrate/AddHMasterRegionServerGraphConfigs.py
@@ -23,7 +23,7 @@ sm.require("1.0.0")
 class AddHMasterRegionServerGraphConfigs(Migrate.Step):
     """ Add GraphConfigs and MetricConfigs to HMaster and RegionServer """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/FixDatapointsFormat.py
+++ b/Products/ZenModel/migrate/FixDatapointsFormat.py
@@ -17,7 +17,7 @@ sm.require("1.0.0")
 class FixDatapointsFormat(Migrate.Step):
     """ Fix printf format for zenpop3 and zenmail datapoints format """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addHBaseMetricsConfig.py
+++ b/Products/ZenModel/migrate/addHBaseMetricsConfig.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 
 class AddHBaseMetricsConfig(Migrate.Step):
     """ Set metrics reporting frequency to 15 secs. See ZEN-25317 """
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addSnmpV3UserCommand.py
+++ b/Products/ZenModel/migrate/addSnmpV3UserCommand.py
@@ -13,7 +13,7 @@ SNMPV3_COMMAND = ('snmpwalk -${device/zSnmpVer} -l authNoPriv -a ${device/zSnmpA
 
 class AddSnmpV3UserCommand(Migrate.Step):
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         if SNMPV3_ID not in [d.id for d in dmd.userCommands()]:

--- a/Products/ZenModel/migrate/addTagToImages.py
+++ b/Products/ZenModel/migrate/addTagToImages.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class AddTagToImages(Migrate.Step):
     "Add tag latest to all Images that do not have a tag"
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
+++ b/Products/ZenModel/migrate/addzCommandUserCommandTimeout.py
@@ -18,7 +18,7 @@ import Migrate
 
 class addzCommandUserCommandTimeout(Migrate.Step):
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         if not hasattr(dmd.Devices, 'zCommandUserCommandTimeout'):

--- a/Products/ZenModel/migrate/beakerHttpOnly.py
+++ b/Products/ZenModel/migrate/beakerHttpOnly.py
@@ -20,7 +20,7 @@ class BeakerHTTPOnly(Migrate.Step):
     Set beaker session.httponly to true in config
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/changeMemcachedStartup.py
+++ b/Products/ZenModel/migrate/changeMemcachedStartup.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 class ChangeMemcachedStartup(Migrate.Step):
     "Change memcached startup to respect config file and update config file"
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def _update_config(self, config):
         USER_RE = r'USER="\w+"'

--- a/Products/ZenModel/migrate/checkHBaseTablesExist.py
+++ b/Products/ZenModel/migrate/checkHBaseTablesExist.py
@@ -21,7 +21,7 @@ class CheckHBaseTablesExist(Migrate.Step):
     See ZEN-24094
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/disableZproxyAccessLog.py
+++ b/Products/ZenModel/migrate/disableZproxyAccessLog.py
@@ -20,7 +20,7 @@ sm.require("1.0.0")
 class DisableZproxyAccessLog(Migrate.Step):
     "Disable zproxy nginx access logging by default"
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/enableNginxPagespeed.py
+++ b/Products/ZenModel/migrate/enableNginxPagespeed.py
@@ -23,7 +23,7 @@ class EnableNginxPagespeed(Migrate.Step):
     Turn pagespeed in zproxy-nginx.conf
     '''
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/fixDefaultmappingSequences.py
+++ b/Products/ZenModel/migrate/fixDefaultmappingSequences.py
@@ -40,7 +40,7 @@ def resequence(items):
 
 class FixDefaultmappingSequences(Migrate.Step):
 
-    version = Migrate.Version(107,0,0)
+    version = Migrate.Version(108,0,0)
 
     def cutover(self, dmd):
         changed = 0

--- a/Products/ZenModel/migrate/fixMariadbHealthCheck.py
+++ b/Products/ZenModel/migrate/fixMariadbHealthCheck.py
@@ -22,7 +22,7 @@ class FixMariadbHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/fixZauthHealthCheck.py
+++ b/Products/ZenModel/migrate/fixZauthHealthCheck.py
@@ -22,7 +22,7 @@ class FixZauthHealthCheck(Migrate.Step):
     Use different curl request to prevent `authentication failed` spam in audit.log
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/moveProductionStateToBTree.py
+++ b/Products/ZenModel/migrate/moveProductionStateToBTree.py
@@ -28,7 +28,7 @@ MIGRATED_FLAG = "_migrated_prodstates"
 
 class MoveProductionStateToBTree(Migrate.Step):
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/removeEmptyGraphs.py
+++ b/Products/ZenModel/migrate/removeEmptyGraphs.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RemoveEmptyGraphs(Migrate.Step):
     """Remove some graph datapoints from a few services."""
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/removeRegionServerPrereqs.py
+++ b/Products/ZenModel/migrate/removeRegionServerPrereqs.py
@@ -19,7 +19,7 @@ sm.require("1.0.0")
 
 class RemoveRegionServerPrereqs(Migrate.Step):
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/retryZopeHealthCheck.py
+++ b/Products/ZenModel/migrate/retryZopeHealthCheck.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class RetryZopeHealthCheck(Migrate.Step):
     "Change 'answering' healthcheck to retry a few times on failture"
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/setMariaDbConfigDefaults.py
+++ b/Products/ZenModel/migrate/setMariaDbConfigDefaults.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 class SetMariaDbConfigDefaults(Migrate.Step):
     """Setting MariaDB buffer pool size default"""
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/updateHBaseLogPath.py
+++ b/Products/ZenModel/migrate/updateHBaseLogPath.py
@@ -22,7 +22,7 @@ class UpdateHBaseLogPath(Migrate.Step):
     See ZEN-23724
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateMariaDbPoolAllocations.py
+++ b/Products/ZenModel/migrate/updateMariaDbPoolAllocations.py
@@ -16,7 +16,7 @@ log = logging.getLogger("zen.migrate")
 sm.require("1.0.0")
 
 class UpdateMariaDBPoolAlloc(Migrate.Step):
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateMemcachedMaxObjectSize.py
+++ b/Products/ZenModel/migrate/updateMemcachedMaxObjectSize.py
@@ -20,7 +20,7 @@ class UpdateMemcachedMaxObjectSize(Migrate.Step):
     that memcached clients can send
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     OPTIONS_TEXT = '''{{ $size := (getContext . "global.conf.zodb-cache-max-object-size") }}
 OPTIONS="-v -R 4096 -I {{if $size}} {{$size}} {{else}} 1048576 {{end}}"'''

--- a/Products/ZenModel/migrate/updateMetricsHealthchecks.py
+++ b/Products/ZenModel/migrate/updateMetricsHealthchecks.py
@@ -18,7 +18,7 @@ sm.require("1.0.0")
 
 
 class UpdateMetricsHealthChecks(Migrate.Step):
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateOpenTSDBConfigRandomUIDEnable.py
+++ b/Products/ZenModel/migrate/updateOpenTSDBConfigRandomUIDEnable.py
@@ -27,7 +27,7 @@ class UpdateOpenTSDBConfigRandomUIDEnable(Migrate.Step):
         - If the paramter already exists then no change is made to the config file.
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         """ This method is called by the migration process and overrides the method

--- a/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
+++ b/Products/ZenModel/migrate/updateOpenTsdbCreateTables.py
@@ -22,7 +22,7 @@ class UpdateOpenTsdbCreateTables(Migrate.Step):
     See ZEN-22929
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateZepLogbackConfig.py
+++ b/Products/ZenModel/migrate/updateZepLogbackConfig.py
@@ -10,7 +10,7 @@ class UpdateZepLogbackConfig(Migrate.Step):
     """ 
     Removing zeneventserver metrics logging inside container.
     """
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     UPDATED_LOGBACK_CONFIG = """<?xml version="1.0" encoding="UTF-8"?>
 <!--

--- a/Products/ZenModel/migrate/updateZodbConfigFiles.py
+++ b/Products/ZenModel/migrate/updateZodbConfigFiles.py
@@ -24,7 +24,7 @@ class UpdateZodbConfigFiles(Migrate.Step):
     - For Zauth, we need to update the above files to be built from global.conf
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     ZODB_MAIN_CFG_CONTENT = """
     <mysql>

--- a/Products/ZenModel/migrate/updateZopeAnsweringHealthChecks.py
+++ b/Products/ZenModel/migrate/updateZopeAnsweringHealthChecks.py
@@ -23,7 +23,7 @@ class UpdateZopeAnsweringHealthChecks(Migrate.Step):
     healthcheck script
     """
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateZproxyPagespeedUpstreams.py
+++ b/Products/ZenModel/migrate/updateZproxyPagespeedUpstreams.py
@@ -190,7 +190,7 @@ http {
 
 class UpdateZproxyPagespeedUpstreams(Migrate.Step):
 
-    version = Migrate.Version(107, 0, 0)
+    version = Migrate.Version(108, 0, 0)
 
     config_file = "/opt/zenoss/zproxy/conf/zproxy-nginx.conf"
     save_file = "/opt/zenoss/var/ext/zproxy-nginx.conf.orig"


### PR DESCRIPTION
This one:
https://github.com/zenoss/zenoss-prodbin/blob/support/5.1.x/Products/ZenModel/migrate/removeEmptyGraphs.py
has switched 5.1.x dmd.version to 107, because of that a lot of 107 migrations from 5.2.x are not run during 5.1.x -> 5.2.1 upgrade and because of this we have an issue described in ZEN-26635.