### PR TITLE
Add decoder for numerical values

### DIFF
--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -1,5 +1,5 @@
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
-from Products.ZenEvents.zentrap import Decoders
+from Products.ZenEvents.zentrap import decode_snmp_value
 
 from struct import pack
 
@@ -9,63 +9,63 @@ class DecodersUnitTest(BaseTestCase):
     def test_decode_oid(self):
         value = (1, 2, 3, 4)
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             "1.2.3.4"
         )
 
     def test_decode_utf8(self):
         value = 'valid utf8 string \xc3\xa9'.encode('utf8')
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             u'valid utf8 string \xe9'.decode('utf8')
         )
 
     def test_decode_datetime(self):
         value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 50, 8, '+', 6, 5)
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             '2017-12-20T11:50:50.800+06:05'
         )
 
     def test_decode_value_ipv4(self):
         value = '\xcc\x0b\xc8\x01'
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             '204.11.200.1'
         )
 
     def test_decode_value_ipv6(self):
         value = 'Z\xef\x00+\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x08'
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             '5aef:2b::8'
         )
 
     def test_decode_long_values(self):
         value = long(555)
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             int(555)
         )
 
     def test_decode_int_values(self):
         value = int(555)
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             int(555)
         )
 
     def test_encode_invalid_chars(self):
         value = '\xde\xad\xbe\xef\xfe\xed\xfa\xce'
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             'BASE64:3q2+7/7t+s4='
         )
 
     def test_decode_unexpected_object_type(self):
         value = object()
         self.assertEqual(
-            Decoders.decode(value),
+            decode_snmp_value(value),
             None
         )
 

--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -41,11 +41,32 @@ class DecodersUnitTest(BaseTestCase):
             '5aef:2b::8'
         )
 
+    def test_decode_long_values(self):
+        value = long(555)
+        self.assertEqual(
+            Decoders.decode(value),
+            int(555)
+        )
+
+    def test_decode_int_values(self):
+        value = int(555)
+        self.assertEqual(
+            Decoders.decode(value),
+            int(555)
+        )
+
     def test_encode_invalid_chars(self):
         value = '\xde\xad\xbe\xef\xfe\xed\xfa\xce'
         self.assertEqual(
             Decoders.decode(value),
             'BASE64:3q2+7/7t+s4='
+        )
+
+    def test_decode_unexpected_object_type(self):
+        value = object()
+        self.assertEqual(
+            Decoders.decode(value),
+            None
         )
 
 

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -775,31 +775,30 @@ class Decoders:
         try:
             for decoder in decoders:
                 out = decoder(value)
-                if out or out == 0:
+                if out is not None:
                     return out
         except Exception as err:
             log.exception("Unexpected exception: %s", err)
 
     @staticmethod
     def dateandtime(value):
-        """
-            Tries converting a DateAndTime value to a printable string.
+        """Tries converting a DateAndTime value to a printable string.
 
-            A date-time specification.
-            field  octets  contents                  range
-            -----  ------  --------                  -----
-            1      1-2     year*                     0..65536
-            2        3     month                     1..12
-            3        4     day                       1..31
-            4        5     hour                      0..23
-            5        6     minutes                   0..59
-            6        7     seconds                   0..60
-                          (use 60 for leap-second)
-            7        8     deci-seconds              0..9
-            8        9     direction from UTC        '+' / '-'
-            9       10     hours from UTC*           0..13
-            10      11     minutes from UTC          0..59
-            """
+        A date-time specification.
+        field  octets  contents                  range
+        -----  ------  --------                  -----
+        1      1-2     year*                     0..65536
+        2        3     month                     1..12
+        3        4     day                       1..31
+        4        5     hour                      0..23
+        5        6     minutes                   0..59
+        6        7     seconds                   0..60
+                      (use 60 for leap-second)
+        7        8     deci-seconds              0..9
+        8        9     direction from UTC        '+' / '-'
+        9       10     hours from UTC*           0..13
+        10      11     minutes from UTC          0..59
+        """
         try:
             # Some traps send invalid UTC times (direction/hours/minutes all zeros)
             if value[8:] == '\x00\x00\x00':

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -846,20 +846,21 @@ class Decoders:
         return 'BASE64:' + base64.b64encode(value)
 
 
-_decoders = [Decoders.oid,
-             Decoders.number,
-             Decoders.utf8,
-             Decoders.ipaddress,
-             Decoders.dateandtime,
-             Decoders.encode_base64]
+# NOTE: The order of decoders in the list determines their priority
+_decoders = [
+    Decoders.oid,
+    Decoders.number,
+    Decoders.utf8,
+    Decoders.ipaddress,
+    Decoders.dateandtime,
+    Decoders.encode_base64
+]
 
 
 def decode_snmp_value(value):
     """Given a raw OID value
     Itterate over the list of decoder methods in order
     Returns the first value returned by a decoder method
-
-    NOTE: The order of decoders in the list determines their priority
     """
 
     try:

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -635,6 +635,7 @@ class TrapTask(BaseTask, CaptureReplay):
         result.update(
             {name: ','.join(vals) for name, vals in vb_result.iteritems()}
         )
+
         return eventType, result
 
     def decodeSnmpv2(self, addr, pdu):
@@ -646,12 +647,15 @@ class TrapTask(BaseTask, CaptureReplay):
         for vb_oid, vb_value in variables:
             vb_value = Decoders.decode(vb_value)
             vb_oid = '.'.join(map(str, vb_oid))
+
             # SNMPv2-MIB/snmpTrapOID
             if vb_oid == '1.3.6.1.6.3.1.1.4.1.0':
                 result["oid"] = vb_value
