### PR TITLE
ZEN-26741 All on Same Graph Legends

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -954,6 +954,9 @@ class DeviceFacade(TreeFacade):
             return []
 
         if allOnSame:
+            # ZEN-26741 identify by name to match individual charts
+            for comp in components:
+                comp.id = comp.name()
             return [MultiContextMetricServiceGraphDefinition(graphDef, components)]
 
         graphs = []


### PR DESCRIPTION
Identify metrics in all-in-same-graph graph by the same name when in individual charts.