### PR TITLE
ZEN-27921: using new index in modelcatalog for ip search

### DIFF
--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -28,7 +28,7 @@ from OFS.ObjectManager import checkValidId
 from zope.interface import implements
 from Products.ZenModel.DeviceOrganizer import DeviceOrganizer
 from Products.ZenModel.ComponentOrganizer import ComponentOrganizer
-from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, In
+from Products.AdvancedQuery import MatchRegexp, And, Or, Eq, Between, In, MatchGlob
 from Products.ZenUtils.guid.interfaces import IGlobalIdentifier
 from Products.Zuul.interfaces import IFacade, ITreeNode
 from Products.Zuul.interfaces import (
@@ -175,15 +175,7 @@ class TreeFacade(ZuulFacade):
         params = params if params else {}
         for key, value in params.iteritems():
             if key == 'ipAddress':
-                ip = ensureIp(value)
-                try:
-                    checkip(ip)
-                except IpAddressError:
-                    pass
-                else:
-                    if numbip(ip):
-                        minip, maxip = getSubnetBounds(ip)
-                        qs.append(Between('decimal_ipAddress', str(minip), str(maxip)))
+                qs.append(MatchGlob('text_ipAddress', '{}*'.format(value)))
             elif key == 'productionState':
                 qs.append(Or(*[Eq('productionState', str(state))
                              for state in value]))


### PR DESCRIPTION
On Infrastructure page if you enter IPv6 address in ip address
column filter it won't match any device. IPv6 filtering is
not working.
Using new index idx_ipAddressAsText  for searching in model
catalog which was added with solr implementation.
https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/Zuul/catalog/indexable.py#L105
