### PR TITLE
Improve search, fix some of the Zuul tests

### DIFF
--- a/Products/ZenModel/DmdBuilder.py
+++ b/Products/ZenModel/DmdBuilder.py
@@ -107,7 +107,6 @@ class DmdBuilder(object):
                 object.isInTree = True
                 self.dmd._setObject(objectId, object)
         devices = self.dmd._getOb('Devices')
-        devices.createCatalog()
         devices.buildDeviceTreeProperties()
 
     def buildMonitors(self):

--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -298,10 +298,12 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
     #----------------------------------------------------------
 
     def before_object_deleted_handler(self):
-        self.get_network_cache().delete_net_obj(self)
+        if not self.id.endswith("Networks"):
+            self.get_network_cache().delete_net_obj(self)
 
     def after_object_added_or_moved_handler(self):
-        self.get_network_cache().add_net(self)
+        if not self.id.endswith("Networks"):
+            self.get_network_cache().add_net(self)
 
     def object_added_handler(self):
         pass

--- a/Products/ZenTestCase/BaseTestCase.py
+++ b/Products/ZenTestCase/BaseTestCase.py
@@ -11,6 +11,7 @@
 import logging
 
 import zope.component
+import zenoss.modelindex.api
 from zope.traversing.adapters import DefaultTraversable
 from transaction._transaction import Transaction
 
@@ -99,6 +100,12 @@ class ZenossTestCaseLayer(ZopeLite):
         # Have to force registering these as they are torn down between tests
         from zenoss.protocols.adapters import registerAdapters
         registerAdapters()
+
+        from Products.Zuul.catalog.model_catalog import register_model_catalog
+        from zenoss.modelindex.api import _register_factories, reregister_subscriptions
+        _register_factories()
+        register_model_catalog()
+        reregister_subscriptions()
 
         from twisted.python.runtime import platform
         platform.supportsThreads_orig = platform.supportsThreads

--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -1,13 +1,19 @@
 
 
 import logging
-
+import re
+from itertools import islice
 
 from interfaces import IModelCatalog, IModelCatalogTool
 from Products.AdvancedQuery import Eq, Or, Generic, And, In, MatchRegexp, MatchGlob
 
+from Products.ZenUtils.NaturalSort import natural_compare
 from Products.Zuul.catalog.interfaces import IModelCatalog
-from Products.Zuul.utils import dottedname, allowedRolesAndGroups
+from Products.Zuul.catalog.model_catalog import SearchResults
+from Products.Zuul.infos import InfoBase
+from Products.Zuul.interfaces import IInfo
+from Products.Zuul.tree import StaleResultsException
+from Products.Zuul.utils import dottedname, allowedRolesAndGroups, unbrain
 from zenoss.modelindex.model_index import SearchParams
 from zenoss.modelindex.constants import INDEX_UNIQUE_FIELD as UID
 from zope.interface import implements
@@ -165,6 +171,73 @@ class ModelCatalogTool(object):
             brain_fields.add(self.uid_field_name)
         return list(brain_fields)
 
+    def _filterQueryResults(self, queryResults, infoFilters):
+        """
+        filters the results by the passed in infoFilters dictionary. If the
+        property of the info object is another info object the "name" attribute is used.
+        The filters are applied as case-insensitive strings on the attribute of the info object.
+        @param queryResults list of brains
+        @param infoFilters dict: key/value pairs of filters
+        @return list of brains
+        """
+        if not infoFilters:
+            return list(queryResults)
+
+        #Optimizing!
+        results = { brain: [True, IInfo(brain.getObject())] for brain in queryResults }
+        for key, value in infoFilters.iteritems():
+            valRe = re.compile(".*" + unicode(value) + ".*", re.IGNORECASE)
+            for result in results:
+                match, info = results[result]
+                if not match:
+                    continue
+
+                testvalues = getattr(info, key)
+                if not hasattr(testvalues, "__iter__"):
+                    testvalues = [testvalues]
+
+                # if the property was a dictionary see if the "key" is valid
+                # or if it is a dict representation of an info object, then check for the
+                # name attribute.
+                if isinstance(testvalues, dict):
+                    val = testvalues.get(key, testvalues.get('name'))
+                    if not (val and valRe.match(str(val))):
+                        results[result][0] = False
+                else:
+                    # if anyone of these values is satisfied then include the object
+                    isMatch = False
+                    for testVal in testvalues:
+                        if isinstance(testVal, InfoBase):
+                            testVal = testVal.name
+                        if valRe.match(str(testVal)):
+                            isMatch = True
+                            break
+                    if not isMatch:
+                        results[result][0] = False
+        return [key for key,matches in results.iteritems() if matches[0]]
+
+    def _sortQueryResults(self, queryResults, orderby, reverse):
+
+        # save the values during sorting in case getting the value is slow
+        savedValues = {}
+
+        def getValue(obj):
+            key = obj.getPrimaryPath()
+            if key in savedValues:
+                value = savedValues[key]
+            else:
+                value = getattr(IInfo(obj), orderby)
+                if callable(value):
+                    value = value()
+                # if an info object is returned then sort by the name
+                if IInfo.providedBy(value):
+                    value = value.name.lower()
+                savedValues[key] = value
+            return value
+
+        return sorted((unbrain(brain) for brain in queryResults),
+                      key=getValue, reverse=reverse, cmp=natural_compare)
+
     def search(self, types=(), start=0, limit=None, orderby='name',
                reverse=False, paths=(), depth=None, query=None,
                hashcheck=None, filterPermissions=True, globFilters=None, uid_only=True, fields=None):
