### PR TITLE
ZEN-23718: check if device with the same ip exist

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -904,11 +904,9 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         return ip
 
     def _isDuplicateIp(self, ip):
-        ipMatch = self.getNetworkRoot().findIp(ip)
-        if ipMatch:
-            dev = ipMatch.device()
-            if dev and self.id != dev.id:
-                return True
+        dev = self.getDmdRoot("Devices").findDeviceByIdOrIp(ip)
+        if dev and self.id != dev.id:
+            return True
         return False
 
     security.declareProtected(ZEN_ADMIN_DEVICE, 'setManageIp')


### PR DESCRIPTION
If device wasn't modeled we could set its ip to other
devices and than have several devices with the same ip.
We were searching for the duplicate ip first in Network
and then from IP object we were taking a device object,
but if device wasn't modeled ip from Network wasn't assigned
to it. Now try to find device by its ip from Devices.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-23718)