### PR TITLE
Allow Disabled WinService to be monitored via gui

### DIFF
--- a/Products/ZenModel/WinService.py
+++ b/Products/ZenModel/WinService.py
@@ -111,15 +111,6 @@ class WinService(Service):
         return self.serviceclass().monitoredStartModes
 
 
-    def monitored(self):
-        """Should this Windows Service be monitored
-        """
-        startMode = getattr(self, "startMode", None)
-        #don't monitor Disabled services
-        if startMode and startMode == "Disabled": return False
-        return Service.monitored(self)
-
-
     def getStatus(self, statClass=None):
         """
         Return the status number for this WinService

--- a/Products/Zuul/infos/component/winservice.py
+++ b/Products/Zuul/infos/component/winservice.py
@@ -31,11 +31,6 @@ class WinServiceInfo(ComponentInfo):
         return self._object.serviceclass()
 
     @property
-    def usesMonitorAttribute(self):
-        return (not safe_hasattr(self._object, "startMode") \
-                or self._object.startMode != "Disabled")
-
-    @property
     def monitored(self):
         return self._object.monitored() if self.usesMonitorAttribute else ""
 


### PR DESCRIPTION
Fixes ZEN-28263

Disabled windows services need to be able to be monitored to ensure
that they are in a STOPPED state.