### PR TITLE
ZEN-26894 fix production state sort error

### DIFF
--- a/Products/ZenWidgets/browser/Portlets.py
+++ b/Products/ZenWidgets/browser/Portlets.py
@@ -19,7 +19,7 @@ from Products.Zuul import getFacade
 from Products.ZenEvents.HeartbeatUtils import getHeartbeatObjects
 from zenoss.protocols.services import ServiceException
 from zenoss.protocols.services.zep import ZepConnectionError
-from Products.ZenUtils.guid.interfaces import IGUIDManager
+from Products.ZenUtils.guid.interfaces import IGUIDManager, IGlobalIdentifier
 from Products.ZenUtils.productionstate.interfaces import IProdStateManager
 from Products.ZenUtils.jsonutils import json
 from Products.ZenUtils.Utils import nocache, formreq, extractPostContent
@@ -105,7 +105,7 @@ class ProductionStatePortletView(BrowserView):
         objects = catalog.evalAdvancedQuery(query, ((orderby, orderdir),))
 
         psManager = IProdStateManager(self.context)
-        results = (x for x in objects if psManager.getProductionStateFromGUID(x.uuid) in numericProdStates)
+        results = (x for x in objects if psManager.getProductionStateFromGUID(IGlobalIdentifier(x).getGUID()) in numericProdStates)
         devs = (x.getObject() for x in results)
         mydict = {'columns':['Device', 'Prod State'], 'data':[]}
         for dev in devs:

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -247,7 +247,6 @@ class TreeFacade(ZuulFacade):
                     prodStateBuckets[ps] = []
 
                 for brain in psFilteredbrains:
-                    import pdb; pdb.set_trace()
                     prodState = psManager.getProductionStateFromGUID(IGlobalIdentifier(brain).getGUID())
                     prodStateBuckets[prodState].append(brain)
 

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -198,7 +198,7 @@ class TreeFacade(ZuulFacade):
 
         if sort == "productionState":
             useProdStates = True
-            orderby = None
+            orderby = 'name'
             startp = 0
             limitp = None
 
@@ -207,7 +207,6 @@ class TreeFacade(ZuulFacade):
             useProdStates = True
             startp = 0
             limitp = None
