### PR TITLE
ZEN-27160: Pause zenhub applyDataMap jobs during zenpack install/upgrade/remove

### DIFF
--- a/Products/ZenHub/tests/testWorklist.py
+++ b/Products/ZenHub/tests/testWorklist.py
@@ -1,10 +1,10 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2012, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
 
@@ -167,6 +167,33 @@ class TestWorklist(BaseTestCase):
         self.assertEqual(len(worklist.otherworklist), 0)
         self.assertEqual(len(worklist), 0)
 
+    def testPopNoADM(self):
+        # test that applyworklist items don't get popped when allowADM=False
+        worklist = _ZenHubWorklist()
+        for i in range(10):
+            worklist.push(MockHubWorklistItem(method='test', value=i))
+        for i in range(10,20):
+            worklist.push(MockHubWorklistItem(method='sendEvents', value=i))
+        for i in range(20,30):
+            worklist.push(MockHubWorklistItem(method='applyDataMaps', value=i))
+        for i in range(20):
+            job = worklist.pop(False)
+            self.assertIsInstance(job, MockHubWorklistItem)
+            self.assertTrue(job.method != 'applyDataMaps', True)
+            self.assertTrue(0 <= job.value < 20)
+
+        self.assertEqual(len(worklist.applyworklist), 10)
+
+        for i in range(10):
+            job = worklist.pop(True)
+            self.assertIsInstance(job, MockHubWorklistItem)
+            self.assertTrue(job.method == 'applyDataMaps', True)
+            self.assertTrue(20 <= job.value < 30)
+
+        self.assertEqual(len(worklist.eventworklist), 0)
+        self.assertEqual(len(worklist.otherworklist), 0)
+        self.assertEqual(len(worklist.applyworklist), 0)
+        self.assertEqual(len(worklist), 0)
 
 def test_suite():
     from unittest import TestSuite, makeSuite

--- a/Products/ZenHub/tests/testWorklist.py
+++ b/Products/ZenHub/tests/testWorklist.py
@@ -178,16 +178,23 @@ class TestWorklist(BaseTestCase):
             worklist.push(MockHubWorklistItem(method='applyDataMaps', value=i))
         for i in range(20):
             job = worklist.pop(False)
+            self.assertIsNotNone(job)
             self.assertIsInstance(job, MockHubWorklistItem)
-            self.assertTrue(job.method != 'applyDataMaps', True)
+            self.assertTrue(job.method != 'applyDataMaps', "Got an applyDataMaps job!")
             self.assertTrue(0 <= job.value < 20)
 
         self.assertEqual(len(worklist.applyworklist), 10)
+        self.assertEqual(len(worklist), 10)
+
+        # Another pop with allowADM=False should return None
+        job = worklist.pop(False)
+        self.assertIsNone(job)
 
         for i in range(10):
             job = worklist.pop(True)
+            self.assertIsNotNone(job)
             self.assertIsInstance(job, MockHubWorklistItem)
-            self.assertTrue(job.method == 'applyDataMaps', True)
+            self.assertTrue(job.method == 'applyDataMaps', "job.method was %s, expected 'applyDataMaps'" % job.method)
             self.assertTrue(20 <= job.value < 30)
 
         self.assertEqual(len(worklist.eventworklist), 0)

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -336,6 +336,8 @@ class _ZenHubWorklist(object):
         allowADM controls whether we should allow popping jobs from the applyDataMaps list,
         this should be False while models are changing (like during a zenpack install/upgrade/removal)
         """
+        # the priority lists have eventworklist, otherworklist, and applyworklist
+        # when we don't want to allow ApplyDataMaps, we should exclude the possibility of popping from applyworklist
         eventchain = filter(None, self.eventPriorityList if allowADM else [self.eventworklist, self.otherworklist])
         otherchain = filter(None, self.otherPriorityList if allowADM else [self.otherworklist, self.eventworklist])
         applychain = filter(None, self.applyPriorityList if allowADM else [self.eventworklist, self.otherworklist])

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -334,7 +334,7 @@ class _ZenHubWorklist(object):
         preferring tasks according to the above priority.
 
         allowADM controls whether we should allow popping jobs from the applyDataMaps list,
-        this should be False while models are changing (like during a zenpack install)
+        this should be False while models are changing (like during a zenpack install/upgrade/removal)
         """
         eventchain = filter(None, self.eventPriorityList if allowADM else [self.eventworklist, self.otherworklist])
         otherchain = filter(None, self.otherPriorityList if allowADM else [self.otherworklist, self.eventworklist])
