### PR TITLE
ZEN-25648:Fixing zenpack-manager user command actions would be logged…

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -42,6 +42,7 @@ import json
 import pkg_resources
 
 from urlparse import urlparse
+from Products.ZenMessaging.audit import audit
 
 
 log = logging.getLogger('zen.ZenPackCMD')
@@ -109,6 +110,7 @@ def CreateZenPack(zpId, prevZenPackName='', devDir=None):
         f.close()
     base = os.path.join(base, parts[-1])
     shutil.move(os.path.join(destDir, 'CONTENT'), base)
+    audit('Shell.ZenPack.Create', zpId)
 
     return destDir
 
@@ -254,6 +256,7 @@ def InstallEggAndZenPack(dmd, eggPath, link=False,
                                               serviceId=serviceId,
                                               ignoreServiceInstall=ignoreServiceInstall)
                     zenPacks.append(zp)
+                    audit('Shell.ZenPack.Install', zp.id)
                 except NonCriticalInstallError, ex:
                     nonCriticalErrorEncountered = True
                     if sendEvent:
@@ -985,6 +988,7 @@ def RemoveZenPack(dmd, packName, filesOnly=False, skipDepsCheck=False,
     if sendEvent:
         ZPEvent(dmd, 2, 'Removed ZenPack %s' % packName)
 
+    audit('Shell.ZenPack.Remove', packName)
 
 def DoEasyUninstall(name):
     """


### PR DESCRIPTION
… in audit log

Example Logging added:

`2017-03-28 18:41:44 INFO action=Install kind=ZenPack zenpack=ZenPacks.zenoss.ImpactServer-5.1.6.0.0-py2.7.egg source=Shell process=zenpack.py logname=zenoss parameters="--install ZenPacks.zenoss.ImpactServer"`

`2017-03-28 18:55:17 INFO action=Install kind=ZenPack zenpack=ZenPacks.zenoss.Impact-5.1.6.0.0-py2.7.egg source=Shell process=zenpack.py logname=zenoss parameters="--install ZenPacks.zenoss.Impact-5.1.6.0.0-p"`
`2017-03-28 20:45:21 INFO action=Remove kind=ZenPack zenpack=ZenPacks.zenoss.ImpactServer source=Shell process=zenpack.py logname=zenoss parameters="--uninstall ZenPacks.zenoss.ImpactServer --service-id=97yol"`
