### PR TITLE
Bump migration number since it was being skipped in Thebe upgrade.

### DIFF
--- a/Products/ZenModel/migrate/UpdateRedisBindAddress.py
+++ b/Products/ZenModel/migrate/UpdateRedisBindAddress.py
@@ -20,7 +20,7 @@ class UpdateRedisBindAddress(Migrate.Step):
      Fixes redis configs to allow remote connections after the introduction of
      protected-mode in newer versions.
     """
-    version = Migrate.Version(111, 0, 0)
+    version = Migrate.Version(112, 0, 0)
 
     def cutover(self, dmd):
         try:


### PR DESCRIPTION
The migration changes redis config to explicitly listen on 0.0.0.0 since newer versions of redis only listen on 127.0.0.1 by default.