### PR TITLE
Remove productionState from ManagedEntity._properties

### DIFF
--- a/Products/ZenModel/ManagedEntity.py
+++ b/Products/ZenModel/ManagedEntity.py
@@ -50,10 +50,6 @@ class ManagedEntity(ZenModelRM, DeviceResultInt, EventView, MetricMixin,
     _properties = (
      {'id':'snmpindex', 'type':'string', 'mode':'w'},
      {'id':'monitor', 'type':'boolean', 'mode':'w'},
-     {'id':'productionState', 'type':'keyedselection', 'mode':'w',
-        'select_variable':'getProdStateConversions','setter':'setProdState'},
-     {'id':'preMWProductionState', 'type':'keyedselection', 'mode':'w',
-        'select_variable':'getProdStateConversions','setter':'setProdState'},
     )
 
     _relations = (


### PR DESCRIPTION
Certain tests don't like it if there is an entry under _properties that is actually a python property on the object (as opposed to an attribute).  'productionState' didn't exist in the _properties list back when we were storing them in a BTree, so it doesn't appear to be necessary.