### PR TITLE
Allow tasks to opt out of being counted in missedRuns

### DIFF
--- a/Products/ZenCollector/interfaces.py
+++ b/Products/ZenCollector/interfaces.py
@@ -271,6 +271,11 @@ class IScheduledTask(IObservable):
            needed.
         """)
 
+    suppress_late = zope.interface.Attribute("""
+        Some tasks (e.g. config loaders) may not want to be counted as 'late'
+         to avoid muddying the meaning of our 'missedRuns' metrics on daemons.
+        """)
+
 #    childIds = zope.interface.Attribute("""
 #        Optional attribute: List of configIds of tasks that are associated with this task. When a task is
 #        removed any tasks with a configId in childIds will be removed as well.

--- a/Products/ZenCollector/scheduler.py
+++ b/Products/ZenCollector/scheduler.py
@@ -173,6 +173,10 @@ class CallableTask(object):
         Called whenever this task is late and missed its scheduled run time.
         """
         try:
+            # some tasks we don't want to consider a missed run.
+            if getattr(self.task, 'suppress_late', False):
+                return
+
             # send event only for missed runs on devices.
             self.task._eventService.sendEvent(
                 {'eventClass': '/Perf/MissedRuns',

--- a/Products/ZenCollector/tasks.py
+++ b/Products/ZenCollector/tasks.py
@@ -29,6 +29,8 @@ class BaseTask(ObservableMixin):
     """
     Convenience class that consolidates some shared code.
     """
+    # By default, track when this task is 'late.'
+    suppress_late = False
 
     def __init__(self, *args, **kwargs):
         super(BaseTask, self).__init__()


### PR DESCRIPTION
Add suppress_late property to IScheduledTask and set False in BaseTask, then check it in calls to late() in the scheduler.