@@ -183,21 +256,42 @@ class ModelCatalogTool(object):
         
         query, not_indexed_user_filters = self._build_query(types, paths, depth, query, filterPermissions, globFilters)
 
-        #areBrains = len(not_indexed_user_filters) == 0
+        areBrains = areBrains or len(not_indexed_user_filters) == 0
+        queryStart = start if areBrains else 0
+        queryLimit = limit if areBrains else None
 
-        # if we have not indexed fields, we need to get all the results and manually filter and sort
-        # I guess that with solr we should be able to avoid searching by unindexed fields
-        #
-        # @TODO get all results if areBrains == False
-        #
-        
         fields_to_return = self._get_fields_to_return(uid_only, fields)
 
-        catalog_results = self.search_model_catalog(query, start=start, limit=limit,
-                                                    order_by=orderby, reverse=reverse, fields=fields_to_return)
+        catalog_results = self.search_model_catalog(query, start=queryStart, limit=queryLimit,
+                                                    order_by=queryOrderby, reverse=reverse, fields=fields_to_return)
+        if len(not_indexed_user_filters) > 0:
+            # unbrain everything and filter
+            results = self._filterQueryResults(catalog_results, not_indexed_user_filters)
+            totalCount = len(results)
+        else:
+            results = catalog_results.results
+            totalCount = catalog_results.total
 
-        # @TODO take care of unindexed filters
-        return catalog_results
+        hash_ = totalCount
+
+        if orderby == queryOrderby:
+            allResults = results
+        else:
+            allResults = self._sortQueryResults(results, orderby, reverse)
+
+        if hashcheck is not None:
+            if hash_ != int(hashcheck):
+                raise StaleResultsException("Search results do not match")
+
+        # Return a slice
+        start = max(start, 0)
+        if limit is None:
+            stop = None
+        else:
+            stop = start + limit
+        results = islice(allResults, start, stop)
+
+        return SearchResults(results, totalCount, str(hash_), areBrains)
 
 
     def getBrain(self, path, fields=None):

--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -123,11 +123,15 @@ class ModelCatalogTool(object):
 
         # Build query for paths
         if paths is not False:   # When paths is False we dont add any path condition
-            context_path = '/'.join(self.context.getPhysicalPath()) + '*'
-            if not paths:
-                paths = (context_path, )
-            elif isinstance(paths, basestring):
-                paths = (paths,)
+            # TODO: Account for depth or get rid of it
+            # TODO: Consider indexing the device's uid as a path
+            context_path = '/'.join(self.context.getPhysicalPath())
+            uid_path_query = In('path', (context_path,)) # MatchGlob(UID, context_path)   # Add the context uid as filter
+            partial_queries.append( uid_path_query )
+            if paths:
+                if isinstance(paths, basestring):
+                    paths = (paths,)
+                partial_queries.append( In('path', paths) )
 
             """  OLD CODE. Why this instead of In?  What do we need depth for?
             q = {'query':paths}
@@ -135,9 +139,6 @@ class ModelCatalogTool(object):
                 q['depth'] = depth
             paths_query = Generic('path', q)
             """
