### PR TITLE
Adds explicit description of snmp decode failure

### DIFF
--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -2,6 +2,8 @@ from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from mock import patch
 from Products.ZenEvents.zentrap import TrapTask
 
+from struct import pack
+
 
 class TrapTaskUnitTest(BaseTestCase):
 
@@ -27,14 +29,16 @@ class TrapTaskUnitTest(BaseTestCase):
             u'valid utf8 string \xe9'.decode('utf8')
         )
 
-    '''
     @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
     def test_convert_value_decodes_datetime(self, mock_traptask_init):
         mock_traptask_init.return_value = None
         trap_task = TrapTask()
 
-        self.assertTrue(False, "implement test")
-    '''
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            trap_task._convert_value(value),
+            '2017-12-20T11:50:50.800+06:05'
+        )
 
     @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
     def test_convert_value_handles_invalid_chars(self, mock_traptask_init):

--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -48,7 +48,7 @@ class TrapTaskUnitTest(BaseTestCase):
         value = '\xde\xad\xbe\xef\xfe\xed\xfa\xce'
         self.assertEqual(
             trap_task._convert_value(value),
-            'Failed to decode: converted to BASE64:"3q2+7/7t+s4="'
+            'BASE64:3q2+7/7t+s4='
         )
 
 

--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -1,0 +1,55 @@
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from mock import patch
+from Products.ZenEvents.zentrap import TrapTask
+
+
+class TrapTaskUnitTest(BaseTestCase):
+
+    @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
+    def test_convert_value_snmp_object_id(self, mock_traptask_init):
+        mock_traptask_init.return_value = None
+        trap_task = TrapTask()
+
+        value = (1, 2, 3, 4)
+        self.assertEqual(
+            trap_task._convert_value(value),
+            "1.2.3.4"
+        )
+
+    @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
+    def test_convert_value_decodes_utf8(self, mock_traptask_init):
+        mock_traptask_init.return_value = None
+        trap_task = TrapTask()
+
+        value = 'valid utf8 string \xc3\xa9'.encode('utf8')
+        self.assertEqual(
+            trap_task._convert_value(value),
+            u'valid utf8 string \xe9'.decode('utf8')
+        )
+
+    '''
+    @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
+    def test_convert_value_decodes_datetime(self, mock_traptask_init):
+        mock_traptask_init.return_value = None
+        trap_task = TrapTask()
+
+        self.assertTrue(False, "implement test")
+    '''
+
+    @patch("Products.ZenEvents.zentrap.TrapTask.__init__")
+    def test_convert_value_handles_invalid_chars(self, mock_traptask_init):
+        mock_traptask_init.return_value = None
+        trap_task = TrapTask()
+
+        value = '\xde\xad\xbe\xef\xfe\xed\xfa\xce'
+        self.assertEqual(
+            trap_task._convert_value(value),
+            'Failed to decode: converted to BASE64:"3q2+7/7t+s4="'
+        )
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TrapTaskUnitTest))
+    return suite

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -609,7 +609,10 @@ class TrapTask(BaseTask, CaptureReplay):
                 # Try converting to a date
                 decoded = self._value_from_dateandtime(value)
                 if not decoded:
-                    decoded = 'BASE64:' + base64.b64encode(value)
+                    decoded = ''.join(
+                        ['Failed to decode: converted to BASE64:"',
+                         base64.b64encode(value),
+                         '"'])
                 return decoded
         return value
 

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -609,10 +609,7 @@ class TrapTask(BaseTask, CaptureReplay):
                 # Try converting to a date
                 decoded = self._value_from_dateandtime(value)
                 if not decoded:
-                    decoded = ''.join(
-                        ['Failed to decode: converted to BASE64:"',
-                         base64.b64encode(value),
-                         '"'])
+                    decoded = 'BASE64:' + base64.b64encode(value)
                 return decoded
         return value
 


### PR DESCRIPTION
Fixes ZEN-24658

SNMP Trap values of "BASE64:..." for values we failed to decode
were causing confusion for users who believed the original trap
was sent in base64.

* new value reads "Failed to decode: converted to BASE64:"<base64 encoded value>"
* adds unit tests for zentrap