### PR TITLE
Fix ZEN-26637: raise log level message for start of model run, log if no collection happened

### DIFF
--- a/Products/DataCollector/zenmodeler.py
+++ b/Products/DataCollector/zenmodeler.py
@@ -113,8 +113,6 @@ class ZenModeler(PBDaemon):
         self.devicegen = None
         self.counters = collections.Counter()
         self.configFilter = None
-        # ZEN-26637 - did we collect during collector loop?
-        self.didCollect = False
 
         # Make sendEvent() available to plugins
         zope.component.provideUtility(self, IEventService)
@@ -1115,6 +1113,7 @@ class ZenModeler(PBDaemon):
         if self.clients:
             self.log.error("Modeling cycle taking too long")
             return
+        # ZEN-26637 - did we collect during collector loop?
         self.didCollect = False
         self.start = time.time()
 


### PR DESCRIPTION
I did the following to provide more accurate timing info for modeling runs

  - add flag to check whether any devices were processed during
`ZenModeler` collector loop
  - raise level of log message denoting start of collector loop for
proper modeling run timings