-            paths_query = In('path', paths)
-            uid_path_query = MatchGlob(UID, context_path)   # Add the context uid as filter
-            partial_queries.append( Or(paths_query, uid_path_query) )
 
         # filter based on permissions
         if filterPermissions and allowedRolesAndGroups(self.context):

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -155,12 +155,17 @@ class TreeFacade(ZuulFacade):
         if self.validRegex(filterRegex):
             orgquery = (Eq('objectImplements','Products.ZenModel.%s.%s' % (organizerClass, organizerClass)) &
                         MatchRegexp('uid', filterRegex))
-            paths = [ "{0}/*".format(b.getPath()) for b in IModelCatalogTool(self._dmd).search(query=orgquery)]
+            paths = [ "{0}/".format(b.getPath()) for b in IModelCatalogTool(self._dmd).search(query=orgquery)]
             if paths:
                 return In('path', paths)
 
     def getDeviceBrains(self, uid=None, start=0, limit=50, sort='name',
                         dir='ASC', params=None, hashcheck=None):
+        return self.getObjectBrains(uid=uid, start=start, limit=limit, sort=sort,
+                                    dir=dir, params=params, hashcheck=hashcheck, types='Products.ZenModel.Device.Device')
+
+    def getObjectBrains(self, uid=None, start=0, limit=50, sort='name',
+                        dir='ASC', params=None, hashcheck=None, types=(), fields=[]):
 
         cat = IModelCatalogTool(self._getObject(uid))
 
@@ -200,6 +205,8 @@ class TreeFacade(ZuulFacade):
         limitp = limit
         hashcheckp = hashcheck
         useProdStates = False
+        if 'uuid' not in fields:
+            fields.append('uuid')
 
         if sort == "productionState":
             useProdStates = True
@@ -214,9 +221,9 @@ class TreeFacade(ZuulFacade):
             limitp = None
 
         catbrains = cat.search(
-                'Products.ZenModel.Device.Device', start=startp,
+                types, start=startp,
                 limit=limitp, orderby=orderby, reverse=reverse,
-                query=query, globFilters=globFilters, hashcheck=hashcheckp)
+                query=query, globFilters=globFilters, hashcheck=hashcheckp, fields=fields)
 
         ## Handle Production State separately
         if useProdStates:

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -155,7 +155,7 @@ class TreeFacade(ZuulFacade):
         if self.validRegex(filterRegex):
             orgquery = (Eq('objectImplements','Products.ZenModel.%s.%s' % (organizerClass, organizerClass)) &
                         MatchRegexp('uid', filterRegex))
-            paths = [ "{0}/".format(b.getPath()) for b in IModelCatalogTool(self._dmd).search(query=orgquery)]
+            paths = [ "{0}".format(b.getPath()) for b in IModelCatalogTool(self._dmd).search(query=orgquery)]
             if paths:
                 return In('path', paths)
 

--- a/Products/Zuul/facades/processfacade.py
+++ b/Products/Zuul/facades/processfacade.py
@@ -8,19 +8,20 @@
 ##############################################################################
 import re
 import logging
-from itertools import izip, count, imap
+from itertools import izip, count, imap, islice
 from zope.event import notify
 from Acquisition import aq_parent
 from zope.interface import implements
 from Products.ZenModel.OSProcess import OSProcess
 from Products.ZenModel.OSProcessClass import OSProcessClass
 from Products.ZenModel.OSProcessOrganizer import OSProcessOrganizer
+from Products.Zuul import getFacade
 from Products.Zuul.facades import TreeFacade
 from Products.Zuul.interfaces import IProcessFacade, ITreeFacade
 from Products.Zuul.utils import unbrain
 from Products.Zuul.interfaces import IInfo
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
-from Products.Zuul.tree import SearchResults
+from Products.Zuul.tree import SearchResults, StaleResultsException
 from zope.container.contained import ObjectMovedEvent
 from Products.ZenModel.OSProcessMatcher import OSProcessClassDataMatcher 
 from Products.ZenModel.OSProcessMatcher import applyOSProcessClassMatchers
@@ -208,5 +209,47 @@ class ProcessFacade(TreeFacade):
         brains = self._processSearch(limit, start, sort, dir, params, uid, criteria)
         wrapped = imap(IInfo, imap(unbrain, brains))
         return SearchResults(wrapped, brains.total, brains.hash_)
