### PR TITLE
Fixes ZEN-25893

### DIFF
--- a/Products/ZenModel/MibOrganizer.py
+++ b/Products/ZenModel/MibOrganizer.py
@@ -182,7 +182,10 @@ class MibOrganizer(Organizer, ZenPackable):
         """
         if not moveTarget or not ids: return self()
         if isinstance(ids, basestring): ids = (ids,)
-        target = self.getChildMoveTarget(moveTarget)
+            if moveTarget == '/zport/dmd/Mibs': #handle resolving top level organizer
+                target = self.unrestrictedTraverse(moveTarget)
+            else:
+                target = self.getChildMoveTarget(moveTarget)
         for id in ids:
             rec = self.mibs._getOb(id)
             rec._operation = 1 # moving object state

--- a/Products/ZenModel/MibOrganizer.py
+++ b/Products/ZenModel/MibOrganizer.py
@@ -182,10 +182,10 @@ class MibOrganizer(Organizer, ZenPackable):
         """
         if not moveTarget or not ids: return self()
         if isinstance(ids, basestring): ids = (ids,)
-            if moveTarget == '/zport/dmd/Mibs': #handle resolving top level organizer
-                target = self.unrestrictedTraverse(moveTarget)
-            else:
-                target = self.getChildMoveTarget(moveTarget)
+        if moveTarget == '/zport/dmd/Mibs': #handle resolving top level organizer
+            target = self.unrestrictedTraverse(moveTarget)
+        else:
+            target = self.getChildMoveTarget(moveTarget)
         for id in ids:
             rec = self.mibs._getOb(id)
             rec._operation = 1 # moving object state


### PR DESCRIPTION
If the top level Mibs organizer is passed as a target into 'getChildMoveTarget' it results in a REQUEST attribute error because it is unable to resolve its own organizer off of self.dmdRoot ... which is it's own organizer. If we know the moveTarget is the root Mibs organizer, we should resolve it immediately and not pass it into getChildMoveTarget.