### PR TITLE
Fix ZEN-26417: port of #2118 to support/5.2.x

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
@@ -215,5 +215,14 @@ Ext.onReady(function(){
         grid.restoreURLState();
     }
 
+    // ZEN-26417
+    grid.on("selectionchange", updateEventContext);
+    function updateEventContext() {
+        var selectionModel = this.getSelectionModel()
+        var selection = selectionModel.getSelection()
+        selection.forEach(function(sel) {
+            Zenoss.Security.setContext(sel.data.device.uid)
+            });
+    }
 
 });


### PR DESCRIPTION
Users who have no global role, but have adminObjects added to their account are not able to act upon events in the global EvConsole, because they lack a global context on which to check permissions. These changes address this:
  * in the UI by checking the combined permissions on the currently selected events in the EventPanel Grid, which re-nables the event action toolbar;
  * on the server-side, for each event on which an action is requested, we check user permissions for that event's target device.