### PR TITLE
Feature/fix migration versions.53x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Products/README.txt
+Products/ZenModel/ZMigrateVersion.py
 Products/ZenUI3/browser/resources/js/deploy/
 Products/ZenUI3/node_modules
 bin/zensocket

--- a/Products/ZenModel/ZMigrateVersion.py.in
+++ b/Products/ZenModel/ZMigrateVersion.py.in
@@ -1,12 +1,15 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2008, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
 
-# this is now generated during the build step; see make generate-zversion
-VERSION="5.3.1"
-BUILD_NUMBER="DEV"
+# this file is generated during the build step; see make generate-zversion
+
+# The SCHEMA_* values define the DB schema version used for upgrades
+SCHEMA_MAJOR=%SCHEMA_MAJOR%
+SCHEMA_MINOR=%SCHEMA_MINOR%
+SCHEMA_REVISION=%SCHEMA_REVISION%

--- a/Products/ZenModel/ZVersion.py.in
+++ b/Products/ZenModel/ZVersion.py.in
@@ -1,12 +1,12 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2008, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
-# this is now generated during the build step
+# this is now generated during the build step; see make generate-zversion
 VERSION="%VERSION_STRING%"
 BUILD_NUMBER="%BUILD_NUMBER%"

--- a/Products/ZenModel/migrate/README.md
+++ b/Products/ZenModel/migrate/README.md
@@ -1,5 +1,20 @@
 # Migrations
 
