### PR TITLE
Add dev and comp ids in log msg when data source expression is invalid

### DIFF
--- a/Products/ZenModel/MinMaxThreshold.py
+++ b/Products/ZenModel/MinMaxThreshold.py
@@ -135,8 +135,14 @@ class MinMaxThreshold(ThresholdClass):
                 evaluated = talesEval(express, context)
                 value = evaluated
             except:
+                nodeName = context.getNodeName()
+                if nodeName == 'Device':
+                    location = '{} of Device {}'.format(self.dsnames, context.id)
+                else:
+                    location = '{} of {} {} in Device {}'.format(self.dsnames, nodeName, context.id, context.device().id)
+
                 msg= "User-supplied Python expression (%s) for %s caused error: %s" % (
-                           value, readablePropName, self.dsnames)
+                           value, readablePropName, location)
                 log.error(msg)
                 raise pythonThresholdException(msg)
                 value = None


### PR DESCRIPTION
Before:
2017-02-27 18:48:23,287 ERROR zen.MinMaxCheck: User-supplied Python expression (here.BAD) for minimum value caused error: ['laLoadInt5_laLoadInt5']

After:
2017-02-27 20:35:52,306 ERROR zen.MinMaxCheck: User-supplied Python expression (here.BAD) for minimum value caused error: ['usedBlocks_usedBlocks'] of FileSystem testFS in Device 10.87.128.92