### PR TITLE
5.2.x port of feature/ZEN-26752 zenhub enhancements (#2073)

### DIFF
--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -32,6 +32,8 @@ import time
 import signal
 import os
 
+from Products.ZenUtils.debugtools import ContinuousProfiler
+
 IDLE = "None/None"
 class _CumulativeWorkerStats(object):
     """
@@ -54,12 +56,17 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
     "Execute ZenHub requests in separate process"
 
     def __init__(self):
+        signal.signal(signal.SIGUSR2, signal.SIG_IGN)
         ZCmdBase.__init__(self)
-
+        if self.options.profiling:
+            self.profiler = ContinuousProfiler('zenhubworker', log=self.log)
+            self.profiler.start()
         self.current = IDLE
         self.currentStart = 0
         self.numCalls = 0
         try:
+            self.log.debug("establishing SIGUSR1 signal handler")
+            signal.signal(signal.SIGUSR1, self.sighandler_USR1)
             self.log.debug("establishing SIGUSR2 signal handler")
             signal.signal(signal.SIGUSR2, self.sighandler_USR2)
         except ValueError:
@@ -92,8 +99,19 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
         """
         pass
 
+    def sighandler_USR1(self, *args):
+        try:
+            if self.options.profiling:
+                self.profiler.dump_stats()
+            super(zenhubworker, self).sighandler_USR1(signum, frame)
+        except:
+            pass
+
     def sighandler_USR2(self, *args):
-        self.reportStats()
+        try:
+            self.reportStats()
+        except:
+            pass
 
     def reportStats(self):
         now = time.time()
@@ -108,9 +126,9 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
                 svc = "%s/%s" % (svc[1], svc[0].rpartition('.')[-1])
                 for method,stats in sorted(svcob.callStats.items()):
                     loglines.append(" - %-48s %-32s %8d %12.2f %8.2f %s" %
-                                    (svc, method, 
-                                     stats.numoccurrences, 
-                                     stats.totaltime, 
+                                    (svc, method,
+                                     stats.numoccurrences,
+                                     stats.totaltime,
                                      stats.totaltime/stats.numoccurrences if stats.numoccurrences else 0.0,
                                      isoDateTime(stats.lasttime)))
             self.log.debug('\n'.join(loglines))
@@ -118,8 +136,8 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
             self.log.debug("no service activity statistics")
 
     def gotPerspective(self, perspective):
-        "Once we are connected to zenhub, register ourselves"
-        d = perspective.callRemote('reportingForWork', self)
+        """Once we are connected to zenhub, register ourselves"""
+        d = perspective.callRemote('reportingForWork', self, pid=self.pid)
         def reportProblem(why):
             self.log.error("Unable to report for work: %s", why)
             reactor.stop()
@@ -231,6 +249,8 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
         self.log.info("Shutting down")
         self.reportStats()
         self.log.info("Stopping reactor")
+        if self.options.profiling:
+            self.profiler.stop()
         try:
             reactor.stop()
         except error.ReactorNotRunning:
@@ -263,6 +283,9 @@ class zenhubworker(ZCmdBase, pb.Referenceable):
                                type='int',
                                help="Maximum number of remote calls before restarting worker",
                                default=200)
+        self.parser.add_option('--profiling', dest='profiling',
+                               action='store_true', default=False,
+                               help="Run with profiling on")
 
 if __name__ == '__main__':
     zhw = zenhubworker()

--- a/Products/ZenUtils/debugtools.py
+++ b/Products/ZenUtils/debugtools.py
@@ -11,6 +11,8 @@
 import cProfile
 import pstats
 import tempfile
+import os
+import time
 
 class Profiler(object):
 
@@ -65,3 +67,45 @@ def rpdb_set_trace(log=None):
     debugger = rpdb.Rpdb(ip, port)
     debugger.set_trace()
 
+class ContinuousProfiler(object):
+    def __init__(self, process_identifier='', log=None):
+        self.__profile = cProfile.Profile()
+        self.__isRunning = False
+        self.process_identifier=process_identifier
+        self.log = log
+
+    @property
+    def isRunning(self):
+        return self.__isRunning
+
+    def start(self):
+        if not self.__isRunning:
+            self.__profile.enable()
+            self.__isRunning = True
+            if self.log:
+                self.log.debug("Profiling started")
+
+    def stop(self):
+        if self.__isRunning:
+            self.__profile.disable()
+            self.__isRunning = False
+            if self.log:
+                self.log.debug("Profiling stopped")
+
+    def dump_stats(self, filename=None, tmpdir=None):
+        if filename is not None:
+            stats_filename = filename
+        else:
+            datetime_stamp = time.strftime("%Y-%m-%d-%H-%M-%S", time.gmtime())
+            stats_filename = "{}-{}{}.pstats".format(datetime_stamp, os.getpid(), 
+                                                     '-'+self.process_identifier if self.process_identifier else '')
+
+        if tmpdir is not None:
+            stats_filepath = os.path.join(tmpdir, stats_filename)
+        else:
+            stats_filepath = os.path.join(tempfile.gettempdir(), stats_filename)
+
+        self.__profile.dump_stats(stats_filepath)
+        if self.log:
+            self.log.debug("pStats file created at {}".format(stats_filepath))
+        return stats_filepath

--- a/Products/ZenUtils/tests/testContinuousProfiler.py
+++ b/Products/ZenUtils/tests/testContinuousProfiler.py
@@ -1,0 +1,67 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from unittest import makeSuite
+from Products.ZenUtils.debugtools import ContinuousProfiler
+import os
+import random
+
+class TestContinuousProfiler(BaseTestCase):
+    """
+    Tests the functionality of the ContinuousProfiler class
+    """
+
+    def helper(self, profiler, dump_stats_args):
+        self.assertEqual(profiler.isRunning, False)
+
+        profiler.start()
+        self.assertEqual(profiler.isRunning, True)
+
+        sysRand = random.SystemRandom()
+        [i * sysRand.random() for i in range(100)]
+
+        filename, tmpdir = dump_stats_args
+        pstats_filepath = profiler.dump_stats(filename, tmpdir)
+        self.assertEqual(os.path.isfile(pstats_filepath), True)
+        if filename is not None:
+            if tmpdir is None:
+                tmpdir = '/tmp'
+            self.assertEqual(pstats_filepath, os.path.join(tmpdir, filename))
+
+        profiler.stop()
+        self.assertEqual(profiler.isRunning, False)
+
+    def testContinuousProfiling(self):
+        p1 = ContinuousProfiler()
+        self.helper(p1, (None, None))
+
+    def testContinuousProfilingWithProcessIdentifer(self):
+        p2 = ContinuousProfiler(process_identifier='TestContinuousProfiler')
+        self.helper(p2, (None, None))
+
+    def testContinuousProfilingWithFilename(self):
+        p3 = ContinuousProfiler()
+        self.helper(p3, ('TestContinuousProfiler', None))
+
+    def testContinuousProfilingWithFilenameAndDirectory(self):
+        p4 = ContinuousProfiler()
+        self.helper(p4, ('TestContinuousProfiler', '/tmp'))
+
+    def testContinuousProfilingWithLogging(self):
+        import logging
+        log = logging.getLogger('zen.testContinuousProfiler')
+        p5 = ContinuousProfiler(log=log)
+        self.helper(p5, (None, None))
+
+def test_suite():
+    return makeSuite(TestContinuousProfiler)
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
* add the zenhubworker PID to zenhub stats output

- zenhubworker will report its PID when reportingForWork
- zenhub will output the PID for each worker along with its stats
- zenhub will warn when a worker's status doesn't match its stats
- This is change is intended to provide more info when debugging
zenhub activity

* added class+tests for continuous profiling

* add zenhub config option to run with profiler on

* add cmd config option for profiling zenhubworkers

* fix typo that would've coused incorrect signal handler registration