### PR TITLE
ZEN-17882: check for existing OIDs when installing zenpack

### DIFF
--- a/Products/ZenRelations/ImportRM.py
+++ b/Products/ZenRelations/ImportRM.py
@@ -277,9 +277,13 @@ for a ZenPack.
         try:
             if id.startswith('/'):
                 obj = getObjByPath2(self.app, id)
+            # Checks whether this mib exists in our system
+            elif attrs.get('class') in ['MibNode', 'MibNotification']:
+                obj = self.dmd.getDmdRoot("Mibs").mibSearch(
+                    id=attrs.get('id'))[0].getObject()
             else:
                 obj = self.context()._getOb(id)
-        except (KeyError, AttributeError, NotFound):
+        except (KeyError, AttributeError, IndexError, NotFound):
             pass
 
         if obj is None:


### PR DESCRIPTION
When installing zenpack, it ignors what OIDs are already
in the system and just create duplicates in its MIBs modules.
When zenpack install  OIDs using object.xml check whether OID
is presented in the system, and if yes skip creating new OID.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-17882)