### PR TITLE
ZEN-26530 Event generation ignoring production state changes

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -1349,6 +1349,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         """
         # Set production state on all components that inherit from this device
         ret = super(Device, self).setProdState(state, maintWindowChange, REQUEST)
+        self._p_changed = True
         if REQUEST:
             audit('UI.Device.Edit', self, productionState=state,
                   maintenanceWindowChange=maintWindowChange)


### PR DESCRIPTION
Devices whose production state had been set above their
threshold were not generating events, and devices with their
threshold above their production state continued to generate
events.

Setting _p_changed is enough for that change to take hold and be
propagated to start and stop those events from being generated
as expected.