### PR TITLE
Fix/ZEN-26671 - zenhub stats kill zenhubworker processes

### DIFF
--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -967,8 +967,7 @@ class ZenHub(ZCmdBase):
         self.log.debug("Starting %s", ' '.join(args))
         prot = WorkerRunningProtocol(self)
         proc = reactor.spawnProcess(prot, exe, args, os.environ)
-        spawn_time = time.time()
-        proc.spawn_time = spawn_time
+        proc.spawn_time = time.time()
         self.workerprocessmap[proc.pid] = proc
         self.worker_processes.add(prot)
 

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -487,6 +487,8 @@ class ZenHub(ZCmdBase):
             # ValueError: signal only works in main thread
             # Ignore it as we've already set up the signal handler.
             pass
+        # ZEN-26671 Wait at least this duration in secs before signaling a worker process
+        self.SIGUSR_TIMEOUT = 5
 
     def setKeepAlive(self, sock):
         import socket
@@ -502,9 +504,13 @@ class ZenHub(ZCmdBase):
         self._workerStats()
 
         # send SIGUSR2 signal to all workers
+        now = time.time()
         for worker in self.workerprocessmap.values():
             try:
-                worker.signalProcess(signal.SIGUSR2)
+                elapsed_since_spawn = now - worker.spawn_time
+                self.log.debug('{} secs elapsed since this worker proc was spawned'.format(elapsed_since_spawn))
+                if elapsed_since_spawn >= self.SIGUSR_TIMEOUT:
+                    worker.signalProcess(signal.SIGUSR2)
                 time.sleep(0.5)
             except Exception:
                 pass
@@ -939,9 +945,11 @@ class ZenHub(ZCmdBase):
 
             def processEnded(self, reason):
                 self.parent.worker_processes.discard(self)
-                self.parent.workerprocessmap.pop(self.pid, None)
-                self.log.warning("Worker (%d) exited with status: %d (%s)",
+                ended_proc = self.parent.workerprocessmap.pop(self.pid, None)
+                ended_proc_age = time.time() - ended_proc.spawn_time
+                self.log.warning("Worker (%d), age %f secs, exited with status: %d (%s)",
                                  self.pid,
+                                 ended_proc_age,
                                   reason.value.exitCode or -1,
                                   getExitMessage(reason.value.exitCode))
                 # if not shutting down, restart a new worker
@@ -959,6 +967,8 @@ class ZenHub(ZCmdBase):
         self.log.debug("Starting %s", ' '.join(args))
         prot = WorkerRunningProtocol(self)
         proc = reactor.spawnProcess(prot, exe, args, os.environ)
+        spawn_time = time.time()
+        proc.spawn_time = spawn_time
         self.workerprocessmap[proc.pid] = proc
         self.worker_processes.add(prot)
 

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -54,8 +54,8 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
     "Execute ZenHub requests in separate process"
 
     def __init__(self):
+        signal.signal(signal.SIGUSR2, signal.SIG_IGN)
         ZCmdBase.__init__(self)
-
         self.current = IDLE
         self.currentStart = 0
         self.numCalls = 0
@@ -93,7 +93,10 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
         pass
 
     def sighandler_USR2(self, *args):
-        self.reportStats()
+        try:
+            self.reportStats()
+        except:
+            pass
 
     def reportStats(self):
         now = time.time()


### PR DESCRIPTION
This adds hook for ZenHub to wait some amount of time before `kill -SIGUSR2` a new hubworker process. Zenhubworker instances are configured to ignore SIGUSR2 until its initialization is complete.