### PR TITLE
Use the rabbit-env.conf to get the rabbit node name

### DIFF
--- a/bin/quiesce-rabbitmq.sh
+++ b/bin/quiesce-rabbitmq.sh
@@ -182,7 +182,7 @@ function main()
     VARDIR="/etc/rabbitmq"
     [[ -n "$VARDIR" ]] || die "VARDIR env var is not set"
     [[ -d "$VARDIR" ]] || die "VARDIR=$VARDIR is not a directory"
-    export RABBITMQ_NODENAME="rabbit@$(hostname -s)"
+    export RABBITMQ_NODENAME=$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)
 
     CMD="$1"
     shift

--- a/bin/quiesce-rabbitmq.sh
+++ b/bin/quiesce-rabbitmq.sh
@@ -182,7 +182,7 @@ function main()
     VARDIR="/etc/rabbitmq"
     [[ -n "$VARDIR" ]] || die "VARDIR env var is not set"
     [[ -d "$VARDIR" ]] || die "VARDIR=$VARDIR is not a directory"
-    export RABBITMQ_NODENAME=$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)
+    export RABBITMQ_NODENAME="$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)"
 
     CMD="$1"
     shift


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28014
For systems upgraded from <= 5.0.9, the rabbit node name will be different compared to new systems.  In earlier systems, this was "rabbit@localhost".  In newer systems this is "rabbit@rbt0" (which also matches the hostname).  Upgraded systems still have the old rabbit node name.  In either case, the node name is defined in the rabbit conf file (this config file/location hasn't changed).  Read the node name from /etc/rabbitmq/rabbitmq-env.conf file directly in the quiesce script to avoid giving the wrong node name.