### PR TITLE
ZEN-26628: add hyperlink tag handling

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/Renderers.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Renderers.js
@@ -275,6 +275,9 @@ Ext.apply(Zenoss.render, {
         if (url && name) {
             return '<a class="z-entity" href="'+url+'">'+Ext.htmlEncode(name)+'</a>';
         }
+        if (url) {
+           return url;
+        }
     },
 
     default_uid_renderer: function(uid, name) {
@@ -477,6 +480,12 @@ Ext.apply(Zenoss.render, {
         }
         return Zenoss.render.link(null, url, name);
     },
+
+    HyperlinkTag : function(uid, name) {
+        //When we get hyperlink tag return it back
+        return Zenoss.render.link(null, uid, null);
+    },
+
     eventSummaryRow:function (data, metadata, record){
         var msg = record.data.message;
         if (!msg || msg === "None" ) {

--- a/Products/ZenUI3/browser/resources/js/zenoss/Types.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Types.js
@@ -10,7 +10,8 @@ var _tm = {
     'DeviceClass':      ["^/zport/dmd/Devices(/(?!devices)[^/]+)*/?$"],
     'EventClass':       ["^/zport/dmd/Events(/[A-Za-z][^/]*)*/?$"],
     'Network':          ["^/zport/dmd/Networks(/(?!ipaddresses)[^/]+)*/?$"],
-    'Process':          ["^/zport/dmd/Processes(.*)$"]
+    'Process':          ["^/zport/dmd/Processes(.*)$"],
+    'HyperlinkTag':     ["href=[\"\'](.*?)[\"\']"]
 };
 
 var T = Ext.ns('Zenoss.types');


### PR DESCRIPTION
The 'Links' for the device are broken.
Add hyperlink handling when we get hyperlink tag
of guest device from some main one.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-26628)