+
+    def getDevices(self, uid=None, start=0, limit=50, sort='name', dir='ASC',
+                   params=None, hashcheck=None):
+
+        # We have to query for the process(es) and then use unrestrictedTraverse on the deviceIds to get the devices
+        brains = self.getObjectBrains(uid, 0, None, sort, dir, params, None, 'Products.ZenModel.OSProcess.OSProcess', ['deviceId'])
+        # ZEN-10057 - Handle the case of empty results for a filter with no matches
+        if not brains:
+            return SearchResults([], 0, [])
+
+        def getDevice(devId):
+            return self.context.dmd.unrestrictedTraverse(str(devId))
+
+        devices = list(getDevice(brain.deviceId) for brain in iter(brains))
+        devices = list(device for device in devices if device)
+
+        # we may have changed the number of results, so check the hash here
+        totalCount = len(devices)
+        hash_ = str(totalCount)
+        if hashcheck is not None:
+            if hash_ != hashcheck:
+                raise StaleResultsException("Search results do not match")
+
+        # Pick out the correct range
+        start = max(start, 0)
+        if limit is None:
+            stop = None
+        else:
+            stop = start + limit
+        results = islice(devices, start, stop)
+
+        deviceInfos = list(imap(IInfo, results))
+
+        # This part is copy-paste from ZuulFacade.getDevices:
+        uuids = set(dev.uuid for dev in deviceInfos)
+        if uuids:
+            zep = getFacade('zep', self._dmd)
+            severities = zep.getEventSeverities(uuids)
+            for device in deviceInfos:
+                device.setEventSeverities(severities[device.uuid])
+
+        return SearchResults(iter(deviceInfos), totalCount, hash_)
 
 

--- a/Products/Zuul/facades/processfacade.py
+++ b/Products/Zuul/facades/processfacade.py
@@ -222,7 +222,7 @@ class ProcessFacade(TreeFacade):
         def getDevice(devId):
             return self.context.dmd.unrestrictedTraverse(str(devId))
 
-        devices = list(getDevice(brain.deviceId) for brain in iter(brains))
+        devices = list(getDevice(brain.deviceId) for brain in brains)
         devices = list(device for device in devices if device)
 
         # we may have changed the number of results, so check the hash here

--- a/Products/Zuul/tests/test_devicefacade.py
+++ b/Products/Zuul/tests/test_devicefacade.py
@@ -12,11 +12,13 @@ import unittest
 from zope.interface.verify import verifyClass
 from zope.event import notify
 from Products import Zuul
-from Products.Zuul.tests.base import ZuulFacadeTestCase
+from Products.Zuul.tests.base import ZuulFacadeTestCase, init_modelcatalog
 from Products.Zuul.interfaces import IDeviceInfo
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.Zuul.infos.device import DeviceInfo
 from Products.ZenModel.Location import manage_addLocation
 from Products.Zuul.catalog.events import IndexingEvent
+from Products.Zuul.utils import unbrain
 
 
 class DeviceFacadeTest(ZuulFacadeTestCase):
@@ -31,6 +33,7 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
     def test_interfaces(self):
         verifyClass(IDeviceInfo, DeviceInfo)
 
+    @init_modelcatalog
     def testDeleteOrganizerRemovesDevices(self):
         """When we delete an organizer all the devices assigned to it should not
         still have a relationship to it in the catalog
@@ -39,7 +42,7 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         organizer = self.facade.addOrganizer("/zport/dmd/Groups", 'testOrganizer')
         organizer_path = organizer.uid
 
-        catalog = self.dmd.zport.global_catalog
+        catalog = IModelCatalogTool(self.dmd)
 
         # Add some devices to it (use createInstance to create a device)
         devices = self.dmd.Devices
@@ -49,15 +52,15 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
 
         # test we have added the device
         self.assertEqual(len(organizer.getDevices()), 1, "make sure we saved our device")
-        deviceBrains = catalog(path='/'.join(organizer.getPhysicalPath()))
-        self.assertTrue(len(deviceBrains) > 1, " At this point we should have the organizer and the device")
+        deviceBrains = catalog.search(paths='/'.join(organizer.getPhysicalPath()))
+        self.assertTrue(deviceBrains.total > 1, " At this point we should have the organizer and the device")
 
         # Delete the Organizer
         self.facade.deleteNode(organizer_path)
 
         # Get the devices directly from the path
-        deviceBrains = catalog(path='/'.join(organizer.getPhysicalPath()))
-        self.assertEqual(len(deviceBrains), 0, " we should not have any devices at this point")
+        deviceBrains = catalog.search(paths='/'.join(organizer.getPhysicalPath()))
+        self.assertEqual(deviceBrains.total, 0, " we should not have any devices at this point")
 
     def test_removeDeviceFromSingleGroup(self):
         red = self.facade.addOrganizer("/zport/dmd/Groups", 'Red')
@@ -129,6 +132,7 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         self.assertTrue(not green_org in systems)
         self.assertTrue(yellow_org in systems)
 
+    @init_modelcatalog
     def test_deviceSearchParams(self):
         """
         Search for something we defniitely do not have
