### PR TITLE
ZEN-26760: add autoScroll option to expandGraph window

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -450,6 +450,7 @@
             config.height = window.outerHeight * 0.75;
             config.width = Math.min(window.outerWidth * 0.80, config.height * 1.6180339887);
             config.maxWidth = 2000;
+            config.autoScroll = true;
             delete config.html;
 
             var win = Ext.create('Zenoss.dialog.BaseWindow', {


### PR DESCRIPTION
The legend can be quite large due to the volume of data
points and data point names being long so there is no way
to scroll down to graph.
Add autoScroll to config of the expandGraph window.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-26760)