### PR TITLE
ZEN-27520: changed api query to elstic

### DIFF
--- a/Products/ZenUtils/elastic/client.py
+++ b/Products/ZenUtils/elastic/client.py
@@ -135,6 +135,16 @@ class ElasticClient(object):
         """
         return self._doRequest('/' + index_string + '/_count?q=' + query)['count']
 
+    def doScrollURI(self, query):
+        """
+        Scroll through the matched documents
+
+        @param query
+        The query string, sans '?q='.  For example:
+            query = 'service:(applesauce)&size=666'
+        """
+        return self._doRequest('/_search/scroll?' + query)
+
 
 # Define the names to export via 'from client import *'.
 __all__ = (


### PR DESCRIPTION
Number of log files for zope was different
from number of log files that should be
created. In addition, support bundle wasn't
working at all, since we moved to newer
version of ES.
Changed query to elastic, now using scroll api,
file name format now include instance id
instead of host name.

[JIRA](https://jira.zenoss.com/browse/ZEN-27520)