### PR TITLE
ZEN-27341 ZenPack dependencies not always installed in correct order

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -383,7 +383,7 @@ def InstallDistAsZenPack(dmd, dist, eggPath, link=False, filesOnly=False,
             #running files only or zenpack by same name doesn't already exists
             # so no need to install the zenpack in an external process
             runExternalZenpack = False
-            module = packEntry.load()
+            module = packEntry.resolve()
             if hasattr(module, 'ZenPack'):
                 zenPack = module.ZenPack(packName)
             else:


### PR DESCRIPTION
port from https://github.com/zenoss/zenoss-prodbin/pull/2290
[Jira](https://jira.zenoss.com/browse/ZEN-27341)