@@ -856,7 +856,7 @@ class ZenHub(ZCmdBase):
             allowADM = self.dmd.getPauseADMLife() > self.options.modeling_pause_timeout
             job = self.workList.pop(allowADM)
             if job is None:
-                self.log.info("Got None from the job worklist.  ApplyDataMaps may be paused for zenpack install/upgrade.")
+                self.log.info("Got None from the job worklist.  ApplyDataMaps may be paused for zenpack install/upgrade/removal.")
                 yield wait(0.1)
                 break
 
@@ -1102,7 +1102,7 @@ class ZenHub(ZCmdBase):
             help="Run with profiling on")
         self.parser.add_option('--modeling-pause-timeout',
             type='int', default=3600,
-            help="Maximum number of seconds to pause modeling during ZenPack install/upgrade (default: %default)")
+            help="Maximum number of seconds to pause modeling during ZenPack install/upgrade/removal (default: %default)")
 
         notify(ParserReadyForOptionsEvent(self.parser))
 

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -336,17 +336,18 @@ class _ZenHubWorklist(object):
         allowADM controls whether we should allow popping jobs from the applyDataMaps list,
         this should be False while models are changing (like during a zenpack install)
         """
-        eventchain = filter(None, self.eventPriorityList)
-        otherchain = filter(None, self.otherPriorityList)
-        applychain = filter(None, self.applyPriorityList)
+        eventchain = filter(None, self.eventPriorityList if allowADM else [self.eventworklist, self.otherworklist])
+        otherchain = filter(None, self.otherPriorityList if allowADM else [self.otherworklist, self.eventworklist])
+        applychain = filter(None, self.applyPriorityList if allowADM else [self.eventworklist, self.otherworklist])
 
         # choose a job to pop based on weighted random
-        choice_list = [eventchain]*4 + [otherchain]*2
-        # only include applyDataMap jobs if allowed
-        if allowADM:
-            choice_list.append(applychain)
-
-        return heapq.heappop(choice(choice_list)[0])
+        choice_list = [eventchain]*4 + [otherchain]*2 + [applychain]
+        chosen_list = choice(choice_list)
+        if len(chosen_list) > 0:
+            item = heapq.heappop(chosen_list[0])
+            return item
+        else:
+            return None
 
     def push(self, job):
         heapq.heappush(self[job.method], job)
@@ -854,6 +855,11 @@ class ZenHub(ZCmdBase):
 
             allowADM = self.dmd.getPauseADMLife() > self.options.modeling_pause_timeout
             job = self.workList.pop(allowADM)
+            if job is None:
+                self.log.info("Got None from the job worklist.  ApplyDataMaps may be paused for zenpack install/upgrade.")
+                yield wait(0.1)
+                break
+
             candidateWorkers = list(self.workerselector.getCandidateWorkerIds(job.method, self.workers))
             for i in candidateWorkers:
                 worker = self.workers[i]

--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -33,6 +33,7 @@ from Products.ZenRelations.RelSchema import ToManyCont, ToOne
 from Products.ZenUtils.IpUtil import IpAddressError
 from Products.ZenWidgets import messaging
 from Products.ZenUtils.Security import activateSessionBasedAuthentication, activateCookieBasedAuthentication
+from ZODB.transact import transact
 from Commandable import Commandable
 from datetime import datetime
 import os
@@ -925,14 +926,16 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         """
         Gets time in seconds since pauseADMStart
         """
-        return (datetime.now() - self.pauseADMStart).total_seconds()
+        return (datetime.utcnow() - self.pauseADMStart).total_seconds()
 
+    @transact
     def startPauseADM(self):
         """
         Sets pauseADMStart to the current time
         """
-        self.pauseADMStart = datetime.now()
+        self.pauseADMStart = datetime.utcnow()
 
+    @transact
     def stopPauseADM(self):
         """
         Sets pauseADMStart to the min datetime

--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -34,6 +34,7 @@ from Products.ZenUtils.IpUtil import IpAddressError
 from Products.ZenWidgets import messaging
 from Products.ZenUtils.Security import activateSessionBasedAuthentication, activateCookieBasedAuthentication
 from Commandable import Commandable
+from datetime import datetime
 import os
 import sys
 import string
@@ -100,6 +101,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
     userAuthType = AUTH_TYPE_SESSION
     pauseHubNotifications = False
     zendmdStartupCommands = []
