### PR TITLE
ZEN-21889: catch the exception if there is a broken component search

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -224,7 +224,15 @@ class DeviceFacade(TreeFacade):
         brains = cat.evalAdvancedQuery(query)
 
         # unbrain the results
-        comps=map(IInfo, map(unbrain, brains))
+        comps = []
+        for brain in brains:
+            try:
+                comps.append(IInfo(unbrain(brain)))
+            except:
+                log.warn('There is broken component "{}" in componentSearch catalog on {} device.'.format(
+                     brain.id, obj.device().id
+                     )
+                )
 
         # filter the components
         if name is not None:


### PR DESCRIPTION
No components are loaded at all if there is an object with a
broken component search.
Load all the components and scrip the broken one and log a
message that there is a broken component.

this is port from https://github.com/zenoss/zenoss-prodbin/pull/2619

[JIRA](https://jira.zenoss.com/browse/ZEN-21889)