### PR TITLE
ZEN-27437 Remove extra log.infos from MetricReporter

### DIFF
--- a/Products/ZenEvents/zeneventd.py
+++ b/Products/ZenEvents/zeneventd.py
@@ -31,6 +31,7 @@ from zope.component.event import objectEventNotify
 
 from Products.ZenCollector.utils.maintenance import MaintenanceCycle, maintenanceBuildOptions, QueueHeartbeatSender
 from Products.ZenMessaging.queuemessaging.interfaces import IQueueConsumerTask
+from Products.ZenUtils.MetricReporter import MetricReporter
 from Products.ZenUtils.ZCmdBase import ZCmdBase
 from Products.ZenUtils.guid import guid
 from Products.ZenUtils.daemonconfig import IDaemonConfig
@@ -79,6 +80,8 @@ class EventPipelineProcessor(object):
             ClearClassRefreshPipe(self._manager),
             CheckHeartBeatPipe(self._manager)
         )
+        self.reporter = MetricReporter(prefix='zenoss.')
+        self.reporter.start()
 
         if not self.SYNC_EVERY_EVENT:
             # don't call sync() more often than 1 every 0.5 sec - helps throughput

--- a/Products/ZenUtils/MetricReporter.py
+++ b/Products/ZenUtils/MetricReporter.py
@@ -49,7 +49,6 @@ class MetricReporter(Reporter):
         snapshot_keys = ['median', 'percentile_95th']
         for name, metric in self.registry:
             log.debug("metric info: %s, %s", name, metric)
-            log.info("metric info: %s, %s", name, metric)
             if isinstance(metric, Meter):
                 keys = ['count', 'one_minute_rate', 'five_minute_rate',
                         'fifteen_minute_rate', 'mean_rate']
@@ -82,7 +81,6 @@ class MetricReporter(Reporter):
             self.session.headers.update({'User-Agent': 'Zenoss Service Metrics'})
             post_data = {'metrics': metrics}
             log.debug("Sending metric payload: %s" % post_data)
-            log.info("Sending metric payload: %s" % post_data)
             response = self.session.post(self.metric_destination,
                                          data=json.dumps(post_data))
             if response.status_code != 200:

--- a/Products/ZenUtils/ZCmdBase.py
+++ b/Products/ZenUtils/ZCmdBase.py
@@ -24,7 +24,6 @@ from zope.component import getUtility
 from AccessControl.SecurityManagement import newSecurityManager
 from AccessControl.SecurityManagement import noSecurityManager
 
-from Products.ZenUtils.MetricReporter import MetricReporter
 from Products.ZenUtils.Utils import getObjByPath, zenPath
 from Products.ZenUtils.ZodbFactory import IZodbFactoryLookup
 
@@ -98,8 +97,6 @@ class ZCmdBase(ZenDaemon):
         self.poollock = Lock()
         self.getDataRoot()
         self.login()
-        self.reporter = MetricReporter(prefix='zenoss.')
-        self.reporter.start()
 
         setDescriptors(self.dmd)
 


### PR DESCRIPTION
Removed two extra log.info lines from MetricReporter
Moved MetricReporter instance from ZCmdBase to zeventd