### PR TITLE
Prevent duplicate OIDs

### DIFF
--- a/Products/ZenModel/MibModule.py
+++ b/Products/ZenModel/MibModule.py
@@ -1,10 +1,10 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
 
@@ -13,11 +13,10 @@ from AccessControl import ClassSecurityInfo
 from AccessControl import Permissions
 from zope.interface import implements
 
-from Products.ZenRelations.RelSchema import *
+from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenWidgets import messaging
 
 from Products.ZenModel.interfaces import IIndexed
-from Products.ZenModel.ZenossSecurity import *
 from ZenModelRM import ZenModelRM
 from ZenPackable import ZenPackable
 
@@ -32,9 +31,9 @@ class MibModule(ZenModelRM, ZenPackable):
     description = ""
 
     _properties = (
-        {'id':'language', 'type':'string', 'mode':'w'},
-        {'id':'contact', 'type':'string', 'mode':'w'},
-        {'id':'description', 'type':'string', 'mode':'w'},
+        {'id': 'language',    'type': 'string', 'mode': 'w'},
+        {'id': 'contact',     'type': 'string', 'mode': 'w'},
+        {'id': 'description', 'type': 'string', 'mode': 'w'},
     )
 
     _relations = ZenPackable._relations + (
@@ -44,41 +43,36 @@ class MibModule(ZenModelRM, ZenPackable):
     )
 
     # Screen action bindings (and tab definitions)
-    factory_type_information = ( 
-        { 
-            'immediate_view' : 'viewMibModule',
-            'actions'        :
-            ( 
-                { 'id'            : 'overview'
-                , 'name'          : 'Overview'
-                , 'action'        : 'viewMibModule'
-                , 'permissions'   : ( Permissions.view, )
-                },
-                { 'id'            : 'edit'
-                , 'name'          : 'Edit'
-                , 'action'        : 'editMibModule'
-                , 'permissions'   : ( Permissions.view, )
-                },
-            )
-         },
+    factory_type_information = ({
+        'immediate_view' : 'viewMibModule',
+        'actions'        :
+        (
+            { 'id'            : 'overview'
+            , 'name'          : 'Overview'
+            , 'action'        : 'viewMibModule'
+            , 'permissions'   : (Permissions.view,)
+            },
+            { 'id'            : 'edit'
+            , 'name'          : 'Edit'
+            , 'action'        : 'editMibModule'
+            , 'permissions'   : (Permissions.view,)
+            },
         )
+    },)
 
     security = ClassSecurityInfo()
 
-    def getModuleName(self): 
+    def getModuleName(self):
         return self.id
 
-    
     def nodeCount(self):
         return self.nodes.countObjects()
-
 
     def notificationCount(self):
         return self.notifications.countObjects()
 
-
     def deleteMibNodes(self, ids=[], REQUEST=None):
-        """Delete MibNodes 
+        """Delete MibNodes
         """
         for node in self.nodes():
             id = getattr(node, 'id', None)
@@ -90,7 +84,6 @@ class MibModule(ZenModelRM, ZenPackable):
                 'Mib nodes deleted: %s' % (', '.join(ids))
             )
             return self.callZenScreen(REQUEST)
-
 
     def addMibNode(self, id, oid, nodetype, REQUEST=None):
         """Add a MibNode
@@ -110,21 +103,19 @@ class MibModule(ZenModelRM, ZenPackable):
                 )
             return self.callZenScreen(REQUEST)
 
-
     def createMibNode(self, id, **kwargs):
-        """Create a MibNotification 
+        """Create a MibNotification
         """
         from MibNode import MibNode
         if self.oid2name(kwargs['oid'], exactMatch=True, strip=False):
             return None
-        node = MibNode(id, **kwargs) 
+        node = MibNode(id, **kwargs)
         self.nodes._setObject(node.id, node)
         node = self.nodes._getOb(node.id)
-        return node 
-
+        return node
 
     def deleteMibNotifications(self, ids=[], REQUEST=None):
-        """Delete MibNotifications 
+        """Delete MibNotifications
         """
         for notification in self.notifications():
             id = getattr(notification, 'id', None)
@@ -137,13 +128,14 @@ class MibModule(ZenModelRM, ZenPackable):
             )
             return self.callZenScreen(REQUEST)
 
-
     def addMibNotification(self, id, oid, nodetype, REQUEST=None):
-        """Add a MibNotification 
+        """Add a MibNotification
         """
-        notification = self.createMibNotification(id, oid=oid, nodetype=nodetype)
+        notification = self.createMibNotification(
+            id, oid=oid, nodetype=nodetype
+        )
         if REQUEST:
-            if notification: 
+            if notification:
                 messaging.IMessageSender(self).sendToBrowser(
                     'Trap added',
                     'Trap %s was created with oid %s.' % (id, oid)
@@ -156,17 +148,16 @@ class MibModule(ZenModelRM, ZenPackable):
                 )
             return self.callZenScreen(REQUEST)
 
-
     def createMibNotification(self, id, **kwargs):
-        """Create a MibNotification 
+        """Create a MibNotification
         """
         from MibNotification import MibNotification
         if self.oid2name(kwargs['oid'], exactMatch=True, strip=False):
             return None
-        node = MibNotification(id, **kwargs) 
+        node = MibNotification(id, **kwargs)
         self.notifications._setObject(node.id, node)
         node = self.notifications._getOb(node.id)
         return node
-    
+
 
 InitializeClass(MibModule)

--- a/Products/ZenModel/MibOrganizer.py
+++ b/Products/ZenModel/MibOrganizer.py
@@ -1,43 +1,46 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
-
-import os
 import logging
-log = logging.getLogger('zen.Mibs')
 
 from Globals import DTMLFile
 from Globals import InitializeClass
 from AccessControl import ClassSecurityInfo
 from AccessControl import Permissions
-from Products.Jobber.jobs import SubprocessJob
-from Products.ZenModel.ZenossSecurity import *
 
-from Products.ZenRelations.RelSchema import *
+from Products.Jobber.jobs import SubprocessJob
+from Products.ZenModel.ZenossSecurity import ZEN_MANAGE_DMD, ZEN_ADD
+from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenUtils.Search import makeCaseInsensitiveKeywordIndex
 from Products.ZenWidgets import messaging
 from Products.ZenUtils.Utils import atomicWrite, binPath, zenPath
+
 from Organizer import Organizer
 from MibModule import MibModule
 from ZenPackable import ZenPackable
 
+log = logging.getLogger('zen.Mibs')
 _pathToMIB = '/var/ext/uploadedMIBs'
 
-def manage_addMibOrganizer(context, id, REQUEST = None):
+
+def manage_addMibOrganizer(context, id, REQUEST=None):
     """make a device class"""
     sc = MibOrganizer(id)
     context._setObject(id, sc)
     sc = context._getOb(id)
     if REQUEST is not None:
-        REQUEST['RESPONSE'].redirect(context.absolute_url_path() + '/manage_main')
+        REQUEST['RESPONSE'].redirect(
+            context.absolute_url_path() + '/manage_main'
+        )
 
-addMibOrganizer = DTMLFile('dtml/addMibOrganizer',globals())
+
+addMibOrganizer = DTMLFile('dtml/addMibOrganizer', globals())
 
 
 def _oid2name(mibSearch, oid, exactMatch=True, strip=False):
@@ -57,7 +60,8 @@ def _oid2name(mibSearch, oid, exactMatch=True, strip=False):
     oidlist = oid.split('.')
     for i in range(len(oidlist), 0, -1):
         brains = mibSearch(oid='.'.join(oidlist[:i]))
-        if len(brains) < 1: continue
+        if len(brains) < 1:
+            continue
         if len(oidlist[i:]) > 0 and not strip:
             return "%s.%s" % (brains[0].id, '.'.join(oidlist[i:]))
         else:
@@ -74,27 +78,26 @@ class MibOrganizer(Organizer, ZenPackable):
 
     _relations = Organizer._relations + ZenPackable._relations + (
         ("mibs", ToManyCont(ToOne,"Products.ZenModel.MibModule","miborganizer")),
-        )
-
+    )
 
     # Screen action bindings (and tab definitions)
