### PR TITLE
Feature/zen 28055

### DIFF
--- a/bin/quiesce-rabbitmq.sh
+++ b/bin/quiesce-rabbitmq.sh
@@ -182,7 +182,7 @@ function main()
     VARDIR="/etc/rabbitmq"
     [[ -n "$VARDIR" ]] || die "VARDIR env var is not set"
     [[ -d "$VARDIR" ]] || die "VARDIR=$VARDIR is not a directory"
-    export RABBITMQ_NODENAME="rabbit@$(hostname -s)"
+    export RABBITMQ_NODENAME=$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)
 
     CMD="$1"
     shift

--- a/bin/quiesce-rabbitmq.sh
+++ b/bin/quiesce-rabbitmq.sh
@@ -182,7 +182,7 @@ function main()
     VARDIR="/etc/rabbitmq"
     [[ -n "$VARDIR" ]] || die "VARDIR env var is not set"
     [[ -d "$VARDIR" ]] || die "VARDIR=$VARDIR is not a directory"
-    export RABBITMQ_NODENAME=$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)
+    export RABBITMQ_NODENAME="$(source /etc/rabbitmq/rabbitmq-env.conf; echo $NODENAME)"
 
     CMD="$1"
     shift


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28055
For systems upgraded from 5.0.9, the rabbit node name will be different compared to new systems.  In either case, the node name is defined in the rabbit conf file (this config hasn't changed).  Read the node name from the conf file directly.