### PR TITLE
Moving audit logging of graph point addition and using new list of gr…

### DIFF
--- a/Products/ZenModel/GraphDefinition.py
+++ b/Products/ZenModel/GraphDefinition.py
@@ -348,10 +348,10 @@ class GraphDefinition(ZenModelRM, ZenPackable):
             if includeThresholds:
                 for dpName in dpNames:
                     newGps += self.addThresholdsForDataPoint(dpName)
+            for gp in newGps:
+                audit('UI.GraphDefinition.AddGraphPoint', self.id, graphPointType='DataPoint',
+                      graphPoint=gp.id, includeThresholds=str(includeThresholds))
             if REQUEST:
-                for dpName in dpNames:
-                    audit('UI.GraphDefinition.AddGraphPoint', self.id, graphPointType='DataPoint',
-                          graphPoint=dpName, includeThresholds=str(includeThresholds))
                 messaging.IMessageSender(self).sendToBrowser(
                     'Graph Points Added',
                     '%s graph point%s were added.' % (len(newGps),


### PR DESCRIPTION
…aphpoints

This PR resolves the issue identified in [ZEN-486](https://jira.zenoss.com/browse/ZEN-486) where the name of the fully qualified graphpoint was not being logged to the audit log.  For example, if the same graphpoint `membuffer` was added two times, these would appear in the UI as `membuffer` and `membuffer2`.  However, in the audit log they would both appear as `membuffer`.  This PR fixes this so the audit log contains `membuffer` and `membuffer2`.

For this PR I did the following:
* Moved the audit log line up out of the REQUEST check so it would always be logged (it appears to not have been logged when it should be).
* Changed the variables being logged to be those that have the new graphpoint names with the proper numerical suffix.
