### PR TITLE
Feature/ZEN-26752 zenhub enhancements

### DIFF
--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -926,6 +926,7 @@ class ZenHub(ZCmdBase):
             workerfd.write("logseverity %s\n" % self.options.logseverity)
             workerfd.write("zodb-cachesize %s\n" % self.options.zodb_cachesize)
             workerfd.write("calllimit %s\n" % self.options.worker_call_limit)
+            workerfd.write("profiling %s\n" % self.options.profiling)
 
     def createWorker(self):
         """Start a worker subprocess

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -66,7 +66,7 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
         self.numCalls = 0
         try:
             self.log.debug("establishing SIGUSR1 signal handler")
-            signal.signal(signal.SIGUSR2, self.sighandler_USR1)
+            signal.signal(signal.SIGUSR1, self.sighandler_USR1)
             self.log.debug("establishing SIGUSR2 signal handler")
             signal.signal(signal.SIGUSR2, self.sighandler_USR2)
         except ValueError:

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -111,9 +111,9 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
                 svc = "%s/%s" % (svc[1], svc[0].rpartition('.')[-1])
                 for method,stats in sorted(svcob.callStats.items()):
                     loglines.append(" - %-48s %-32s %8d %12.2f %8.2f %s" %
-                                    (svc, method, 
-                                     stats.numoccurrences, 
-                                     stats.totaltime, 
+                                    (svc, method,
+                                     stats.numoccurrences,
+                                     stats.totaltime,
                                      stats.totaltime/stats.numoccurrences if stats.numoccurrences else 0.0,
                                      isoDateTime(stats.lasttime)))
             self.log.debug('\n'.join(loglines))
@@ -121,8 +121,8 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
             self.log.debug("no service activity statistics")
 
     def gotPerspective(self, perspective):
-        "Once we are connected to zenhub, register ourselves"
-        d = perspective.callRemote('reportingForWork', self)
+        """Once we are connected to zenhub, register ourselves"""
+        d = perspective.callRemote('reportingForWork', self, pid=self.pid)
         def reportProblem(why):
             self.log.error("Unable to report for work: %s", why)
             reactor.stop()

--- a/Products/ZenUtils/debugtools.py
+++ b/Products/ZenUtils/debugtools.py
@@ -97,7 +97,8 @@ class ContinuousProfiler(object):
             stats_filename = filename
         else:
             datetime_stamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
-            stats_filename = "{}-{}{}.profile".format(datetime_stamp, os.getpid(), self.process_identifier)
+            stats_filename = "{}-{}{}.pstats".format(datetime_stamp, os.getpid(), 
+                                                     '-'+self.process_identifier if self.process_identifier else '')
 
         if tmpdir is not None:
             stats_filepath = os.path.join(tmpdir, stats_filename)

--- a/Products/ZenUtils/tests/testContinuousProfiler.py
+++ b/Products/ZenUtils/tests/testContinuousProfiler.py
@@ -1,0 +1,67 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from unittest import makeSuite
+from Products.ZenUtils.debugtools import ContinuousProfiler
+import os
+import random
+
+class TestContinuousProfiler(BaseTestCase):
+    """
+    Tests the functionality of the ContinuousProfiler class
+    """
+
+    def helper(self, profiler, dump_stats_args):
+        self.assertEqual(profiler.isRunning, False)
+
+        profiler.start()
+        self.assertEqual(profiler.isRunning, True)
+
+        sysRand = random.SystemRandom()
+        [i * sysRand.random() for i in range(100)]
+
+        filename, tmpdir = dump_stats_args
+        pstats_filepath = profiler.dump_stats(filename, tmpdir)
+        self.assertEqual(os.path.isfile(pstats_filepath), True)
+        if filename is not None:
+            if tmpdir is None:
+                tmpdir = '/tmp'
+            self.assertEqual(pstats_filepath, os.path.join(tmpdir, filename))
+
+        profiler.stop()
+        self.assertEqual(profiler.isRunning, False)
+
+    def testContinuousProfiling(self):
+        p1 = ContinuousProfiler()
+        self.helper(p1, (None, None))
+
+    def testContinuousProfilingWithProcessIdentifer(self):
+        p2 = ContinuousProfiler(process_identifier='TestContinuousProfiler')
+        self.helper(p2, (None, None))
+
+    def testContinuousProfilingWithFilename(self):
+        p3 = ContinuousProfiler()
+        self.helper(p3, ('TestContinuousProfiler', None))
+
+    def testContinuousProfilingWithFilenameAndDirectory(self):
+        p4 = ContinuousProfiler()
+        self.helper(p4, ('TestContinuousProfiler', '/tmp'))
+
+    def testContinuousProfilingWithLogging(self):
+        import logging
+        log = logging.getLogger('zen.testContinuousProfiler')
+        p5 = ContinuousProfiler(log=log)
+        self.helper(p5, (None, None))
+
+def test_suite():
+    return makeSuite(TestContinuousProfiler)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
This PR adds more process info and the ability to run ZenHub and its zenhubworkers with profiling on.

To run zenhub with profiling on, add this line below to zenhub.conf
```profiling True```
To get current profile data from the profiler, attach to the zenhub container and the run the following:
```zenhub debug```

If profiling is turned on for zenhub, each invocation of the `zenhub debug` command will cause zenhub and the currently running zenhubworker to dump their individual profile stats to files within the standard OS temporary directory (most likely `/tmp`). Initially, zenhubworkers will inherit their profiling config from their hub, but you can drop into the container and turn profiling for the hubworker if you like. Debug statement are logged each time stats are dumped with the location of the stats that just created.