### PR TITLE
Fix filename in quiesce-mariadb.sh to match file rename

### DIFF
--- a/bin/quiesce-mariadb.sh
+++ b/bin/quiesce-mariadb.sh
@@ -241,7 +241,7 @@ function main()
 }
 
 
-if [[ "$(basename $0)" == "quiesce-mysql.sh" ]]; then
+if [[ "$(basename $0)" == "quiesce-mariadb.sh" ]]; then
     if [[ $(whoami) == "root" ]]; then
         FULLPATH="$(cd $(dirname $0); pwd -P)"
         exec su - zenoss -c "$FULLPATH/$(basename $0) $*"


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-23656

The script was renamed but the main function wasn't changed; result is that zodb/zep haven't been properly paused for backups since Nov 2014.