+    pauseADMStart = datetime.min
 
     _properties=(
         {'id':'title', 'type': 'string', 'mode':'w'},
@@ -128,6 +130,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         {'id':'userAuthType', 'type': 'string', 'mode':'w'},
         {'id':'pauseHubNotifications', 'type': 'boolean', 'mode':'w'},
         {'id':'zendmdStartupCommands', 'type': 'lines', 'mode':'w'},
+        {'id':'pauseADMStart', 'type': 'datetime', 'mode':'w'},
         )
 
     _relations =  (
@@ -622,7 +625,6 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         $ZENHOME/backups.
         """
         import stat
-        import datetime
         import operator
 
         def FmtFileSize(size):
@@ -647,7 +649,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
                         'size': info[stat.ST_SIZE],
                         'sizeFormatted': FmtFileSize(info[stat.ST_SIZE]),
                         'modDate': info[stat.ST_MTIME],
-                        'modDateFormatted': datetime.datetime.fromtimestamp(
+                        'modDateFormatted': datetime.fromtimestamp(
                                 info[stat.ST_MTIME]).strftime(
                                 '%c'),
                         })
@@ -918,5 +920,23 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
 
     def removeZendmdStartupCommand(self, command):
         self.zendmdStartupCommands = PersistentList([x for x in self.zendmdStartupCommands if x != command])
+
+    def getPauseADMLife(self):
+        """
+        Gets time in seconds since pauseADMStart
+        """
+        return (datetime.now() - self.pauseADMStart).total_seconds()
+
+    def startPauseADM(self):
+        """
+        Sets pauseADMStart to the current time
+        """
+        self.pauseADMStart = datetime.now()
+
+    def stopPauseADM(self):
+        """
+        Sets pauseADMStart to the min datetime
+        """
+        self.pauseADMStart = datetime.min
 
 InitializeClass(DataRoot)

--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -288,21 +288,25 @@ class ZenPackCmd(ZenScriptBase):
             return EggPackCmd.ExportZenPack(
                 self.dmd, self.options.exportPack)
         elif self.options.removePackName:
-            pack = self.dmd.ZenPackManager.packs._getOb(
-                                        self.options.removePackName, None)
+            try:
+                self.dmd.startPauseADM()
+                pack = self.dmd.ZenPackManager.packs._getOb(
+                                            self.options.removePackName, None)
 
-            if not pack:
-                if not self.options.ifinstalled:
-                    self.log.info('ZenPack %s is not installed.' %
-                                            self.options.removePackName)
-                    return False
-            else:
-                if pack:
-                    removeZenPackQueuesExchanges(pack.path())
-                    if pack.isEggPack():
-                        return EggPackCmd.RemoveZenPack(
-                                self.dmd, self.options.removePackName)
-                RemoveZenPack(self.dmd, self.options.removePackName, self.log)
+                if not pack:
+                    if not self.options.ifinstalled:
+                        self.log.info('ZenPack %s is not installed.' %
+                                                self.options.removePackName)
+                        return False
+                else:
+                    if pack:
+                        removeZenPackQueuesExchanges(pack.path())
+                        if pack.isEggPack():
+                            return EggPackCmd.RemoveZenPack(
+                                    self.dmd, self.options.removePackName)
+                    RemoveZenPack(self.dmd, self.options.removePackName, self.log)
+            finally:
+                self.dmd.stopPauseADM()
 
         elif self.options.list:
             for zpId in self.dmd.ZenPackManager.packs.objectIds():

--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -693,7 +693,6 @@ class ZenPackCmd(ZenScriptBase):
                 zp = self.dmd.ZenPackManager.packs._getOb(packName)
                 self.log.info('Upgrading %s' % packName)
                 self.dmd.startPauseADM()
-                transaction.commit()
                 zp.upgrade(self.app)
             except AttributeError:
                 try:
@@ -721,7 +720,6 @@ class ZenPackCmd(ZenScriptBase):
             transaction.abort()
         finally:
             self.dmd.stopPauseADM()
-            transaction.commit()
 
     def extract(self, fname):
         """Unpack a ZenPack, and return the name"""


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27160
Port of https://github.com/zenoss/zenoss-prodbin/pull/2236

Added dmd.startPauseADM() and dmd.stopPauseADM() to prevent zenhub from assigning applyDataMaps jobs to workers. The pause has a configurable timeout that defaults to 1 hour.