### PR TITLE
ZEN-24402 Graph legends truncated

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -338,7 +338,6 @@
                     removeRepeatedComponent(datapts, cname);
                 }, this);
             }
-            truncateLongLegends(this.datapoints);
 
             // these assume that the graph panel has already been rendered
             var height = this.getEl().getHeight();


### PR DESCRIPTION
Fixes truncated lower legend names -- most often seen when the "show all on one graph" checkbox is checked.