### PR TITLE
ZEN-26758: set drange variable when graph is opened in the new tab

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -603,6 +603,9 @@
             if (graphPanel && Ext.isNumber(graphPanel.drange)) {
                 drange = graphPanel.drange;
             }
+            else if(graph.graph_params && Ext.isNumber(graph.graph_params.drange)) {
+                drange = graph.graph_params.drange;
+            }
 
             // create a new window that will later be
             // redirected to the graph url


### PR DESCRIPTION
Open graph in the new tab the zoom in/out/arrow buttons do not work.
If we cannot get drange from graphPanel take it from graph params.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-26758)