-    factory_type_information = (
-        {
-            'immediate_view' : 'mibOrganizerOverview',
-            'actions'        :
-            (
-                { 'id'            : 'overview'
-                , 'name'          : 'Overview'
-                , 'action'        : 'mibOrganizerOverview'
-                , 'permissions'   : ( Permissions.view, )
-                },
-            )
-         },
+    factory_type_information = ({
+        'immediate_view' : 'mibOrganizerOverview',
+        'actions'        :
+        (
+            { 'id'            : 'overview'
+            , 'name'          : 'Overview'
+            , 'action'        : 'mibOrganizerOverview'
+            , 'permissions'   : (Permissions.view,)
+            },
         )
+    },)
 
-
-    def __init__(self, id=None, description=None, text=None, content_type='text/html'):
-        if not id: id = self.dmdRootName
+    def __init__(
+            self, id=None, description=None, text=None,
+            content_type='text/html'):
+        if not id:
+            id = self.dmdRootName
         super(MibOrganizer, self).__init__(id, description)
         if self.id == self.dmdRootName:
             self.createCatalog()
@@ -113,8 +116,9 @@ class MibOrganizer(Organizer, ZenPackable):
         """
         Return a name for an oid.
         """
-        return _oid2name(self.getDmdRoot("Mibs").mibSearch, oid,
-            exactMatch, strip)
+        return _oid2name(
+            self.getDmdRoot("Mibs").mibSearch, oid, exactMatch, strip
+        )
 
     def name2oid(self, name):
         """
@@ -133,7 +137,6 @@ class MibOrganizer(Organizer, ZenPackable):
             count += group.countClasses()
         return count
 
-
     def createMibModule(self, name, path="/"):
         """Create a MibModule
         """
@@ -145,7 +148,6 @@ class MibOrganizer(Organizer, ZenPackable):
             modorg.mibs._setObject(mod.id, mod)
             mod = modorg.mibs._getOb(mod.id)
         return mod
-
 
     def manage_addMibModule(self, id, REQUEST=None):
         """Create a new service class in this Organizer.
@@ -161,12 +163,13 @@ class MibOrganizer(Organizer, ZenPackable):
         else:
             return self.mibs._getOb(id)
 
-
     def removeMibModules(self, ids=None, REQUEST=None):
         """Remove MibModules from an EventClass.
         """
-        if not ids: return self()
-        if isinstance(ids, basestring): ids = (ids,)
+        if not ids:
+            return self()
+        if isinstance(ids, basestring):
+            ids = (ids,)
         for id in ids:
             self.mibs._delObject(id)
         if REQUEST:
@@ -176,16 +179,17 @@ class MibOrganizer(Organizer, ZenPackable):
             )
             return self()
 
-
     def moveMibModules(self, moveTarget, ids=None, REQUEST=None):
         """Move MibModules from this organizer to moveTarget.
         """
-        if not moveTarget or not ids: return self()
-        if isinstance(ids, basestring): ids = (ids,)
+        if not moveTarget or not ids:
+            return self()
+        if isinstance(ids, basestring):
+            ids = (ids,)
         target = self.getChildMoveTarget(moveTarget)
         for id in ids:
             rec = self.mibs._getOb(id)
-            rec._operation = 1 # moving object state
+            rec._operation = 1  # moving object state
             self.mibs._delObject(id)
             target.mibs._setObject(id, rec)
         if REQUEST:
@@ -195,17 +199,15 @@ class MibOrganizer(Organizer, ZenPackable):
             )
             REQUEST['RESPONSE'].redirect(target.getPrimaryUrlPath())
 
-
     security.declareProtected(ZEN_MANAGE_DMD, 'reIndex')
     def reIndex(self):
         """Go through all devices in this tree and reindex them."""
         zcat = self._getOb(self.default_catalog)
         zcat.manage_catalogClear()
-        for org in [self,] + self.getSubOrganizers():
+        for org in [self] + self.getSubOrganizers():
             for mib in org.mibs():
                 for thing in mib.nodes() + mib.notifications():
                     thing.index_object()
-
 
     security.declareProtected(ZEN_ADD, 'createCatalog')
     def createCatalog(self):
@@ -238,11 +240,14 @@ class MibOrganizer(Organizer, ZenPackable):
         mypath = self.absolute_url_path().replace('/zport/dmd/Mibs', '')
         if not mypath:
             mypath = '/'
-        commandArgs = [binPath('zenmib'), 'run', savedMIBPath,
-                '--path=%s' % mypath, '--mibdepsdir=%s' % zenPath(_pathToMIB)]
-        return self.dmd.JobManager.addJob(SubprocessJob,
-                   description="Load MIB at %s" % mypath,
-                   kwargs=dict(cmd=commandArgs))
-        
+        commandArgs = [
+            binPath('zenmib'), 'run', savedMIBPath,
+            '--path=%s' % mypath, '--mibdepsdir=%s' % zenPath(_pathToMIB)
+        ]
+        return self.dmd.JobManager.addJob(
+            SubprocessJob, description="Load MIB at %s" % mypath,
+            kwargs=dict(cmd=commandArgs)
+        )
+
 
 InitializeClass(MibOrganizer)

--- a/Products/ZenModel/MibOrganizer.py
+++ b/Products/ZenModel/MibOrganizer.py
@@ -182,8 +182,6 @@ class MibOrganizer(Organizer, ZenPackable):
     def moveMibModules(self, moveTarget, ids=None, REQUEST=None):
         """Move MibModules from this organizer to moveTarget.
         """
-        if not moveTarget or not ids:
-            return self()
         if isinstance(ids, basestring):
             ids = (ids,)
         target = self.getChildMoveTarget(moveTarget)

--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -784,7 +784,7 @@ class ZenMib(ZCmdBase):
                                   oid, values['oid'])
             
             try:
-                functor(name, **values)
+                functor(name, logger=self.log, **values)
                 entriesAdded += 1
             except BadRequest:
                 try:

--- a/Products/ZenRelations/ImportRM.py
+++ b/Products/ZenRelations/ImportRM.py
@@ -208,9 +208,23 @@ for a ZenPack.
 
         if name in ('object', 'tomany', 'tomanycont'):
             obj = self.objstack.pop()
+            if obj.getNodeName() in ('MibNode', 'MibNotification'):
+                oid_list = [
+                    brain.getObject()
+                    for brain in self.dmd.Mibs.mibSearch(oid=obj.oid)
+                ]
+                for old_oid in oid_list:
+                    if old_oid.moduleName != obj.moduleName:
+                        self.log.debug(
+                            "OID '%s' will be removed from organizer '%s' "
+                            "and added to organizer '%s'.",
+                            obj.oid, old_oid.moduleName, obj.moduleName
+                        )
+                    old_oid.getParentNode()._delObject(old_oid.id)
+
             notify(IndexingEvent(obj))
             if hasattr(aq_base(obj), 'index_object'):
-               obj.index_object()
+                obj.index_object()
             if self.rootpath == obj.getPrimaryId():
                 self.log.info('Calling reIndex %s', obj.getPrimaryId())
                 obj.reIndex()

--- a/Products/ZenUI3/browser/resources/js/zenoss/MIBs.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/MIBs.js
@@ -7,43 +7,45 @@
  *
  ****************************************************************************/
 
