### PR TITLE
ZEN-27380: bump the version on the migration script

### DIFF
--- a/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
+++ b/Products/ZenModel/migrate/updateZeneventserverHealthCheck.py
@@ -12,13 +12,13 @@ log = logging.getLogger("zen.migrate")
 
 import Migrate
 import servicemigration as sm
-sm.require("1.0.0")
+sm.require("1.1.5")
 
 
 class UpdateZeneventserverHealthCheck(Migrate.Step):
     "Change 'answering' healthcheck to only care about successful curl."
 
-    version = Migrate.Version(5,0,70)
+    version = Migrate.Version(111,0,0)
 
     def cutover(self, dmd):
         try:


### PR DESCRIPTION
This is port from #2282 

[JIRA](https://jira.zenoss.com/browse/ZEN-27380)