### PR TITLE
Fix Password Appearing in Audit Messages

### DIFF
--- a/Products/Zuul/routers/properties.py
+++ b/Products/Zuul/routers/properties.py
@@ -148,8 +148,8 @@ class PropertiesRouter(DirectRouter):
             oldValue = str(oldValue) if not oldValue else oldValue  # must match
             obj = facade._getObject(uid)
 
-            maskFields = 'value' if obj.zenPropIsPassword(zProperty) else None
-            audit('UI.zProperty.Edit', zProperty, maskFields_=maskFields,
+            maskFields = 'value' if obj.zenPropIsPassword(key) else None
+            audit('UI.zProperty.Edit', key, maskFields_=maskFields,
                   data_={obj.meta_type: uid, 'value': value},
                   oldData_={'value': oldValue})          
         


### PR DESCRIPTION
The password would be visible in plain text in audit log messages.
It would appear in the zProperty field where the entire JSON object
was displayed.  This change just puts the key (which is the
property name you get by looping through the JSON object) into
that field.