-                eventType = self.oid2name(vb_value,
-                                          exactMatch=False,
-                                          strip=False)
+                eventType = self.oid2name(
+                    vb_value,
+                    exactMatch=False,
+                    strip=False
+                )
             elif vb_oid.startswith('1.3.6.1.6.3.18.1.3'):
                 self.log.debug("found snmpTrapAddress OID: %s = %s",
                                vb_oid, vb_value)
@@ -762,71 +766,79 @@ class Decoders:
         """
 
         decoders = [Decoders.oid,
+                    Decoders.number,
                     Decoders.basestring,
                     Decoders.ipaddress,
                     Decoders.dateandtime,
                     Decoders.encode_base64]
 
-        for decoder in decoders:
-            out = decoder(value)
-            if out:
-                return out
+        try:
+            for decoder in decoders:
+                out = decoder(value)
+                if out or out == 0:
+                    return out
+        except Exception as err:
+            log.exception("Unexpected exception: %s", err)
 
     @staticmethod
     def dateandtime(value):
         """
-        Tries converting a DateAndTime value to a printable string.
+            Tries converting a DateAndTime value to a printable string.
 
-        A date-time specification.
-        field  octets  contents                  range
-        -----  ------  --------                  -----
-        1      1-2     year*                     0..65536
-        2        3     month                     1..12
-        3        4     day                       1..31
-        4        5     hour                      0..23
-        5        6     minutes                   0..59
-        6        7     seconds                   0..60
-                      (use 60 for leap-second)
-        7        8     deci-seconds              0..9
-        8        9     direction from UTC        '+' / '-'
-        9       10     hours from UTC*           0..13
-        10      11     minutes from UTC          0..59
-        """
-        # Some traps send invalid UTC times (direction/hours/minutes all zeros)
-        if value[8:] == '\x00\x00\x00':
-            value = value[:8]
-        vallen = len(value)
-        if vallen == 8 or (vallen == 11 and value[8] in ('+', '-')):
-            (year, mon, day,
-             hour, mins, secs, dsecs) = unpack(">HBBBBBB", value[:8])
-            # Ensure valid date representation
-            if mon < 1 or mon > 12:
-                return None
-            if day < 1 or day > 31:
-                return None
-            if hour < 0 or hour > 23:
-                return None
-            if mins > 60:
-                return None
-            if secs > 60:
-                return None
-            if dsecs > 9:
-                return None
-            if vallen == 11:
-                utc_dir = value[8]
-                (utc_hours, utc_mins) = unpack(">BB", value[9:])
-            else:
-                tz_mins = time.timezone / 60
-                if tz_mins < 0:
-                    utc_dir = '-'
-                    tz_mins = -tz_mins
+            A date-time specification.
+            field  octets  contents                  range
+            -----  ------  --------                  -----
+            1      1-2     year*                     0..65536
+            2        3     month                     1..12
+            3        4     day                       1..31
+            4        5     hour                      0..23
+            5        6     minutes                   0..59
+            6        7     seconds                   0..60
+                          (use 60 for leap-second)
+            7        8     deci-seconds              0..9
+            8        9     direction from UTC        '+' / '-'
+            9       10     hours from UTC*           0..13
+            10      11     minutes from UTC          0..59
+            """
+        try:
+            # Some traps send invalid UTC times (direction/hours/minutes all zeros)
+            if value[8:] == '\x00\x00\x00':
+                value = value[:8]
+            vallen = len(value)
+            if vallen == 8 or (vallen == 11 and value[8] in ('+', '-')):
+                (year, mon, day,
+                 hour, mins, secs, dsecs) = unpack(">HBBBBBB", value[:8])
+                # Ensure valid date representation
+                if mon < 1 or mon > 12:
+                    return None
+                if day < 1 or day > 31:
+                    return None
+                if hour < 0 or hour > 23:
+                    return None
+                if mins > 60:
+                    return None
+                if secs > 60:
+                    return None
+                if dsecs > 9:
+                    return None
+                if vallen == 11:
+                    utc_dir = value[8]
+                    (utc_hours, utc_mins) = unpack(">BB", value[9:])
                 else:
-                    utc_dir = '+'
-                utc_hours = tz_mins / 60
-                utc_mins = tz_mins % 60
-            return "%04d-%02d-%02dT%02d:%02d:%02d.%d00%s%02d:%02d" % (
-                year, mon, day, hour, mins, secs,
-                dsecs, utc_dir, utc_hours, utc_mins)
+                    tz_mins = time.timezone / 60
+                    if tz_mins < 0:
+                        utc_dir = '-'
+                        tz_mins = -tz_mins
+                    else:
+                        utc_dir = '+'
+                    utc_hours = tz_mins / 60
+                    utc_mins = tz_mins % 60
+                return "%04d-%02d-%02dT%02d:%02d:%02d.%d00%s%02d:%02d" % (
+                    year, mon, day, hour, mins, secs,
+                    dsecs, utc_dir, utc_hours, utc_mins)
+
+        except TypeError:
+            pass
 
     @staticmethod
     def oid(value):
@@ -835,19 +847,23 @@ class Decoders:
                 return '.'.join(map(str, value))
 
     @staticmethod
+    def number(value):
+        if type(value) in [long, int]:
+            return value
+
+    @staticmethod
     def ipaddress(value):
         for version in [socket.AF_INET, socket.AF_INET6]:
             try:
                 return socket.inet_ntop(version, value)
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
 
     @staticmethod
     def basestring(value):
         try:
-            value.decode('utf8')
-            return value
-        except UnicodeDecodeError:
+            return value.decode('utf8')
+        except (UnicodeDecodeError, AttributeError):
             pass
 
     @staticmethod


### PR DESCRIPTION
Fixes ZEN-27714

* Add test case for `int` and `long` types
* Add decoder that returns the unaltered value for numerics