### PR TITLE
ZEN-24255: add new rpn field to threshold

### DIFF
--- a/Products/ZenModel/ThresholdClass.py
+++ b/Products/ZenModel/ThresholdClass.py
@@ -92,3 +92,16 @@ class ThresholdClass(ZenModelRM, ZenPackable):
             else:
                 names.append('%s(<span style="color: red">missing</span>)' % dsName)
         return ','.join(names)
+
+
+    def getDataPointsWithRPN(self, all=False):
+        """
+        Return a dictionary where key is datapoint name and value
+        is rpn used to that datapoint.
+        """
+        dpsrpn = []
+        dpsnames = self.rrdTemplate.getRRDDataPointNames() if all else self.dsnames
+        for point in dpsnames:
+            for graph in self.rrdTemplate.getGraphDefs():
+                dpsrpn.extend([(point, pobj.rpn if pobj.rpn else 'No RPN') for pobj in graph.getDataPointGraphPoints(point)])
+        return dict(dpsrpn)

--- a/Products/ZenUI3/browser/resources/js/zenoss/form/DataPointItemSelector.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/DataPointItemSelector.js
@@ -13,6 +13,19 @@
 Ext.define("Zenoss.form.DataPointItemSelector", {
     alias:['widget.datapointitemselector'],
     extend:"Ext.ux.form.ItemSelector",
+    listeners: {
+        // show datapoint name and its RPN according to datapoints that
+        // were selected in selector form
+        change: function(obj, event) {
+            rpnTextObj = Ext.ComponentQuery.query('[name=rpnused]')[0];
+            if (rpnTextObj) {
+                rpnTextObj.setValue('');
+                Ext.each(obj.getValue(), function(dpname, index){
+                    rpnTextObj.setValue(rpnTextObj.value + dpname + ": " + rpnTextObj.record.allDataPoints[dpname] + "; ");
+                });
+            }
+        }
+    },
     constructor: function(config) {
         var record = config.record;
 
@@ -27,7 +40,7 @@ Ext.define("Zenoss.form.DataPointItemSelector", {
             drawDownIcon: false,
             drawTopIcon: false,
             drawBotIcon: false,
-            store: record.allDataPoints
+            store: Object.keys(record.allDataPoints)
         });
         this.callParent(arguments);
     },

--- a/Products/Zuul/facades/templatefacade.py
+++ b/Products/Zuul/facades/templatefacade.py
@@ -280,11 +280,12 @@ class TemplateFacade(ZuulFacade):
         @param String uid: the id of the threshold
         @returns IThresholdInfo
         """
+        alldp = True
         threshold = self._getObject(uid)
         template = threshold.rrdTemplate()
         info = IInfo(threshold)
         # don't show the "selected one" in the list of avaialble
-        info.allDataPoints = [point for point in template.getRRDDataPointNames()]
+        info.allDataPoints = threshold.getDataPointsWithRPN(alldp)
         return info
 
     def addDataPoint(self, dataSourceUid, name):

--- a/Products/Zuul/infos/template.py
+++ b/Products/Zuul/infos/template.py
@@ -583,6 +583,9 @@ class MinMaxThresholdInfo(ThresholdInfo):
     explanation = ProxyProperty("explanation")
     resolution = ProxyProperty("resolution")
 
+    @property
+    def rpnused(self):
+        return '; '.join('{}: {}'.format(key, val) for key, val in self._object.getDataPointsWithRPN().items())
 
 class GraphInfo(InfoBase):
 

--- a/Products/Zuul/interfaces/template.py
+++ b/Products/Zuul/interfaces/template.py
@@ -148,6 +148,8 @@ class IMinMaxThresholdInfo(IThresholdInfo):
     """
     minval = schema.TextLine(title=_t(u'Minimum Value'), order=6)
     maxval = schema.TextLine(title=u'Maximum Value', order=7)
+    rpnused = schema.Text(title=_t(u'RPN is used'),
+                          readonly=True, order=8)
     escalateCount = schema.Int(title=_t(u'Escalate Count'), order=9)
 
     description = schema.TextLine(title=u'Description', order=2)


### PR DESCRIPTION
It was confusing for user what value should he enter in min/max
field, since after that value was calculated with the same rpn
of the datapoint threshold is related to.
Added new field to to Threshold UI which show the rpn expression
that will be used to threshold min/max value. This will help to
adopt the value to rpn expression.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-24255)

Related PR https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold/pull/24