@@ -141,12 +145,17 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(location="test1"))
         self.assertEquals(1, results.total)
 
-    def test_deviceSearchByProdState(self):
+    @init_modelcatalog
+    def test_deviceSearchAndSortByProdState(self):
         devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devProduction = self.dmd.Devices.createInstance('devProduction')
+        devMaintenance.setPerformanceMonitor('localhost')
         devMaintenance.setProdState(400)
+
+        devProduction = self.dmd.Devices.createInstance('devProduction')
+        devProduction.setPerformanceMonitor('localhost')
         devProduction.setProdState(1000)
 
+        # Search by prod state
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", params=dict(productionState=[400]))
         self.assertEquals(1, results.total)
         self.assertEquals(iter(results).next().getObject().getProductionState(), 400)
@@ -155,35 +164,22 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         self.assertEquals(1, results.total)
         self.assertEquals(iter(results).next().getObject().getProductionState(), 1000)
 
-    def test_deviceSortByProdState(self):
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devMaintenance.setProdState(400)
-        devProduction.setProdState(1000)
-
+        # Sort by prod state
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState')
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         self.assertEquals(resultIter.next().getObject().getProductionState(), 400)
         self.assertEquals(resultIter.next().getObject().getProductionState(), 1000)
 
-        # descending order
+        # Sort by prod state, descending order
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', dir='DESC')
         resultIter = iter(results)
         self.assertEquals(2, results.total)
         self.assertEquals(resultIter.next().getObject().getProductionState(), 1000)
         self.assertEquals(resultIter.next().getObject().getProductionState(), 400)
 
-    def test_deviceSortByNonIndexedFieldWithProdStateFilterReturnsCorrectDevices(self):
         # This test specifically verifies the fix for ZEN-26901 sorting by a non-indexed
         # field while filtering on productionState caused a ProdStateNotSetError.
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setPerformanceMonitor('localhost')
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setPerformanceMonitor('localhost')
-        devProduction.setProdState(1000)
 
         # sort by collector (non-indexed) with productionState filter
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='collector', params=dict(productionState=[400, 1000]))
@@ -196,13 +192,6 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         self.assertEquals(device.getProductionState(), 1000)
         self.assertEquals(device.getPerformanceServer().id, 'localhost')
 
-    def test_deviceSortByIndexedFieldWithProdStateFilterReturnsCorrectDevices(self):
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setProdState(1000)
-
         # sort by name (indexed) with productionState filter
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='name', params=dict(productionState=[400, 1000]))
         resultIter = iter(results)
@@ -212,14 +201,8 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         device = resultIter.next()
         self.assertEquals(device.getObject().getProductionState(), 1000)
 
-    def test_deviceSortByProdStateWithIndexedFieldFilterReturnsCorrectDevices(self):
         # This test specifically verifies the fix for ZEN-26901 sorting productionState
         # while filtering on an indexed field caused a ProdStateNotSetError.
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setProdState(1000)
 
         # sort by productionState with name (indexed) filter
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort="productionState", params=dict(name="dev"))
@@ -232,23 +215,14 @@ class DeviceFacadeTest(ZuulFacadeTestCase):
         self.assertEquals(device.getObject().getProductionState(), 1000)
         self.assertEquals(device.getObject().getDeviceName(), 'devProduction')
 
-    def test_deviceSortByProdStateWithNonIndexedFieldFilterReturnsCorrectDevices(self):
-        devMaintenance = self.dmd.Devices.createInstance('devMaintenance')
-        devMaintenance.setPerformanceMonitor("localhost")
-        devMaintenance.setProdState(400)
-
-        devProduction = self.dmd.Devices.createInstance('devProduction')
-        devProduction.setPerformanceMonitor("localhost")
-        devProduction.setProdState(1000)
-
         # sort by productionState with collector (non-indexed) filter
         results = self.facade.getDeviceBrains(uid="/zport/dmd/Devices", sort='productionState', params=dict(collector="local"))
         resultIter = iter(results)
         self.assertEquals(2, results.total)