+# Table of Contents
+  - [Overview](#overview)
+    - [Model Migrations](#model-migrations)
+    - [ Service Migrations](#service-migrations)
+      - [Writing a new migration](#writing-a-new-migration)
+      - [Adding unit tests](#adding-unit-tests)
+    - [Managing Migrate.Version](managing-migrate.version)
+      - [Starting a new release](#starting-a-new-release)
+      - [Working with SCHEMA versions](#working-with-schema-versions)
+      - [Release Process](#release-process)
+    - [Running unit tests](#running-unit-tests)
+      - [Running a migration manually](#running-a-migration-manually)
+
+# Overview
+
 There are 2 types of migrations, both of which are discussed below
 
 ## Model Migrations
@@ -26,13 +41,14 @@ log = logging.getLogger("zen.migrate")
 
 import Migrate
 import servicemigration as sm
-sm.require("1.0.0")
+from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
+sm.require("1.0.0")
 
 class RenameZopeToFoo(Migrate.Step):
     """Rename zope service to Foo."""
 
-    version = Migrate.Version(5, 0, 70)
+    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
 
     def cutover(self, dmd):
 
@@ -70,6 +86,59 @@ For one, most dictionaries are represented as lists. The key is an attribute of 
 This is done even at the level of ServiceContext.services.
 
 In general, the elements of a service definition are represented as class attributes, usually with a normalized name to keep with Python style and to avoid shadowing builtin names.
+
+
+## Managing Migrate.Version
+
+`Migrate.Version()` is used by the upgrade framework to control which migrations
+are executed when a particular version of Zenoss is upgraded.  The basic idea is
+that the `upgrade` command for the Zope service will execute all of the
+migrations with a value greater than the current value stored in Zope. Upon
+successful completion of the upgrade, the value of the highest migration script
+is then stored in the database.
+
+In order to better manage the values used across a range of different releases,
+we have implemented a semi-automated scheme to minimize the process of manually
+specifying different values for `Migrate.Version()`.
+
+### Starting a new release
+At the start of a new release, the toplevel makefile should be updated to set
+the values of SCHEMA_MAJOR, SCHEMA_MINOR, & SCHEMA_REVISION to the appropriate
+versions for that release.
+
+Each new migration script added for that release should set `Migrate.Version()`
+as follows:
+
+```
+from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
+...
+    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+```
+
+### Working with SCHEMA versions
+
+The regular `make` process for prodbin, as well as `zendev devimg` and `zendev test`
+will invoke the make target `generate-zversion` which will build ZMigrateVersion.py from ZMigrateVersion.py.in
+using the values of SCHEMA_MAJOR, SCHEMA_MINOR, & SCHEMA_REVISION defined in the
+toplevel makefile.  In this way, developers working on a new release do not need
+to specify explicit versions - they can rely on the build process to inject values
+for a given release.  By the same token, changes can be backported to earlier
+releases without working about which versions to use for different releases because
+the toplevel makefile in each release should define the values unique to that release.
+
+### Release Process
+
+As one of the final steps in the release process, someone must run `make replace-zmigrateversion`
+which will edit all of the files in Products/ZenModel/migrate, replacing the variables
+SCHEMA_MAJOR, SCHEMA_MINOR, & SCHEMA_REVISION with the versions defined in the makefile.
+
+Those changes can be verified with `make verify-explicit-zmigrateversion:` which will fail
+if any files were overlooked.  If `make replace-zmigrateversion` was unable to update
+the a version for some unexpected reason, the migration script can be changed manually
+if necessary at this stage.
+
+After the migration scripts have been updated, then they must be checked into git before
+executing the git-flow-release process.
 
 
 ### Adding unit tests
@@ -112,7 +181,9 @@ The first tests that applying the named migration script on `initial_servicedef`
 As these are unittest TestCases, they can be discovered and run via `python -m unittest discover`.
 Any additional `test_*` functions added to the class will also be discovered and run by unittest.
 
-The service migration tests have also been added to zendev, so they can be invoked with `zendev test unit Products.ZenModel.migrate`.
+The service migration tests have also been added to zendev. In the original version of zendev (circa RM 5.0 and 5.1), the tests can be invoked with `zendev test unit Products.ZenModel.migrate`.  In later versions (circa RM 5.2 and higher), the tests can be invoked with `zendev test -- --type=unit --name=Products.ZenModel.migrate -v`
+
+Guidelines for running RM unit-test in general (not just service migrations) is available in the zendev [README](https://github.com/zenoss/zendev/tree/zendev2#testing-with-devimg).
 
 ### Running a migration manually
 

--- a/Products/ZenModel/migrate/README.md
+++ b/Products/ZenModel/migrate/README.md
@@ -6,7 +6,7 @@
     - [ Service Migrations](#service-migrations)
       - [Writing a new migration](#writing-a-new-migration)
       - [Adding unit tests](#adding-unit-tests)
-    - [Managing Migrate.Version](managing-migrate.version)
+    - [Managing Migrate.Version](#managing-migrateversion)
       - [Starting a new release](#starting-a-new-release)
       - [Working with SCHEMA versions](#working-with-schema-versions)
       - [Release Process](#release-process)

--- a/makefile
+++ b/makefile
@@ -19,6 +19,14 @@ ARTIFACT := prodbin-$(VERSION)-$(ARTIFACT_TAG).tar.gz
 # REVISION ?= 1
 # ARTIFACT := prodbin-$(VERSION)-$(REVISION)-$(ARTIFACT_TAG).tar.gz
 
+# The SCHEMA_* values define the DB schema version used for upgrades.
+# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
+# for more information about setting these values.
+# See zenoss-version.mk for more information about make targets that use these values.
+SCHEMA_MAJOR ?= 200
+SCHEMA_MINOR ?= 0
+SCHEMA_REVISION ?= 0
+
 DIST_ROOT := dist
 
 # Define the name, version and tag name for the docker build image

--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ ARTIFACT := prodbin-$(VERSION)-$(ARTIFACT_TAG).tar.gz
 # See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
 # for more information about setting these values.
 # See zenoss-version.mk for more information about make targets that use these values.
-SCHEMA_MAJOR ?= 200
+SCHEMA_MAJOR ?= 118
 SCHEMA_MINOR ?= 0
 SCHEMA_REVISION ?= 0
 

--- a/replace-zmigrateversion.sh
+++ b/replace-zmigrateversion.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Replace SCHEMA_* values in service migration scripts with the actual values
+#
+
+if [ -z "$SCHEMA_MAJOR" ]; then
+    echo "ERROR: Missing required argument SCHEMA_MAJOR"
+    exit 1
+elif [ -z "$SCHEMA_MINOR" ]; then
+    echo "ERROR: Missing required argument SCHEMA_MINOR"
+    exit 1
+elif [ -z "$SCHEMA_REVISION" ]; then
+    echo "ERROR: Missing required argument SCHEMA_REVISION"
+    exit 1
+fi
+
+echo Replacing SCHEMA_MAJOR with $SCHEMA_MAJOR, and
+echo Replacing SCHEMA_MINOR with $SCHEMA_MINOR, and
+echo Replacing SCHEMA_REVISION with $SCHEMA_REVISION
+
+set -e
+
+SED_REGEX="s/SCHEMA_MAJOR/$SCHEMA_MAJOR/g; \
+ s/SCHEMA_MINOR/$SCHEMA_MINOR/g; \
+ s/SCHEMA_REVISION/$SCHEMA_REVISION/g; "
+
+TMP_FILE=replace-zmigrateVersion.tmp
+cd Products/ZenModel/migrate
+for file in `grep -l ZMigrateVersion *.py`
+do
+	echo "Updating $file ..."
+	grep -v ZMigrateVersion $file | sed -e "$SED_REGEX" >$TMP_FILE
+	mv $TMP_FILE $file
+done
+rm -f $TMP_FILE

--- a/zenoss-version.mk
+++ b/zenoss-version.mk
@@ -10,6 +10,7 @@ clean-zenoss-version:
 	rm -f $(ZENOSS_VERSION_BASE)/setup.py
 	rm -rf $(ZENOSS_VERSION_BASE)/src/Zenoss.egg-info
 	rm -rf $(ZENOSS_VERSION_BASE)/build $(ZENOSS_VERSION_BASE)/dist
+	rm -f Products/ZenModel/ZMigrateVersion.py
 
 build-zenoss-version: mk-dist $(WHEEL_ARTIFACT)
 	cp $(WHEEL_ARTIFACT) $(DIST_ROOT)
@@ -21,6 +22,36 @@ build-version-wheel: generate-zversion
 	sed -e 's/%VERSION%/$(VERSION)/g' $(ZENOSS_VERSION_BASE)/setup.py.in > $(ZENOSS_VERSION_BASE)/setup.py
 	$(DOCKER_RUN) "cd /mnt/$(ZENOSS_VERSION_BASE) && python setup.py bdist_wheel"
 
-generate-zversion:
+generate-zversion: generate-zmigrateversion
 	@echo "generating ZVersion.py"
 	sed -e 's/%VERSION_STRING%/$(VERSION)/g; s/%BUILD_NUMBER%/$(BUILD_NUMBER)/g' Products/ZenModel/ZVersion.py.in > Products/ZenModel/ZVersion.py
+
+SED_SCHEMA_REGEX := "\
+    s/%SCHEMA_MAJOR%/$(SCHEMA_MAJOR)/g; \
+    s/%SCHEMA_MINOR%/$(SCHEMA_MINOR)/g; \
+    s/%SCHEMA_REVISION%/$(SCHEMA_REVISION)/g;"
+
+# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
+# for more information about setting these SCHEMA_* values.
+generate-zmigrateversion:
+	@echo "generating ZMigrateVersion.py"
+	sed -e $(SED_SCHEMA_REGEX) Products/ZenModel/ZMigrateVersion.py.in > Products/ZenModel/ZMigrateVersion.py
+
+# The target replace-zmigrationversion should be used just prior to release to lock
+# down the schema versions for a particular release
+replace-zmigrateversion:
+	SCHEMA_MAJOR=$(SCHEMA_MAJOR) SCHEMA_MINOR=$(SCHEMA_MINOR) SCHEMA_REVISION=$(SCHEMA_REVISION) ./replace-zmigrateversion.sh
+
+SCHEMA_FOUND = $(shell grep Migrate.Version Products/ZenModel/migrate/*.py  | grep SCHEMA_)
+
+# The target verify-explicit-zmigrateversion should be invoked as a first step in all release
+# builds to verify that all of the SCHEMA_* variables were replaced with an actual numeric value.
+verify-explicit-zmigrateversion:
+ifeq ($(SCHEMA_FOUND),)
+	@echo "Good - no SCHEMA_* variables found: $(SCHEMA_FOUND)"
+else
+	$(info grep for SCHEMA_ in Products/ZenModel/migrate/*.py found:)
+	$(info $(SCHEMA_FOUND))
+	$(error At least one of the SCHEMA_* variables found)
+endif
+


### PR DESCRIPTION
Cherry-pick changes from https://github.com/zenoss/zenoss-prodbin/pull/2605 to improve handling of SCHEMA versions between releases.  

For more details, see https://github.com/zenoss/zenoss-prodbin/pull/2605 and the changes to `Products/ZenModel/migrate/README.md` in this PR.