-
 
         catbrains = cat.search(
                 'Products.ZenModel.Device.Device', start=startp,
@@ -219,7 +218,7 @@ class TreeFacade(ZuulFacade):
             psManager = IProdStateManager(self._dmd)
             # Filter by production state
             if prodStates:
-                psFilteredbrains = [brain for brain in catbrains if psManager.getProductionStateFromGUID(brain.uuid) in prodStates]
+                psFilteredbrains = [brain for brain in catbrains if psManager.getProductionStateFromGUID(brain.getUUID()) in prodStates]
                 totalCount = len(psFilteredbrains)
                 hash_ = str(totalCount)
 
@@ -246,13 +245,13 @@ class TreeFacade(ZuulFacade):
                     prodStateBuckets[ps] = []
 
                 for brain in psFilteredbrains:
-                    prodState = psManager.getProductionStateFromGUID(brain.uuid)
+                    import pdb; pdb.set_trace()
+                    prodState = psManager.getProductionStateFromGUID(brain.getUUID())
                     prodStateBuckets[prodState].append(brain)
 
                 sortedBrains = (brain for brain in mergeBuckets(productionStates, prodStateBuckets))
             else:
                 sortedBrains = psFilteredbrains
-
 
             # Pick out the correct range and build the SearchResults object
             start = max(start, 0)

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -29,6 +29,8 @@ from zope.interface import implements
 from Products.ZenModel.DeviceOrganizer import DeviceOrganizer
 from Products.ZenModel.ComponentOrganizer import ComponentOrganizer
 from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, Generic
+
+from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
 from Products.Zuul.interfaces import IFacade, ITreeNode
 from Products.Zuul.interfaces import (
     ITreeFacade, IInfo, ICatalogTool, IOrganizerInfo
@@ -218,7 +220,7 @@ class TreeFacade(ZuulFacade):
             psManager = IProdStateManager(self._dmd)
             # Filter by production state
             if prodStates:
-                psFilteredbrains = [brain for brain in catbrains if psManager.getProductionStateFromGUID(brain.getUUID()) in prodStates]
+                psFilteredbrains = [brain for brain in catbrains if psManager.getProductionStateFromGUID(IGlobalIdentifier(brain).getGUID()) in prodStates]
                 totalCount = len(psFilteredbrains)
                 hash_ = str(totalCount)
 
@@ -246,7 +248,7 @@ class TreeFacade(ZuulFacade):
 
                 for brain in psFilteredbrains:
                     import pdb; pdb.set_trace()
-                    prodState = psManager.getProductionStateFromGUID(brain.getUUID())
+                    prodState = psManager.getProductionStateFromGUID(IGlobalIdentifier(brain).getGUID())
                     prodStateBuckets[prodState].append(brain)
 
                 sortedBrains = (brain for brain in mergeBuckets(productionStates, prodStateBuckets))

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -29,7 +29,6 @@ from zope.interface import implements
 from Products.ZenModel.DeviceOrganizer import DeviceOrganizer
 from Products.ZenModel.ComponentOrganizer import ComponentOrganizer
 from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, Generic
-
 from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
 from Products.Zuul.interfaces import IFacade, ITreeNode
 from Products.Zuul.interfaces import (
@@ -220,7 +219,7 @@ class TreeFacade(ZuulFacade):
             psManager = IProdStateManager(self._dmd)
             # Filter by production state
             if prodStates:
-                psFilteredbrains = [brain for brain in catbrains if psManager.getProductionStateFromGUID(IGlobalIdentifier(brain).getGUID()) in prodStates]
+                psFilteredbrains = [b for b in catbrains if psManager.getProductionStateFromGUID(IGlobalIdentifier(b).getGUID()) in prodStates]
                 totalCount = len(psFilteredbrains)
                 hash_ = str(totalCount)
 
@@ -246,9 +245,9 @@ class TreeFacade(ZuulFacade):
                 for ps in productionStates:
                     prodStateBuckets[ps] = []
 
-                for brain in psFilteredbrains:
-                    prodState = psManager.getProductionStateFromGUID(IGlobalIdentifier(brain).getGUID())
-                    prodStateBuckets[prodState].append(brain)
+                for b in psFilteredbrains:
+                    prodState = psManager.getProductionStateFromGUID(IGlobalIdentifier(b).getGUID())
+                    prodStateBuckets[prodState].append(b)
 
                 sortedBrains = (brain for brain in mergeBuckets(productionStates, prodStateBuckets))
             else:

--- a/Products/Zuul/tests/test_devicefacade.py
+++ b/Products/Zuul/tests/test_devicefacade.py
@@ -151,11 +151,11 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
 
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(productionState=[400]))
         self.assertEquals(1, results.total)
-        self.assertEquals(iter(results).next().getProductionState(), 400)
+        self.assertEquals(iter(results).next().getObject().getProductionState(), 400)
 
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(productionState=[1000]))
         self.assertEquals(1, results.total)
-        self.assertEquals(iter(results).next().getProductionState(), 1000)
+        self.assertEquals(iter(results).next().getObject().getProductionState(), 1000)
 
     def test_deviceSortByProdState(self):
         devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
@@ -166,15 +166,15 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState')
         resultIter = iter(results)
         self.assertEquals(2, results.total)
-        self.assertEquals(resultIter.next().getProductionState(), 400)
-        self.assertEquals(resultIter.next().getProductionState(), 1000)
+        self.assertEquals(resultIter.next().getObject().getProductionState(), 400)
+        self.assertEquals(resultIter.next().getObject().getProductionState(), 1000)
 
         # descending order
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', dir='DESC')
         resultIter = iter(results)
         self.assertEquals(2, results.total)
-        self.assertEquals(resultIter.next().getProductionState(), 1000)
-        self.assertEquals(resultIter.next().getProductionState(), 400)
+        self.assertEquals(resultIter.next().getObject().getProductionState(), 1000)
+        self.assertEquals(resultIter.next().getObject().getProductionState(), 400)
 
     def test_deviceSearchByProdStateAndLocationReturnsCorrectDevices(self):
         manage_addLocation(self.dmd.Locations, "test1")
@@ -195,14 +195,14 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(productionState=[400], location="test1"))
         self.assertEquals(1, results.total)
         device = iter(results).next()
