### PR TITLE
Dont monitor if admin status is > 1

### DIFF
--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -586,7 +586,7 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
         Return True if this instance should be monitored. False
         otherwise.
         '''
-        if self.adminStatus != 1:
+        if self.adminStatus > 1:
             return False
         else:
             return super(IpInterface, self).monitored()


### PR DESCRIPTION
Modifies the change made here:  https://github.com/zenoss/zenoss-prodbin/commit/6d2edce8b248ee9452da094a0d3f489a12a468cd

Admin status of '0' is "Unknown".  We will still monitor until the admin status is known to be "Down", "Testing" or anything that isn't "Up".  This also fixes some zenpack unit tests that were failing due to this change.