+Ext.onReady(function() {
 
-Ext.onReady(function () {
+Ext.ns('Zenoss.ui.Mibs');
 
-var MibBrowser,
-    mib_browser,
-    router = Zenoss.remote.MibRouter,
-    node_type_store,
-    node_type_maps,
-    oid_grid,
-    trap_grid,
-    node_details,
-    treesm,
-    mib_tree,
-    footerBar,
-    currentAddNodeTitle = _t('Add OID Mapping'),
-    currentAddFn = router.addOidMapping,
-    currentDeleteFn = router.deleteOidMapping;
-    Ext.ns('Zenoss.ui.Mibs');
+var router = Zenoss.remote.MibRouter;
 
-node_type_maps = [{
-    detailsTitle: _t('OID Mapping Overview'),
-    addNodeTitle: _t('Add OID Mapping'),
-    addFn: router.addOidMapping,
-    deleteFn: router.deleteOidMapping,
-    accessOrObjectsLabel: _t('Access:')
-},{
-    detailsTitle: _t('Trap Overview'),
-    addNodeTitle: _t('Add Trap'),
-    addFn: router.addTrap,
-    deleteFn: router.deleteTrap,
-    accessOrObjectsLabel: _t('Objects:')
-}];
+// A model for OID types.
+Ext.define('Zenoss.mibs.NodeType', {
+    extend: 'Ext.data.Model',
+    fields: [
+        {name: 'name', type: 'string'},
+        {name: 'label', type: 'string'},
+        {name: 'accessOrObjects', type: 'string'},
+        {name: 'addfn'},
+        {name: 'deletefn'}
+    ]
+});
 
-node_type_store = [
-    _t('OID Mappings'),
-    _t('Traps')
-];
+// A store of OID type instances
+// Only two records: 'OID Mapping' and 'Trap'
+var nodeTypes = Ext.create('Ext.data.Store', {
+    model: 'Zenoss.mibs.NodeType',
+    data: [{
+        name: _t('OID Mapping'),
+        label: _t('OID Mappings'),
+        accessOrObjects: _t("Access"),
+        addfn: router.addOidMapping,
+        deletefn: router.deleteOidMapping
+    }, {
+        name: _t('Trap'),
+        label: _t('Traps'),
+        accessOrObjects: _t("Objects"),
+        addfn: router.addTrap,
+        deletefn: router.deleteTrap
+    }],
+    // proxy:'memory' required so that ExtJS doesn't try to
+    // load data from an unspecified URL.
+    proxy: 'memory'
+});
 
 
 /**
@@ -55,35 +57,14 @@ Ext.define('Zenoss.mibs.TrapModel',  {
     extend: 'Ext.data.Model',
     idProperty: 'uid',
     fields: [
-         {name: 'uid'},
-         {name: 'name'},
-         {name: 'oid'},
-         {name: 'nodetype'},
-         {name: 'objects'},
-         {name: 'status'},
-         {name: 'description'}
+        {name: 'uid'},
+        {name: 'name'},
+        {name: 'oid'},
+        {name: 'nodetype'},
+        {name: 'objects'},
+        {name: 'status'},
+        {name: 'description'}
     ]
-});
-
-/**
- * @class Zenoss.mibs.TrapStore
- * @extend Zenoss.DirectStore
- * Direct store for loading trap
- */
-Ext.define("Zenoss.mibs.TrapStore", {
-    extend: "Zenoss.DirectStore",
-    constructor: function(config) {
-        config = config || {};
-        Ext.applyIf(config, {
-            model: 'Zenoss.mibs.TrapModel',
-            pageSize: 50,
-            initialSortColumn: "name",
-            totalProperty: 'count',
-            directFn: router.getTraps,
-            root: 'data'
-        });
-        this.callParent(arguments);
-    }
 });
 
 /**
@@ -105,136 +86,160 @@ Ext.define('Zenoss.mibs.OidModel',  {
     ]
 });
 
-/**
- * @class Zenoss.mibs.OidStore
- * @extend Zenoss.DirectStore
- * Direct store for loading ip addresses
- */
-Ext.define("Zenoss.mibs.OidStore", {
+
+Ext.define('Zenoss.mibs.MibStore', {
     extend: "Zenoss.DirectStore",
     constructor: function(config) {
         config = config || {};
         Ext.applyIf(config, {
-            model: 'Zenoss.mibs.OidModel',
             pageSize: 50,
             initialSortColumn: "name",
             totalProperty: 'count',
-            directFn: router.getOidMappings,
             root: 'data'
         });
         this.callParent(arguments);
     }
 });
 
-function rowSelect(sm, rec, ri) {
-    var node = Ext.getCmp('node_details');
-    node.name.setValue(rec.data.name);
-    node.oid.setValue(rec.data.oid);
-    node.accessOrObjects.setValue(rec.data.access);
-    if (rec.data.access === undefined) {
-        node.accessOrObjects.setValue(rec.data.objects);
-    } else {
-        node.accessOrObjects.setValue(rec.data.access);
+
+Ext.define('Zenoss.mibs.NodeGridPanel', {
+    extend: 'Zenoss.BaseGridPanel',
+    constructor: function(config) {
+        config = config || {};
+        Ext.applyIf(config, {
+            defaults: {sortable: true},
+            columns: [{
+                width: 300,
+                flex: 1,
+                dataIndex: 'name',
+                header: _t('Name')
+            },{
+                width: 180,
+                dataIndex: 'oid',
+                header: _t('OID')
+            },{
+                width: 100,
+                dataIndex: 'nodetype',
+                header: _t('Node Type')
+            }],
+            selModel: Ext.create('Zenoss.SingleRowSelectionModel', {
+                listeners: {
+                    select: function(sm, rec, ri) {
+                        Ext.getCmp('node_details').getForm().setValues({
+                            name: rec.data.name,
+                            oid: rec.data.oid,
+                            accessOrObjects: (rec.data.access === undefined)
+                                ? rec.data.objects.join(', ')
+                                : rec.data.access,
+                            nodetype: rec.data.nodetype,
+                            status: rec.data.status,
+                            description: rec.data.description
+                        });
+                    }
+                }
+            })
+        });
+        this.callParent(arguments);
     }
-    node.nodetype.setValue(rec.data.nodetype);
-    node.status.setValue(rec.data.status);
-    node.description.setValue(rec.data.description);
-}
+});
 
-oid_grid = Ext.create('Zenoss.BaseGridPanel', {
+var oid_grid = Ext.create('Zenoss.mibs.NodeGridPanel', {
     id: 'oid_grid',
-    store: Ext.create('Zenoss.mibs.OidStore', {}),
-    columns: [{
-        width: 300,
-        id: 'name',
-        flex: 1,
-        dataIndex: 'name',
-        header: _t('Name'),
-        sortable: true
-    },{
-        width: 180,
-        id: 'oid',
-        dataIndex: 'oid',
-        header: _t('OID'),
-        sortable: true
-    },{
-        width: 100,
-        id: 'nodetype',
-        dataIndex: 'nodetype',
-        header: _t('Node Type'),
-        sortable: true
-    }],
-    selModel: Ext.create('Zenoss.SingleRowSelectionModel', {
-        listeners: {
-            select: rowSelect
-        }
+    store: Ext.create('Zenoss.mibs.MibStore', {
+        model: 'Zenoss.mibs.OidModel',
+        directFn: router.getOidMappings
     })
 });
 
-trap_grid = Ext.create('Zenoss.BaseGridPanel', {
+var trap_grid = Ext.create('Zenoss.mibs.NodeGridPanel', {
     id: 'trap_grid',
-    store: Ext.create('Zenoss.mibs.TrapStore', {}),
-    columns: [{
-        width: 300,
-        id: 'trapname',
-        flex: 1,
-        dataIndex: 'name',
-        header: _t('Name'),
-        sortable: true
-    },{
-        width: 180,
-        id: 'trapoid',
-        dataIndex: 'oid',
-        header: _t('OID'),
-        sortable: true
-    },{
-        width: 100,
-        id: 'trapnodetype',
-        dataIndex: 'nodetype',
-        header: _t('Node Type'),
-        sortable: true
-    }],
-    selModel: Ext.create('Zenoss.SingleRowSelectionModel', {
-        listeners: {
-            select: rowSelect
-        }
+    store: Ext.create('Zenoss.mibs.MibStore', {
+        model: 'Zenoss.mibs.TrapModel',
+        directFn: router.getTraps
     })
-
 });
 
 
-node_details = new Ext.form.FormPanel({
-    title: _t('OID Mapping Overview'),
+var node_details = Ext.create('Ext.form.Panel', {
     id: 'node_details',
+    title: _t(nodeTypes.first().data.name + " Overview"),
+    bodyPadding: 10,
     region: 'center',
-    split: true,
-    columnWidth: 1,
-    bodyStyle: 'padding:5px 15px 0',
     defaultType: 'displayfield',
+    defaults: {
+        labelWidth: 80
+    },
     autoScroll: true,
     items: [{
         fieldLabel: _t('Name'),
-        ref: 'name'
+        name: 'name'
     },{
         fieldLabel: _t('OID'),
-        ref: 'oid'
+        name: 'oid'
     },{
         id: 'access_or_objects',
-        fieldLabel: _t('Access'),
-        ref: 'accessOrObjects'
+        fieldLabel: nodeTypes.first().data.accessOrObjects,
+        name: 'accessOrObjects'
     },{
         fieldLabel: _t('Node Type'),
-        ref: 'nodetype'
+        name: 'nodetype'
     },{
         fieldLabel: _t('Status'),
-        ref: 'status'
+        name: 'status'
     },{
         fieldLabel: _t('Description'),
-        ref: 'description'
+        name: 'description',
+        renderer: Ext.util.Format.nl2br
     }]
 });
 
-MibBrowser = Ext.extend(Ext.Container, {
+function createAddNodeDialog(nodeType) {
+    return new Zenoss.dialog.CloseDialog({
+        id: 'addNodeDialog',
+        width: 300,
+        title: "Add " + nodeType.name,
+        items: [{
+            xtype: 'form',
+            buttonAlign: 'left',
+            fieldDefaults: {
+                labelAlign: 'top'
+            },
+            footerStyle: 'padding-left: 0',
+            id: 'addNodeForm',
+            defaultType: 'textfield',
+            defaults: {allowBlank: false},
+            items: [{
+                fieldLabel: _t('ID'),
+                name: 'id'
+            },{
+                fieldLabel: _t('OID'),
+                name: 'oid'
+            }],
+            buttons: [{
+                xtype: 'DialogButton',
+                text: _t('Submit'),
+                handler: function(button, evt) {
+                    var form = Ext.getCmp('addNodeForm').getForm();
+                    var params = {
+                        uid: Zenoss.env.currentUid,
+                        id: Ext.htmlEncode(form.findField('id').getValue()),
+                        oid: Ext.htmlEncode(form.findField('oid').getValue()),
+                    };
+                    nodeType.addfn(params, function(response) {
+                        if (response.success) {
+                            Zenoss.message.info(_t('OID was successfully added.'));
+                            Ext.getCmp('gridCardPanel').layout.activeItem.refresh();
+                        } else {
+                            Zenoss.message.info(_t('Could not add OID.'));
+                        }
+                    });
+                }
+            }, Zenoss.dialog.CANCEL]
+        }]
+    });
+}
+
+var MibBrowser = Ext.extend(Ext.Container, {
     currentUid: null,
     constructor: function(config) {
         Ext.applyIf(config, {
@@ -261,7 +266,8 @@ MibBrowser = Ext.extend(Ext.Container, {
                         ref: 'name'
                     },{
                         fieldLabel: _t('Contact'),
-                        ref: 'contact'
+                        ref: 'contact',
+                        renderer: Ext.util.Format.nl2br
                     }]
                 },{
                     xtype: 'form',
@@ -275,7 +281,8 @@ MibBrowser = Ext.extend(Ext.Container, {
                         ref: 'language'
                     },{
                         fieldLabel: _t('Description'),
-                        ref: 'description'
+                        ref: 'description',
+                        renderer: Ext.util.Format.nl2br
                     }]
                 }]
             },{
@@ -287,110 +294,61 @@ MibBrowser = Ext.extend(Ext.Container, {
                     cls: 'largetoolbar componenttbar',
                     height: 37,
                     items: [{
-                        xtype: 'tbtext',
-                        html: _t('Display:')
-                    }, {
                         xtype: 'combo',
+                        id: 'node_type_combo',
                         cls: 'mibcombobottom',
-                        store: node_type_store,
-                        typeAhead: true,
-                        allowBlank: false,
+                        store: nodeTypes,
+                        displayField: 'label',
+                        value: nodeTypes.first(),
+                        editable: false,
+                        autoSelect: true,
                         forceSelection: true,
                         triggerAction: 'all',
-                        value: _t('OID Mappings'),
                         selectOnFocus: false,
                         listeners: {
-                            select: function (combo, records, options) {
+                            select: function(combo, records, options) {
                                 if (!records || !records.length) {
                                     return;
                                 }
                                 var record = records[0],
-                                    node_type_map = node_type_maps[record.index],
-                                    node_details = Ext.getCmp('node_details');
+                                    combo = Ext.getCmp('node_type_combo'),
+                                    nodeType = combo.findRecordByDisplay(combo.getValue()).data,
+                                    node_details = Ext.getCmp('node_details'),
+                                    gridCardPanel = Ext.getCmp('gridCardPanel');
 
-                                currentAddNodeTitle = node_type_map.addNodeTitle;
-                                currentAddFn = node_type_map.addFn;
-                                currentDeleteFn = node_type_map.deleteFn;
-                                Ext.getCmp('gridCardPanel').layout.setActiveItem(record.index);
-                                Ext.getCmp('gridCardPanel').layout.activeItem.setContext(Zenoss.env.PARENT_CONTEXT);
-                                node_details.setTitle(node_type_map.detailsTitle);
-                                node_details.name.setValue('');
-                                node_details.oid.setValue('');
-                                node_details.accessOrObjects.setValue('');
-                                node_details.accessOrObjects.setValue('');
-                                node_details.nodetype.setValue('');
-                                node_details.status.setValue('');
-                                node_details.description.setValue('');
-                                Ext.getCmp('access_or_objects').labelEl.update(node_type_map.accessOrObjectsLabel);
+                                gridCardPanel.layout.setActiveItem(record.index);
+                                gridCardPanel.layout.activeItem.setContext(Zenoss.env.PARENT_CONTEXT);
+                                node_details.setTitle(nodeType.name + " Overview");
+                                node_details.getForm().reset();
+                                Ext.getCmp('access_or_objects').setFieldLabel(nodeType.accessOrObjects);
                             }
                         }
                     }, '-', {
                         xtype: 'button',
                         id: 'add_node_button',
                         iconCls: 'add',
-                        handler: function() {
-                            var dialog = new Zenoss.dialog.CloseDialog({
-                                id: 'addNodeDialog',
-                                width: 300,
-                                title: currentAddNodeTitle,
-                                items: [{
-                                    xtype: 'form',
-                                    buttonAlign: 'left',
-                                    fieldDefaults: {
-                                        labelAlign: 'top'
-                                    },
-                                    footerStyle: 'padding-left: 0',
-                                    id: 'addNodeForm',
-                                    items: [{
-                                        fieldLabel: _t('ID'),
-                                        xtype: 'textfield',
-                                        allowBlank: false,
-                                        name: 'id'
-                                    },{
-                                        fieldLabel: _t('OID'),
-                                        xtype: 'textfield',
-                                        allowBlank: false,
-                                        name: 'oid'
-                                    }],
-                                    buttons: [{
-                                        xtype: 'DialogButton',
-                                        text: _t('Submit'),
-                                        handler: function() {
-                                            var form = Ext.getCmp('addNodeForm').getForm();
-                                            var addParams = {
-                                                    uid: Zenoss.env.currentUid,
-                                                    id: Ext.htmlEncode(form.findField('id').getValue()),
-                                                    oid: Ext.htmlEncode(form.findField('oid').getValue())
-                                                };
-                                            currentAddFn(addParams, function() {
-                                                Ext.getCmp('gridCardPanel').layout.activeItem.refresh();
-                                            });
-                                        }
-                                    }, Zenoss.dialog.CANCEL]
-                                }]
-                            });
-                            dialog.show();
+                        handler: function(btn, evt) {
+                            var combo = Ext.getCmp('node_type_combo'),
+                                nodeType = combo.findRecordByDisplay(combo.getValue()).data,
+                                addNodeDialog = createAddNodeDialog(nodeType);
+                            addNodeDialog.show();
                         }
                     }, {
                         xtype: 'button',
                         id: 'delete_node_button',
                         iconCls: 'delete',
                         handler: function() {
-                            var grid = Ext.getCmp('gridCardPanel').layout.activeItem;
-                            var sm = grid.getSelectionModel(),
+                            var combo = Ext.getCmp('node_type_combo'),
+                                nodeType = combo.findRecordByDisplay(combo.getValue()).data,
+                                grid = Ext.getCmp('gridCardPanel').layout.activeItem,
+                                sm = grid.getSelectionModel(),
                                 sel = sm.getSelected();
-                            if (sel === undefined) {
+                            if (sel === undefined || sel === null) {
                                 return;
                             }
-                            currentDeleteFn({uid: sel.get("uid")}, function() {
+                            nodeType.deletefn({uid: sel.get("uid")}, function() {
                                 var node = Ext.getCmp('node_details');
-                                node.name.setValue('');
-                                node.oid.setValue('');
-                                node.accessOrObjects.setValue('');
-                                node.accessOrObjects.setValue('');
-                                node.nodetype.setValue('');
-                                node.status.setValue('');
-                                node.description.setValue('');
+                                node.getForm().reset();
                                 grid.refresh();
                             });
                         }
@@ -404,7 +362,7 @@ MibBrowser = Ext.extend(Ext.Container, {
                     split: true,
                     width: 600,
                     items: [oid_grid, trap_grid ]
-                } , node_details]
+                }, node_details]
             }]
         });
         MibBrowser.superclass.constructor.call(this, config);
@@ -428,7 +386,7 @@ MibBrowser = Ext.extend(Ext.Container, {
     }
 });
 
-mib_browser = new MibBrowser({});
+var mib_browser = new MibBrowser({});
 
 /**********************************************************************
  *
@@ -474,7 +432,7 @@ Ext.define("Zenoss.MibTreePanel", {
                 viewConfig: {
                     listeners: {
                         drop: this.onNodeDrop,
-                        scope:this
+                        scope: this
                     }
 
                 }
@@ -486,9 +444,11 @@ Ext.define("Zenoss.MibTreePanel", {
                     uids: [nodedata.records[0].data.uid],
                     target: nodedata.records[0].parentNode.data.uid
                 },
-                function () {
+                function() {
                     this.moveMibsCallback(nodedata.records[0].parentNode.data.uid);
-                }, this);
+                },
+                this
+            );
         },
         moveMibsCallback: function(targetId) {
             Ext.History.add('navTree' + Ext.History.DELIMITER + targetId);
@@ -528,9 +488,9 @@ Ext.define("Zenoss.MibTreePanel", {
  *
  */
 
-treesm = new Zenoss.TreeSelectionModel({
+var treesm = new Zenoss.TreeSelectionModel({
     listeners: {
-        'selectionchange': function (sm, nodes) {
+        'selectionchange': function(sm, nodes) {
             var newnode;
             if (nodes.length) {
                 newnode = nodes[0];
@@ -548,20 +508,24 @@ treesm = new Zenoss.TreeSelectionModel({
                 if (newnode.data.uid === '/zport/dmd/Mibs') {
                     isRoot = true;
                 }
-                Ext.getCmp('add-organizer-button').setDisabled(newnode.data.leaf || Zenoss.Security.doesNotHavePermission('Manage DMD'));
-                Ext.getCmp('edit-mib-action').setDisabled(!newnode.data.leaf || Zenoss.Security.doesNotHavePermission('Manage DMD'));
+                Ext.getCmp('add-organizer-button').setDisabled(
+                    newnode.data.leaf || Zenoss.Security.doesNotHavePermission('Manage DMD')
+                );
+                Ext.getCmp('edit-mib-action').setDisabled(
+                    !newnode.data.leaf || Zenoss.Security.doesNotHavePermission('Manage DMD')
+                );
                 // do not allow them to delete the root node
-                Ext.getCmp('delete-button').setDisabled(isRoot || Zenoss.Security.doesNotHavePermission('Manage DMD'));
-
+                Ext.getCmp('delete-button').setDisabled(
+                    isRoot || Zenoss.Security.doesNotHavePermission('Manage DMD')
+                );
                 // add to history
                 Ext.History.add('mibtree' + Ext.History.DELIMITER + newnode.data.uid);
             }
-
         }
     }
 });
 
-mib_tree = new Zenoss.MibTreePanel({
+var mib_tree = new Zenoss.MibTreePanel({
     id: 'mibtree',
     cls: 'mib-tree',
     ddGroup: 'mibtreedd',
@@ -574,7 +538,7 @@ mib_tree = new Zenoss.MibTreePanel({
         allowDrop: false
     },
     listeners: {
-        click: function (node, e) {
+        click: function(node, e) {
             if (node.data.leaf) {
                 mib_browser.setContext(node);
             }
@@ -613,52 +577,52 @@ Ext.getCmp('center_panel').add({
  */
 function showEditMibDialog(response){
     var data = response.data, win,
-        items = response.form.items[0].items;
-    // show the edit form
-    win = Ext.create('Zenoss.dialog.BaseWindow', {
-        id: 'editMIBDialog',
-        title: _t('Edit MIB'),
-        height: 360,
-        width: 510,
-        modal: true,
-        autoScroll: true,
-        plain: true,
-        buttonAlight: 'left',
-        items:{
-            xtype:'form',
-            ref: 'editForm',
-            buttonAlign: 'left',
-
-            items: items,
-            listeners: {
-                validitychange: function(form, valid) {
-                    if (win.isVisible()){
-                        win.submitButton.setDisabled(!valid);
+        items = response.form.items[0].items,
+        win = Ext.create('Zenoss.dialog.BaseWindow', {
+            id: 'editMIBDialog',
+            title: _t('Edit MIB'),
+            height: 360,
+            width: 510,
+            modal: true,
+            autoScroll: true,
+            plain: true,
+            buttonAlight: 'left',
+            items: {
+                xtype:'form',
+                ref: 'editForm',
+                buttonAlign: 'left',
+                items: items,
+                listeners: {
+                    validitychange: function(form, valid) {
+                        if (win.isVisible()){
+                            win.submitButton.setDisabled(!valid);
+                        }
                     }
                 }
-            }
-        },
-        buttons:[{
-            xtype: 'DialogButton',
-            ref: '../submitButton',
-            text: _t('Submit'),
-            handler: function(button) {
-                var form = button.refOwner.editForm.getForm(),
-                dirtyOnly=true,
-                opts = form.getValues(false, dirtyOnly);
-                opts.uid = data.uid;
-                router.setInfo(opts, function(response) {
-                    reloadTree(response.data.uid);
-                });
-            }
-        },{
-            xtype: 'DialogButton',
-            text: _t('Cancel')
-        }]
-    });
-
+            },
+            buttons:[{
+                xtype: 'DialogButton',
+                ref: '../submitButton',
+                text: _t('Submit'),
+                handler: function(button) {
+                    var form = button.refOwner.editForm.getForm(),
+                        dirtyOnly = true,
+                        opts = form.getValues(false, dirtyOnly);
+                        opts.uid = data.uid;
+                    router.setInfo(opts, function(response) {
+                        reloadTree(response.data.uid);
+                    });
+                }
+            },{
+                xtype: 'DialogButton',
+                text: _t('Cancel')
+            }]
+        });
+    // show the edit form
     win.show();
 }
+
+
 /**********************************************************************
  *
  * Footer Bar
@@ -669,143 +633,141 @@ function createAction(typeName, text) {
     return new Zenoss.Action({
         text: _t('Add ') + text + '...',
         iconCls: 'add',
-        handler: function () {
+        handler: function() {
             var addDialog = new Zenoss.FormDialog({
-                title: _t('Create ') + text,
-                modal: true,
-                formId: Ext.id(),
-                formListeners: {
-                    validitychange: function(field, isValid) {
-                        if (addDialog.isVisible()) {
-                             addDialog.submitButton.setDisabled(!isValid);
+                    title: _t('Create ') + text,
+                    modal: true,
+                    formId: Ext.id(),
+                    formListeners: {
+                        validitychange: function(field, isValid) {
+                            if (addDialog.isVisible()) {
+                                 addDialog.submitButton.setDisabled(!isValid);
+                            }
                         }
-                    }
-                },
-                width: 310,
-                items: [{
-                    xtype: 'idfield',
-                    fieldLabel: _t('ID'),
-                    ref: '../nameField',
-                    name: 'name',
-                    tabIndex: 0,
-                    allowBlank: false
-                }],
-                buttons: [{
-                    xtype: 'DialogButton',
-                    text: _t('Submit'),
-                    ref: '../submitButton',
-                    disabled: true,
-                    tabIndex: 1,
-                    handler: function () {
-                        var newName;
-                        newName = addDialog.nameField.getValue();
-                        mib_tree.addNode(typeName, newName);
-                    }
-                },
-                    Zenoss.dialog.CANCEL
-                ]
-            });
+                    },
+                    width: 310,
+                    items: [{
+                        xtype: 'idfield',
+                        fieldLabel: _t('ID'),
+                        ref: '../nameField',
+                        name: 'name',
+                        tabIndex: 0,
+                        allowBlank: false
+                    }],
+                    buttons: [{
+                        xtype: 'DialogButton',
+                        text: _t('Submit'),
+                        ref: '../submitButton',
+                        disabled: true,
+                        tabIndex: 1,
+                        handler: function() {
+                            var newName;
+                            newName = addDialog.nameField.getValue();
+                            mib_tree.addNode(typeName, newName);
+                        }
+                    },
+                        Zenoss.dialog.CANCEL
+                    ]
+                });
             addDialog.show();
         }
     });
 }
 
 function createLocalMIBAddAction() {
-
     return new Zenoss.Action({
-    text: _t('Add MIB from Desktop') + '...',
-    id: 'addmib-item',
-    permission: 'Manage DMD',
-    handler: function(btn, e){
-        var node = getSelectedMibTreeNode(),
-        src = node.data.uid + '/uploadfile',
-        win;
-        win= new Zenoss.dialog.CloseDialog({
-            id: 'fileuploadwindow',
-            width: 300,
-            title: _t('Add MIB from Desktop'),
-            listeners: {
-                close: function(panel) {
-                    // show the message about the uploaded file
-                    Zenoss.messenger.checkMessages();
-                }
-            },
-            items: [{
-                xtype: 'panel',
-                buttonAlign: 'left',
-                fieldDefaults: {
-                    labelAlign: 'top'
-                },
-                footerStyle: 'padding-left: 0',
-                items: [{
-                    xtype: 'panel',
-                    width: 270,
-                    height: 70,
-                    layout: 'anchor',
-                    html: '<iframe frameborder="0" src="' +  src  + '"></iframe>'
-                }]
-            }]
-        });
-        win.show();
-    }
-});
+        text: _t('Add MIB from Desktop') + '...',
+        id: 'addmib-item',
+        permission: 'Manage DMD',
+        handler: function(btn, e){
+            var node = getSelectedMibTreeNode(),
+                src = node.data.uid + '/uploadfile',
+                win = new Zenoss.dialog.CloseDialog({
+                    id: 'fileuploadwindow',
+                    width: 300,
+                    title: _t('Add MIB from Desktop'),
+                    listeners: {
+                        close: function(panel) {
+                            // show the message about the uploaded file
+                            Zenoss.messenger.checkMessages();
+                        }
+                    },
+                    items: [{
+                        xtype: 'panel',
+                        buttonAlign: 'left',
+                        fieldDefaults: {
+                            labelAlign: 'top'
+                        },
+                        footerStyle: 'padding-left: 0',
+                        items: [{
+                            xtype: 'panel',
+                            width: 270,
+                            height: 70,
+                            layout: 'anchor',
+                            html: '<iframe frameborder="0" src="' +  src  + '"></iframe>'
+                        }]
+                    }]
+                });
+            win.show();
+        }
+    });
 }
 
 function createDownloadMIBAddAction() {
     return new Zenoss.Action({
-    text: _t('Download MIB') + '...',
-    id: 'download-addmib-item',
-    permission: 'Manage DMD',
-    handler: function(btn, e){
-        var win = new Zenoss.dialog.CloseDialog({
-            width: 300,
-            title: _t('Download MIB'),
+        text: _t('Download MIB') + '...',
+        id: 'download-addmib-item',
+        permission: 'Manage DMD',
+        handler: function(btn, e){
+            var win = new Zenoss.dialog.CloseDialog({
+                width: 300,
+                title: _t('Download MIB'),
 
-            items: [{
-                xtype: 'form',
-                buttonAlign: 'left',
-                monitorValid: true,
-                fieldDefaults: {
-                    labelAlign: 'top'
-                },
-                footerStyle: 'padding-left: 0',
                 items: [{
-                    xtype: 'textfield',
-                    name: 'package',
-                    fieldLabel: _t('URL'),
-                    id: "add-mib-url",
-                    allowBlank: false
-                }],
-                buttons: [{
-                    xtype: 'DialogButton',
-                    text: _t('Add'),
-                    formBind: true,
-                    handler: function(b) {
-                        var form = b.ownerCt.ownerCt.getForm(),
-                            opts = form.getValues();
-                        opts.organizer = Zenoss.env.PARENT_CONTEXT.replace('/zport/dmd/Mibs', '');
-                        router.addMIB(opts,
-                        function(response) {
-                            if (!response.success) {
-                                new Zenoss.dialog.SimpleMessageDialog({
-                                    message: response.msg,
-                                    buttons: [{
-                                        xtype: 'DialogButton',
-                                        text: _t('OK')
-                                    }]
-                                }).show();
-                            }
-                        });
-                    }
-                }, Zenoss.dialog.CANCEL]
-            }]
-        });
-        win.show();
-    }
-});
+                    xtype: 'form',
+                    buttonAlign: 'left',
+                    monitorValid: true,
+                    fieldDefaults: {
+                        labelAlign: 'top'
+                    },
+                    footerStyle: 'padding-left: 0',
+                    items: [{
+                        xtype: 'textfield',
+                        name: 'package',
+                        fieldLabel: _t('URL'),
+                        id: "add-mib-url",
+                        allowBlank: false
+                    }],
+                    buttons: [{
+                        xtype: 'DialogButton',
+                        text: _t('Add'),
+                        formBind: true,
+                        handler: function(b) {
+                            var form = b.ownerCt.ownerCt.getForm(),
+                                opts = form.getValues();
+                            opts.organizer = Zenoss.env.PARENT_CONTEXT.replace('/zport/dmd/Mibs', '');
+                            router.addMIB(opts,
+                            function(response) {
+                                if (!response.success) {
+                                    new Zenoss.dialog.SimpleMessageDialog({
+                                        message: response.msg,
+                                        buttons: [{
+                                            xtype: 'DialogButton',
+                                            text: _t('OK')
+                                        }]
+                                    }).show();
+                                }
+                            });
+                        }
+                    }, Zenoss.dialog.CANCEL]
+                }]
+            });
+            win.show();
+        }
+    });
 }
 
-footerBar = Ext.getCmp('footer_bar');
+var footerBar = Ext.getCmp('footer_bar');
 
 footerBar.add({
     id: 'add-organizer-button',
@@ -840,13 +802,13 @@ function deleteNode() {
             text: _t('Delete'),
             handler: function() {
                 var params = {
-                    uid: node.data.uid
-                },
-                parentUid = node.parentNode.data.uid,
-                callback = function(response) {
-                    // after deleting the child, select the parent
-                    reloadTree(parentUid);
-                };
+                        uid: node.data.uid
+                    },
+                    parentUid = node.parentNode.data.uid,
+                    callback = function(response) {
+                        // after deleting the child, select the parent
+                        reloadTree(parentUid);
+                    };
                 router.deleteNode(params, callback);
             }
         }, {
@@ -854,7 +816,6 @@ function deleteNode() {
             text: _t('Cancel')
         }]
     }).show();
-
 }
 
 footerBar.add({
@@ -878,25 +839,23 @@ footerBar.add([{
     iconCls: 'customize',
     id: 'mibs-configure-menu',
     disabled: Zenoss.Security.doesNotHavePermission('Manage DMD'),
+    defaultType: 'menuitem',
     menu: {
         items: [{
-            xtype: 'menuitem',
             id: 'edit-mib-action',
             disabled: true,
             text: _t('Edit a Mib'),
             handler: function() {
-                var node = getSelectedMibTreeNode(),
-                    params;
-                if (node){
-                    params = {
+                var node = getSelectedMibTreeNode();
+                if (node) {
+                    var params = {
                         uid: node.data.uid,
                         useFieldSets: false
                     };
                     router.getInfo(params, showEditMibDialog);
                 }
             }
-        },{
-            xtype: 'menuitem',
+        }, {
             text: _t('Add to ZenPack'),
             handler: addToZenPack
         }]

--- a/Products/Zuul/facades/mibfacade.py
+++ b/Products/Zuul/facades/mibfacade.py
@@ -172,7 +172,7 @@ class MibFacade(TreeFacade):
         return jobStatus
 
     def moveMibs(self, sourceUids, targetUid):
-        moveTarget = targetUid.replace('/zport/dmd/Mibs/', '')
+        moveTarget = '/'.join(targetUid.split('/')[4:])
         for sourceUid in sourceUids:
             sourceObj = self._getObject(sourceUid)
 

--- a/Products/Zuul/facades/mibfacade.py
+++ b/Products/Zuul/facades/mibfacade.py
@@ -1,15 +1,13 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2010, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
-
 import logging
-log = logging.getLogger('zen.MibFacade')
 
 from zope.interface import implements
 from Acquisition import aq_parent
@@ -18,13 +16,15 @@ from Products.Zuul.decorators import info
 from Products.Zuul.facades import TreeFacade
 from Products.Zuul.utils import UncataloguedObjectException
 from Products.Zuul.interfaces import ITreeFacade, IMibFacade, IInfo
-from Products.Zuul.infos.mib import MibOrganizerNode, MibNode, FakeTopLevelNodeInfo
-
+from Products.Zuul.infos.mib import (
+    MibOrganizerNode, MibNode, FakeTopLevelNodeInfo
+)
 from Products.Jobber.jobs import SubprocessJob
 from Products.ZenUtils.Utils import binPath, snmptranslate
-
 from Products.ZenModel.MibOrganizer import MibOrganizer
 from Products.ZenModel.MibModule import MibModule
+
+log = logging.getLogger('zen.MibFacade')
 
 
 class MibFacade(TreeFacade):
@@ -64,15 +64,15 @@ class MibFacade(TreeFacade):
         b = node2.oid.split('.')
 
         # Find the point where the OIDs diverge
-        for i in range( min(len(a), len(b)) ):
+        for i in range(min(len(a), len(b))):
             if a[i] == b[i]:
                 continue
 
             # Compare the two oids at the branch, *numerically*
-            return cmp( int(a[i]), int(b[i]) )
+            return cmp(int(a[i]), int(b[i]))
 
         # This case occurs when one OID is the parent of another
-        return cmp( len(a), len(b) )
+        return cmp(len(a), len(b))
 
     def addOidMapping(self, uid, id, oid, nodetype):
         self._getObject(uid).addMibNode(id, oid, nodetype)
@@ -86,18 +86,24 @@ class MibFacade(TreeFacade):
     def deleteTrap(self, mibUid, trapId):
         self._getObject(mibUid).deleteMibNotifications([trapId])
 
-    def getMibNodes(self, uid, limit=0, start=0, sort='name', dir='DESC', relation='nodes'):
+    def getMibNodes(
+            self, uid, limit=0, start=0, sort='name',
+            dir='DESC', relation='nodes'):
         obj = self._getObject(uid)
         if isinstance(obj, MibOrganizer):
-            return 0,[]
+            return 0, []
         functor = getattr(obj, relation, None)
         if functor is None:
-            log.warn("Unable to retrieve the relation '%s' from %s",
-                     relation, obj.id)
-            return 0,[]
+            log.warn(
+                "Unable to retrieve the relation '%s' from %s",
+                relation, obj.id
+            )
+            return 0, []
         all = [IInfo(node) for node in functor()]
         reverse = dir == 'DESC'
-        return len(all), sorted(all, key=lambda info: getattr(info, sort), reverse=reverse)[start:limit + start]
+        return len(all), sorted(
+            all, key=lambda info: getattr(info, sort), reverse=reverse
+        )[start:limit + start]
 
     def getMibNodeTree(self, id):
         return self.getMibBaseNodeTree(id, relation='nodes')
@@ -118,7 +124,7 @@ class MibFacade(TreeFacade):
                      relation, obj.id)
             return []
         seenNodes = {}
-        rootNodeList = [] # There can be only one! ... unless there are many.
+        rootNodeList = []  # There can be only one! ... unless there are many.
         try:
             for node in sorted(functor(), self.oidcmp):
                 prev_oid, _ = node.oid.rsplit('.', 1)
@@ -136,7 +142,7 @@ class MibFacade(TreeFacade):
                             branchNode._addSubNode(subNode)
                             seenNodes[node.oid] = subNode
                             break
-                    else: #  The first entry
+                    else:  # The first entry
                         rootNode = MibNode(node)
                         rootNodeList.append(rootNode)
                         seenNodes[node.oid] = rootNode
@@ -146,7 +152,7 @@ class MibFacade(TreeFacade):
 
             # Create a fake top-level node -- common with traps
             rootNode = FakeTopLevelNodeInfo(obj)
-            baseNode = rootNodeList[0] # Use the first sibling
+            baseNode = rootNodeList[0]  # Use the first sibling
             rootNode.oid = baseNode.oid.rsplit('.', 1)[0]
             for sibling in rootNodeList:
                 rootNode._addSubNode(sibling)
@@ -158,9 +164,11 @@ class MibFacade(TreeFacade):
     def addMibPackage(self, package, organizer):
         args = [binPath('zenmib'), 'run', package,
                 '--path=%s' % organizer]
-        jobStatus = self._dmd.JobManager.addJob(SubprocessJob,
+        jobStatus = self._dmd.JobManager.addJob(
+            SubprocessJob,
             description="Add MIB package %s" % package,
-            kwargs=dict(cmd=args))
+            kwargs=dict(cmd=args)
+        )
         return jobStatus
 
     def moveMibs(self, sourceUids, targetUid):
@@ -170,11 +178,11 @@ class MibFacade(TreeFacade):
 
             if isinstance(sourceObj, MibOrganizer):
                 sourceParent = aq_parent(sourceObj)
-                sourceParent.moveOrganizer(moveTarget, (sourceObj.id,) )
+                sourceParent.moveOrganizer(moveTarget, (sourceObj.id,))
 
             elif isinstance(sourceObj, MibModule):
                 sourceParent = sourceObj.miborganizer()
-                sourceParent.moveMibModules(moveTarget, (sourceObj.id,) )
+                sourceParent.moveMibModules(moveTarget, (sourceObj.id,))
 
             else:
                 args = (sourceUid, sourceObj.__class__.__name__)
@@ -192,4 +200,3 @@ class MibFacade(TreeFacade):
         if not oid:
             oid = snmptranslate('-On', name)
         return oid
-

--- a/Products/Zuul/facades/mibfacade.py
+++ b/Products/Zuul/facades/mibfacade.py
@@ -86,6 +86,12 @@ class MibFacade(TreeFacade):
     def deleteTrap(self, mibUid, trapId):
         self._getObject(mibUid).deleteMibNotifications([trapId])
 
+    def getOidList(self, oid):
+        """Returns a list containing every OID object matching the
+        given oid.
+        """
+        return [i.getObject() for i in self._dmd.Mibs.mibSearch(oid=oid)]
+
     def getMibNodes(
             self, uid, limit=0, start=0, sort='name',
             dir='DESC', relation='nodes'):

--- a/Products/Zuul/infos/mib.py
+++ b/Products/Zuul/infos/mib.py
@@ -1,22 +1,22 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2010, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
-
 
 from itertools import imap, chain
 
-from pprint import pformat
 from zope.component import adapts
 from zope.interface import implements
 from Products.Zuul.tree import TreeNode
 from Products.Zuul.infos import InfoBase, ProxyProperty
 from Products.Zuul.interfaces import IMibInfo, IMibOrganizerNode, IMibNode
-from Products.Zuul.interfaces import IMibOrganizerInfo, IMibNodeInfo, IMibNotificationInfo
+from Products.Zuul.interfaces import (
+    IMibOrganizerInfo, IMibNodeInfo, IMibNotificationInfo
+)
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
 from Products.ZenModel.MibOrganizer import MibOrganizer
 from Products.ZenModel.MibModule import MibModule
@@ -50,7 +50,8 @@ class MibOrganizerNode(TreeNode):
     @property
     def qtip(self):
         return self._object.description
-    
+
+
 class MibNode(TreeNode):
     """
     Nodes or traps are just subclasses of MibBase
@@ -126,6 +127,7 @@ class FakeTopLevelNodeInfo(TreeNode):
 class MibInfoBase(InfoBase):
     pass
 
+
 class MibNodeInfo(MibInfoBase):
     implements(IMibNodeInfo)
 
@@ -139,6 +141,7 @@ class MibNodeInfo(MibInfoBase):
     status = ProxyProperty('status')
     description = ProxyProperty('description')
 
+
 class MibNotificationInfo(MibInfoBase):
     implements(IMibNotificationInfo)
 
@@ -151,10 +154,11 @@ class MibNotificationInfo(MibInfoBase):
 
     @property
     def objects(self):
-        return pformat(self._object.objects)
+        return list(self._object.objects)
 
     status = ProxyProperty('status')
     description = ProxyProperty('description')
+
 
 class MibInfo(MibInfoBase):
     implements(IMibInfo)
@@ -170,7 +174,8 @@ class MibInfo(MibInfoBase):
     language = ProxyProperty('language')
     contact = ProxyProperty('contact')
     description = ProxyProperty('description')
-    
+
+
 class MibOrganizerInfo(MibInfoBase):
     implements(IMibOrganizerInfo)
     adapts(MibOrganizer)

--- a/Products/Zuul/routers/mibs.py
+++ b/Products/Zuul/routers/mibs.py
@@ -1,12 +1,11 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2010, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
-
 
 """
 Operations for MIBs.
@@ -85,16 +84,8 @@ class MibRouter(TreeRouter):
         @return:  B{Properties}:
            - tree: ([dictionary]) Object representing the new tree
         """
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         # GAH!  JS passes back a keyword of 'type'
         nodeType = type
-        if nodeType not in ['organizer', 'MIB']:
-            return DirectResponse.fail('Not creating "%s"' % nodeType)
-
         try:
             if nodeType == 'organizer':
                 uid = contextUid + '/' + id
@@ -102,15 +93,22 @@ class MibRouter(TreeRouter):
                 self.context.dmd.Mibs.manage_addOrganizer(maoUid)
                 self.context.dmd.restrictedTraverse(uid)
                 audit('UI.Organizer.Add', uid)
-            else:
+            elif nodeType == 'MIB':
                 container = self.context.dmd.restrictedTraverse(contextUid)
                 container.manage_addMibModule(id)
                 audit('UI.Mib.Add', contextUid + '/' + id)
-
+            else:
+                return DirectResponse.fail(
+                    'Invalid node type "%s"' % nodeType
+                )
             return DirectResponse.succeed(tree=self.getTree())
-        except Exception, e:
-            return DirectResponse.exception(e)
+        except Exception as ex:
+            log.exception(ex)
+            return DirectResponse.exception(
+                ex, message="Failed to create '{}'".format(id)
+            )
 
+    @require('Manage DMD')
     def addMIB(self, package, organizer='/'):
         """
         Add a new MIB by URL or local file.
@@ -123,19 +121,16 @@ class MibRouter(TreeRouter):
         @return:  B{Properties}:
            - jobId: (string) ID of the add MIB job
         """
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         facade = self._getFacade()
         jobrecord = facade.addMibPackage(package, organizer)
-        if jobrecord:
-            audit('UI.Mib.AddFromPackage', mibpackage=package, organizer=organizer)
-            return DirectResponse.succeed(new_jobs=Zuul.marshal([jobrecord], 
-                                  keys=('uuid', 'description', 'started')))
-        else:
-            return DirectResponse.fail("Failed to add MIB package %s" % package)
+        if not jobrecord:
+            return DirectResponse.fail(
+                "Failed to add MIB package %s" % package
+            )
+        audit('UI.Mib.AddFromPackage', mibpackage=package, organizer=organizer)
+        return DirectResponse.succeed(new_jobs=Zuul.marshal(
+            [jobrecord], keys=('uuid', 'description', 'started')
+        ))
 
     @require('Manage DMD')
     def deleteNode(self, uid):
@@ -148,11 +143,6 @@ class MibRouter(TreeRouter):
         @return:  B{Properties}:
            - tree: ([dictionary]) Object representing the new tree
         """
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         represented = self.context.dmd.restrictedTraverse(uid)
         organizer = represented.getParentNode()
         if represented.meta_type == 'MibOrganizer':
@@ -180,11 +170,6 @@ class MibRouter(TreeRouter):
         @return:  B{Properties}:
            - data: (dictionary) Object representing the new parent organizer
         """
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         parent = self.api.moveMibs(uids, target)
         parent = IInfo(parent)
         for uid in uids:
@@ -206,11 +191,11 @@ class MibRouter(TreeRouter):
             - form: (dictionary) Object representing an edit form for a MIB's
                     properties
         """
-        facade = self._getFacade()
-        info = facade.getInfo(uid)
+        info = self.api.getInfo(uid)
         form = IFormBuilder(info).render(fieldsets=useFieldSets)
-        return DirectResponse(success=True, data=Zuul.marshal(info), form=form)
+        return DirectResponse.succeed(data=Zuul.marshal(info), form=form)
 
+    @require('Manage DMD')
     def setInfo(self, **data):
         """
         Set attributes on a MIB.
@@ -223,11 +208,6 @@ class MibRouter(TreeRouter):
         @return:  B{Properties}
             - data: (dictionary) Object representing a MIB's new properties
         """
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         uid = data['uid']
         del data['uid']
         facade = self._getFacade()
@@ -239,76 +219,65 @@ class MibRouter(TreeRouter):
         """
         Check for illegal characters in OID
         """
-        oidRegex= re.compile('^[.0-9]+$')
-        oid = oidRegex.match(oid)
-        if not oid:
-            return False
-        else:
-            return True
+        oidRegex = re.compile('^[.0-9]+$')
+        matched = oidRegex.match(oid)
+        return bool(matched)
 
+    @require('Manage DMD')
     def addOidMapping(self, uid, id, oid, nodetype='node'):
-
         if not self._validateOid(oid):
             msg = "Invalid OID value %s" % oid
             return DirectResponse.fail(msg)
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         self.api.addOidMapping(uid, id, oid, nodetype)
         audit('UI.Mib.AddOidMapping', uid, id=id, oid=oid, nodetype=nodetype)
         return DirectResponse.succeed()
 
+    @require('Manage DMD')
     def addTrap(self, uid, id, oid, nodetype='notification'):
-
         if not self._validateOid(oid):
             msg = "Invalid OID value %s" % oid
             return DirectResponse.fail(msg)
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         self.api.addTrap(uid, id, oid, nodetype)
         audit('UI.Mib.AddTrap', uid, id=id, oid=oid, nodetype=nodetype)
         return DirectResponse.succeed()
 
+    @require('Manage DMD')
     def deleteOidMapping(self, uid):
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         if uid.find('/nodes/') == -1:
-            return DirectResponse.fail('"%s" does not appear to refer to an OID Mapping' % uid)
+            return DirectResponse.fail(
+                '"%s" does not appear to refer to an OID Mapping' % uid
+            )
         mibUid, mappingId = uid.split('/nodes/')
         self.api.deleteOidMapping(mibUid, mappingId)
         audit('UI.Mib.DeleteOidMapping', mibUid, mapping=mappingId)
         return DirectResponse.succeed()
 
+    @require('Manage DMD')
     def deleteTrap(self, uid):
-
-        # Make sure they have permission
-        if not Zuul.checkPermission('Manage DMD'):
-            return DirectResponse.fail("You don't have permission to execute this command", sticky=False)
-
         if uid.find('/notifications/') == -1:
-            return DirectResponse.fail('"%s" does not appear to refer to a trap' % uid)
+            return DirectResponse.fail(
+                '"%s" does not appear to refer to a trap' % uid
+            )
         mibUid, trapId = uid.split('/notifications/')
         self.api.deleteTrap(mibUid, trapId)
         audit('UI.Mib.DeleteTrap', mibUid, trap=trapId)
         return DirectResponse.succeed()
 
-    def getOidMappings(self, uid, dir='ASC', sort='name', start=0, page=None, limit=256):
-        count, nodes = self.api.getMibNodes(uid=uid, dir=dir, sort=sort,
-                start=start, limit=limit, relation='nodes')
-        return {'count': count, 'data': Zuul.marshal(nodes)}
+    def getOidMappings(
+            self, uid, dir='ASC', sort='name', start=0, page=None, limit=256):
+        count, nodes = self.api.getMibNodes(
+            uid=uid, dir=dir, sort=sort, start=start,
+            limit=limit, relation='nodes'
+        )
+        return DirectResponse.succeed(count=count, data=Zuul.marshal(nodes))
 
-    def getTraps(self, uid, dir='ASC', sort='name', start=0, page=None, limit=256):
-        count, nodes = self.api.getMibNodes(uid=uid, dir=dir, sort=sort,
-                start=start, limit=limit, relation='notifications')
-        return {'count': count, 'data': Zuul.marshal(nodes)}
+    def getTraps(
+            self, uid, dir='ASC', sort='name', start=0, page=None, limit=256):
+        count, nodes = self.api.getMibNodes(
+            uid=uid, dir=dir, sort=sort, start=start,
+            limit=limit, relation='notifications'
+        )
+        return DirectResponse.succeed(count=count, data=Zuul.marshal(nodes))
 
     def getMibNodeTree(self, id=None):
         """

--- a/Products/Zuul/routers/mibs.py
+++ b/Products/Zuul/routers/mibs.py
@@ -279,6 +279,12 @@ class MibRouter(TreeRouter):
         )
         return DirectResponse.succeed(count=count, data=Zuul.marshal(nodes))
 
+    def getOid(self, oid):
+        node = next(iter(self.api.getOidList(oid)), None)
+        if node is None:
+            return DirectResponse.fail()
+        return DirectResponse.succeed(info=Zuul.marshal(IInfo(node)))
+
     def getMibNodeTree(self, id=None):
         """
         A MIB node is a regular OID (ie you can hit it with snmpwalk)


### PR DESCRIPTION
These changes should be improve MIB management.  The main change is to allow ZenPacks, the `zenmib` utility, and users at the web UI to replace existing OIDs.  Prior Zenoss releases have either allowed multiple instances of the same OID to exist or prevented duplicate OIDs by raising an exception.

Should address many of the concerns expressed in ZEN-27323.