### PR TITLE
Hide Password Field in Audit Log Messages

### DIFF
--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -436,7 +436,8 @@ class ZenPropertyManager(object, PropertyManager):
     def zenPropIsPassword(self, id):
         """Is this field a password field.
         """
-        return self.getPropertyType(id) == 'password'
+        passwordTypes = ['password', 'passwd', 'multilinecredentials']
+        return self.getPropertyType(id) in passwordTypes
 
     security.declareProtected(ZEN_ZPROPERTIES_VIEW, 'zenPropertyPath')
     def zenPropertyPath(self, id):


### PR DESCRIPTION
When editing multiline credentials, the credentials are now masked
in the audit log.