-        device = resultIter.next()
+        device = unbrain(resultIter.next())
         self.assertEquals(device.getProductionState(), 400)
         self.assertEquals(device.getPerformanceServer().id, 'localhost')
-        device = resultIter.next()
+        device = unbrain(resultIter.next())
         self.assertEquals(device.getProductionState(), 1000)
         self.assertEquals(device.getPerformanceServer().id, 'localhost')
 

--- a/Products/Zuul/tests/test_mibfacade.py
+++ b/Products/Zuul/tests/test_mibfacade.py
@@ -12,7 +12,7 @@ import unittest
 #import zope.component
 from zope.interface.verify import verifyClass
 from Products import Zuul
-from Products.Zuul.tests.base import ZuulFacadeTestCase
+from Products.Zuul.tests.base import ZuulFacadeTestCase, init_modelcatalog
 from Products.Zuul.interfaces import IMibOrganizerInfo
 from Products.Zuul.infos.mib import MibOrganizerInfo
 
@@ -45,6 +45,7 @@ class MibFacadeTest(ZuulFacadeTestCase):
         trapTree = self.facade.getMibTrapTree('/zport/dmd/Mibs/mibs/myTestMIB')
         self.assert_(trapTree is None)
 
+    @init_modelcatalog
     def test_mib_organizers(self):
         orgTree = self.facade.getOrganizerTree('/zport/dmd/Mibs')
         self.assert_(len([mib for mib in orgTree.children]) == 1)
@@ -80,6 +81,7 @@ class MibFacadeTest(ZuulFacadeTestCase):
         trapTree = self.facade.getMibTrapTree('/zport/dmd/Mibs/mibs/myTestMIB')
         self.assert_(trapTree is None)
 
+    @init_modelcatalog
     def test_missing_base_oids(self):
         # All of these OIDs are siblings -- need to create a fake parent node
         self._addNode('topLevelOid3',  '1.3.6.4.1.3')

--- a/Products/Zuul/tests/test_processfacade.py
+++ b/Products/Zuul/tests/test_processfacade.py
@@ -15,6 +15,7 @@ from zope.interface.verify import verifyClass
 from Products import Zuul
 from Products.Zuul.tests.base import ZuulFacadeTestCase
 from Products.Zuul.tests.base import EventTestCase
+from Products.Zuul.tests.base import init_modelcatalog
 from Products.Zuul.interfaces import IProcessNode
 from Products.Zuul.interfaces import IProcessInfo
 from Products.Zuul.interfaces import IProcessFacade
@@ -82,6 +83,7 @@ class ProcessFacadeTest(EventTestCase, ZuulFacadeTestCase):
         Zuul.unmarshal(data, obj)
         self.assertEqual('barbar', obj.name)
 
+    @init_modelcatalog
     def test_getDevices(self):
         device = self.dmd.Devices.createInstance('quux')
         uid = '/zport/dmd/Processes/foo/osProcessClasses/bar'

--- a/Products/Zuul/tests/test_servicefacade.py
+++ b/Products/Zuul/tests/test_servicefacade.py
@@ -12,7 +12,7 @@ import unittest
 from zope.interface.verify import verifyClass
 from Products.ZenModel.IpService import IpService
 from Products import Zuul
-from Products.Zuul.tests.base import ZuulFacadeTestCase
+from Products.Zuul.tests.base import ZuulFacadeTestCase, init_modelcatalog
 from Products.ZenModel.Service import Service
 from Products.Zuul.interfaces import IComponent
 
@@ -25,6 +25,7 @@ class ServiceFacadeTest(ZuulFacadeTestCase):
     def test_interfaces(self):
         verifyClass(IComponent, Service)
 
+    @init_modelcatalog
     def test_getInstances(self):
         device = self.dmd.Devices.createInstance('foo')
         device.os.ipservices._setObject('tcp_00121', IpService('tcp_00121'))


### PR DESCRIPTION
This PR allows catalog searches against unindexed fields and fixes some issues with search revealed by the Zuul integration tests.  It also makes changes to the test framework to enable tests that use the ModelCatalog.