-        self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), "test1")
+        self.assertEquals(device.getObject().getProductionState(), 400)
+        self.assertEquals(device.getObject().location.getRelatedId(), "test1")
 
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(productionState=[1000], location="test1"))
         self.assertEquals(1, results.total)
         device = iter(results).next()
-        self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), "test1")
+        self.assertEquals(device.getObject().getProductionState(), 1000)
+        self.assertEquals(device.getObject().location.getRelatedId(), "test1")
 
     def test_deviceSortByProdStateWithLocationFilterReturnsCorrectDevicesAndSortsCorrectly(self):
         manage_addLocation(self.dmd.Locations, "test1")
@@ -226,22 +226,22 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getObject().getProductionState(), 400)
+        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
         device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getObject().getProductionState(), 1000)
+        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
 
         # test sort in descending order with location filter
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', dir='DESC', params=dict(location="test1"))
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getObject().getProductionState(), 1000)
+        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
         device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getObject().getProductionState(), 400)
+        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
 
     def test_setProductionState(self):
         dev = self.dmd.Devices.createInstance('dev')

--- a/Products/Zuul/tests/test_devicefacade.py
+++ b/Products/Zuul/tests/test_devicefacade.py
@@ -177,120 +177,80 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
     def test_deviceSortByNonIndexedFieldWithProdStateFilterReturnsCorrectDevices(self):
         # This test specifically verifies the fix for ZEN-26901 sorting by a non-indexed
         # field while filtering on productionState caused a ProdStateNotSetError.
-        manage_addLocation(self.dmd.Locations, "test1")
-        manage_addLocation(self.dmd.Locations, "test2")
-
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setLocation("/test1")
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setLocation("/test1")
-        devProduction.setProdState(1000)
-
-        # this device should never be returned
-        devOther = self.dmd.Devices.createInstance('devOther')
-        devOther.setLocation("/test2")
-        devOther.setProdState(300)
-
-        # sort by location (non-indexed) with productionState filter
-        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='location', params=dict(productionState=[400, 1000]))
-        resultIter = iter(results)
-        self.assertEquals(2, results.total)
-        device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
-        device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
-
-    def test_deviceSortByIndexedFieldWithProdStateFilterReturnsCorrectDevices(self):
-        manage_addLocation(self.dmd.Locations, "test1")
-        manage_addLocation(self.dmd.Locations, "test2")
-
         devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
         devMaintenance.setPerformanceMonitor('localhost')
-        devMaintenance.setLocation("/test1")
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setLocation("/test1")
-        devProduction.setProdState(1000)
-
-        # this device should never be returned
-        devOther = self.dmd.Devices.createInstance('devOther')
-        devOther.setLocation("/test2")
-        devOther.setProdState(300)
-
-        # sort by collector (indexed) with productionState filter
-        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='collector', params=dict(productionState=[400, 1000]))
-        resultIter = iter(results)
-        self.assertEquals(2, results.total)
-        device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
-        device = resultIter.next()
-        self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
-
-    def test_deviceSortByProdStateWithIndexedFieldFilterReturnsCorrectDevices(self):
-        # This test specifically verifies the fix for ZEN-26901 sorting productionState
-        # while filtering on an indexed field caused a ProdStateNotSetError.
-        manage_addLocation(self.dmd.Locations, "test1")
-
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setPerformanceMonitor('localhost')
-        devMaintenance.setLocation("/test1")
         devMaintenance.setProdState(400)
 
         devProduction = self.dmd.Devices.createInstance('devProduction')
         devProduction.setPerformanceMonitor('localhost')
-        devProduction.setLocation("/test1")
         devProduction.setProdState(1000)
 
