### PR TITLE
ZEN-26498 Component graph legends

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -948,10 +948,9 @@ class DeviceFacade(TreeFacade):
             return []
 
         if allOnSame:
-            # ZEN-26498 Identify Docker containers by name
-            if meta_type == 'DockerContainer':
-                for docker in components:
-                    docker.id = docker.name()
+            # ZEN-26498 identify by name to match individual charts
+            for comp in components:
+                comp.id = comp.name()
             return [MultiContextMetricServiceGraphDefinition(graphDef, components)]
 
         graphs = []


### PR DESCRIPTION
Also ZEN-22396. Get component graph legends to show same name regardless of "All on Same Graph" checkbox state.