### PR TITLE
ZEN-26606: do not call device() on components more than needed

### DIFF
--- a/Products/ZenModel/MetricMixin.py
+++ b/Products/ZenModel/MetricMixin.py
@@ -180,24 +180,27 @@ class MetricMixin(object):
         """
         return json.dumps(self.getMetricMetadata(), sort_keys=True)
 
-    def getResourceKey(self):
+    def getResourceKey(self, d=None):
         """
         Formerly RRDView.GetRRDPath, this value is still used as the key for the
         device or component in OpenTSDB.
         """
-        d = self.device()
+        if d is None:
+            d = self.device()
         if not d:
             return "Devices/" + self.id
         skip = len(d.getPrimaryPath()) - 1
         return 'Devices/' + '/'.join(self.getPrimaryPath()[skip:])
 
-    def getMetricMetadata(self):
+    def getMetricMetadata(self, dev=None):
+        if dev is None:
+            dev = self.device()
         return {
                 'type': 'METRIC_DATA',
-                'contextKey': self.getResourceKey(),
-                'deviceId': self.device().id,
+                'contextKey': self.getResourceKey(dev),
+                'deviceId': dev.id,
                 'contextId': self.id,
-                'deviceUUID': self.device().getUUID(),
+                'deviceUUID': dev.getUUID(),
                 'contextUUID': self.getUUID()
                 }
 

--- a/Products/ZenModel/RRDDataSource.py
+++ b/Products/ZenModel/RRDDataSource.py
@@ -174,7 +174,7 @@ class RRDDataSource(ZenModelRM, ZenPackable):
         return newGps
 
 
-    def getCommand(self, context, cmd=None):
+    def getCommand(self, context, cmd=None, device=None):
         """Return localized command target.
         """
         # Perform a TALES eval on the expression using self
@@ -183,7 +183,7 @@ class RRDDataSource(ZenModelRM, ZenPackable):
         if not cmd.startswith('string:') and not cmd.startswith('python:'):
             cmd = 'string:%s' % cmd
         compiled = talesCompile(cmd)
-        d = context.device()
+        d = device if device is not None else context.device()
         environ = {'dev' : d,
                    'device': d,
                    'devname': d.id,
@@ -201,7 +201,7 @@ class RRDDataSource(ZenModelRM, ZenPackable):
         return res
         
 
-    def getComponent(self, context, component=None):
+    def getComponent(self, context, component=None, device=None):
         """Return localized component.
         """
         if component is None:
@@ -210,7 +210,7 @@ class RRDDataSource(ZenModelRM, ZenPackable):
                 not component.startswith('python:'):
             component = 'string:%s' % component
         compiled = talesCompile(component)
-        d = context.device()
+        d = device if device is not None else context.device()
         environ = {'dev' : d,
                    'device': d,
                    'devname': d.id,


### PR DESCRIPTION
To measure the performance improvement, the following code was run in the 5.2 environment ZEN-26606 was reported (with Impact) and an aws 5.3 system:

```
devices = [ "10.88.111.101", "10.88.111.102", "10.88.111.112", "10.88.111.113", "10.88.111.114", "10.88.111.115", "10.88.111.116", "10.88.111.130", "10.88.111.131", "10.88.111.132", "10.88.111.133", "10.88.111.134", "10.88.111.135", "10.88.111.136", "10.88.111.137", "10.88.111.138", "10.88.111.145", "10.88.111.150", "10.88.111.16", "10.88.111.17", "10.88.111.18", "10.88.111.180", "10.88.111.181", "10.88.111.184", "10.88.111.185", "10.88.111.187", "10.88.111.24", "10.88.111.49", "10.88.111.60", "10.88.111.61", "10.88.111.70", "10.88.111.71", "10.88.111.75", "10.88.111.77", "10.88.111.78" ]


from Products.ZenHub.services.CommandPerformanceConfig import CommandPerformanceConfig
import time
total = 0
svc = CommandPerformanceConfig(dmd, "localhost")
for d_name in devices:
    d = find(d_name)
    if d:
        start = time.time()
        config = svc._createDeviceProxy(d)
        duration = time.time()-start
        total += duration
        print "{} took {} seconds".format(d.id, duration)
    else:
        print "{} not found".format(d_name)
print "TOTAL {}seconds".format(total)
```
The results before and after this fix are shown below:

![config_results](https://cloud.githubusercontent.com/assets/3450781/23380360/122d5120-fd00-11e6-8e8b-b62b681b8690.png)
