### PR TITLE
ZEN-27932: change debug to error log and raise an exception

### DIFF
--- a/Products/ZenModel/ZDeviceLoader.py
+++ b/Products/ZenModel/ZDeviceLoader.py
@@ -234,11 +234,12 @@ class CreateDeviceJob(Job):
             return '/'.join(device.getPhysicalPath())
         except DeviceExistsError as e:
             transaction.abort()
-            # If the device already exists, log it and move on.
-            self.log.debug(
+            # If the device already exists, log it and raise exception.
+            self.log.error(
                 "Device already exists (job was likely interrupted "
                 "and restarted): %s", e
             )
+            raise
         except Exception:
             transaction.abort()
             self.log.exception("Failed to create device.")


### PR DESCRIPTION
When we were adding CC host first as /Server/SSH/Linux or
/Server/Linux device class and then using the VIP to
the /Control Center device class The CC device will not
appear even though the job completes successfully.

A device can't be added since the VIP was already assigned
to device when it was first added and modeled as
/Server/SSH/Linux or /Server/Linux. An error wasn't raised
since exception was catched. Now give an error log and raise
an exception for job to be failed.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-27932)