-        # this device should never be returned
-        devOther = self.dmd.Devices.createInstance('devOther')
-        devOther.setLocation("/test2")
-        devOther.setProdState(300)
-
-        # sort by productionState with collector (indexed) filter
-        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort="productionState", params=dict(collector="l"))
+        # sort by collector (non-indexed) with productionState filter
+        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='collector', params=dict(productionState=[400, 1000]))
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         device = resultIter.next()
         self.assertEquals(device.getProductionState(), 400)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getPerformanceServer().id, 'localhost')
         device = resultIter.next()
         self.assertEquals(device.getProductionState(), 1000)
-        self.assertEquals(device.location.getRelatedId(), 'test1')
+        self.assertEquals(device.getPerformanceServer().id, 'localhost')
 
-    def test_deviceSortByProdStateWithNonIndexedFieldFilterReturnsCorrectDevices(self):
-        manage_addLocation(self.dmd.Locations, "test1")
-        manage_addLocation(self.dmd.Locations, "test2")
-
+    def test_deviceSortByIndexedFieldWithProdStateFilterReturnsCorrectDevices(self):
         devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setLocation("/test1")
         devMaintenance.setProdState(400)
 
         devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setLocation("/test1")
         devProduction.setProdState(1000)
 
-        # this device should never be returned
-        devOther = self.dmd.Devices.createInstance('devOther')
-        devOther.setLocation("/test2")
-        devOther.setProdState(300)
-
-        # sort by productionState with location (non-indexed) filter
-        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', params=dict(location="test1"))
+        # sort by name (indexed) with productionState filter
+        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='name', params=dict(productionState=[400, 1000]))
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         device = resultIter.next()
         self.assertEquals(device.getObject().getProductionState(), 400)
-        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
         device = resultIter.next()
         self.assertEquals(device.getObject().getProductionState(), 1000)
-        self.assertEquals(device.getObject().location.getRelatedId(), 'test1')
+
+    def test_deviceSortByProdStateWithIndexedFieldFilterReturnsCorrectDevices(self):
+        # This test specifically verifies the fix for ZEN-26901 sorting productionState
+        # while filtering on an indexed field caused a ProdStateNotSetError.
+        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
+        devMaintenance.setProdState(400)
+
+        devProduction = self.dmd.Devices.createInstance('devProduction')
+        devProduction.setProdState(1000)
+
+        # sort by productionState with name (indexed) filter
+        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort="productionState", params=dict(name="dev"))
+        resultIter = iter(results)
+        self.assertEquals(2, results.total)
+        device = resultIter.next()
+        self.assertEquals(device.getObject().getProductionState(), 400)
+        self.assertEquals(device.getObject().getDeviceName(), 'devMaintenance')
+        device = resultIter.next()
+        self.assertEquals(device.getObject().getProductionState(), 1000)
+        self.assertEquals(device.getObject().getDeviceName(), 'devProduction')
+
+    def test_deviceSortByProdStateWithNonIndexedFieldFilterReturnsCorrectDevices(self):
+        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
+        devMaintenance.setPerformanceMonitor("localhost")
+        devMaintenance.setProdState(400)
+
+        devProduction = self.dmd.Devices.createInstance('devProduction')
+        devProduction.setPerformanceMonitor("localhost")
+        devProduction.setProdState(1000)
+
+        # sort by productionState with collector (non-indexed) filter
+        results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', params=dict(collector="local"))
+        resultIter = iter(results)
+        self.assertEquals(2, results.total)
+        device = resultIter.next()
+        self.assertEquals(device.getProductionState(), 400)
+        self.assertEquals(device.getPerformanceServer().id, 'localhost')
+        device = resultIter.next()
+        self.assertEquals(device.getProductionState(), 1000)
+        self.assertEquals(device.getPerformanceServer().id, 'localhost')
 
     def test_setProductionState(self):
         dev = self.dmd.Devices.createInstance('dev')


### PR DESCRIPTION
In the unit tests for this set of fixes:
* `collector` is used as a non-indexed field
* `name` is used as an index field