### PR TITLE
Fix filename in quiesce-mariadb.sh to match file rename

### DIFF
--- a/bin/quiesce-mariadb.sh
+++ b/bin/quiesce-mariadb.sh
@@ -241,7 +241,7 @@ function main()
 }
 
 
-if [[ "$(basename $0)" == "quiesce-mysql.sh" ]]; then
+if [[ "$(basename $0)" == "quiesce-mariadb.sh" ]]; then
     if [[ $(whoami) == "root" ]]; then
         FULLPATH="$(cd $(dirname $0); pwd -P)"
         exec su - zenoss -c "$FULLPATH/$(basename $0) $*"


### PR DESCRIPTION
Cherry-picked from https://github.com/zenoss/zenoss-prodbin/pull/2235
https://jira.zenoss.com/browse/ZEN-27347

Fix filename to pause/unpause MariaDB after renaming the script from mysql to mariadb.