### PR TITLE
Cleanup catalogservice removal

### DIFF
--- a/Products/ZenModel/migrate/addSolrService.py
+++ b/Products/ZenModel/migrate/addSolrService.py
@@ -44,6 +44,13 @@ class AddSolrService(Migrate.Step):
             ctx.deployService(json.dumps(new_solr), infrastructure)
             changed = True
 
+        # Remove the zencatalogservice-uri global conf option from the top service
+        zenoss = ctx.getTopService()
+        global_conf = zenoss._Service__data.get("Context", None)
+        if global_conf and global_conf.get("global.conf.zencatalogservice-uri", None):
+            del global_conf["global.conf.zencatalogservice-uri"]
+            changed = True
+
         # Now healthchecks
         solr_answering_healthcheck = HealthCheck(
             name="solr_answering",
@@ -62,6 +69,14 @@ class AddSolrService(Migrate.Step):
                 ctx.services.remove(svc)
                 changed = True
                 continue
+            # Remove zencatalogservice response prereq from zenhub and add solr one
+            if svc.name == "zenhub":
+                for pr in svc.prereqs[:]:
+                    if pr.name == "zencatalogservice response":
+                        svc.prereqs.remove(pr)
+                        svc.prereqs.append(sm.Prereq(name='Solr answering', script="""curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"""))
+                        changed = True
+                        break
             # If we've got a solr_answering health check, we can stop.
             # Otherwise, remove catalogservice health checks and add Solr ones
             if filter(lambda c: c.name == 'solr_answering', svc.healthChecks):

--- a/Products/ZenModel/migrate/addSolrService.py
+++ b/Products/ZenModel/migrate/addSolrService.py
@@ -69,14 +69,13 @@ class AddSolrService(Migrate.Step):
                 ctx.services.remove(svc)
                 changed = True
                 continue
-            # Remove zencatalogservice response prereq from zenhub and add solr one
-            if svc.name == "zenhub":
-                for pr in svc.prereqs[:]:
-                    if pr.name == "zencatalogservice response":
-                        svc.prereqs.remove(pr)
-                        svc.prereqs.append(sm.Prereq(name='Solr answering', script="""curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"""))
-                        changed = True
-                        break
+            # Remove zencatalogservice response prereq and add solr one
+            for pr in svc.prereqs[:]:
+                if pr.name == "zencatalogservice response":
+                    svc.prereqs.remove(pr)
+                    svc.prereqs.append(sm.Prereq(name='Solr answering', script="""curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"""))
+                    changed = True
+                    break
             # If we've got a solr_answering health check, we can stop.
             # Otherwise, remove catalogservice health checks and add Solr ones
             if filter(lambda c: c.name == 'solr_answering', svc.healthChecks):

--- a/Products/ZenModel/migrate/addSolrService.py
+++ b/Products/ZenModel/migrate/addSolrService.py
@@ -97,6 +97,7 @@ class AddSolrService(Migrate.Step):
 
 def default_solr_service(imageid):
     return {
+        "ID": "abcd",
         "CPUCommitment": 2,
         "Command": "/bin/supervisord -n -c /opt/solr/zenoss/etc/supervisor.conf",
         "ConfigFiles": {

--- a/Products/ZenModel/migrate/addSolrService.py
+++ b/Products/ZenModel/migrate/addSolrService.py
@@ -75,7 +75,6 @@ class AddSolrService(Migrate.Step):
                     svc.prereqs.remove(pr)
                     svc.prereqs.append(sm.Prereq(name='Solr answering', script="""curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"""))
                     changed = True
-                    break
             # If we've got a solr_answering health check, we can stop.
             # Otherwise, remove catalogservice health checks and add Solr ones
             if filter(lambda c: c.name == 'solr_answering', svc.healthChecks):

--- a/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5-addSolrService.json
+++ b/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5-addSolrService.json
@@ -18487,6 +18487,7 @@
      "DatabaseVersion": 5
    },
   {
+    "ID": "abcd",
     "Tags": [
       "daemon"
     ],

--- a/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5-addSolrService.json
+++ b/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5-addSolrService.json
@@ -5321,8 +5321,8 @@
          "Script": "su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --usedb zodb --execsql=\";\"'"
        },
        {
-         "Name": "zencatalogservice response",
-         "Script": "curl -s http://localhost:8085/zencatalogservice/api/1.0/catalog/acceptingRequests | grep -q True"
+         "Name": "Solr answering",
+         "Script": "curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"
        }
      ],
      "MonitoringProfile": {
@@ -17489,7 +17489,6 @@
        "global.conf.amqpvhost": "/zenoss",
        "global.conf.zauth-password": "MY_PASSWORD",
        "global.conf.zauth-username": "zenoss_system",
-       "global.conf.zencatalogservice-uri": "http://127.0.0.1:8085",
        "global.conf.zep-admin-password": "",
        "global.conf.zep-admin-user": "root",
        "global.conf.zep-db": "zenoss_zep",
@@ -18568,7 +18567,7 @@
         "VHostList": [
           {
             "Enabled": false,
-            "Name": "solr" 
+            "Name": "solr"
           }
         ],
         "Application": "zodb_solr",

--- a/Products/ZenUI3/browser/resources/js/zenoss/manufacturers/ManufacturersConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/manufacturers/ManufacturersConsole.js
@@ -555,16 +555,25 @@ Ext.onReady(function(){
                 onSetContext: function(uid) {
                     Zenoss.env.PARENT_CONTEXT = uid;
                 },
+                hidden: Zenoss.Security.doesNotHavePermission('Manage DMD'),                
                 onGetMenuItems: function() {
                     var menuItems = [];
                     menuItems.push({
                         xtype: 'menuitem',
                         text: _t('Edit'),
-                        hidden: Zenoss.Security.doesNotHavePermission('Manage DMD'),
                         handler: function() {
                             var node = getSelectedManufacturer();
                             var uid = node.data.uid;
                             Zenoss.manufacturers.callEditManufacturerDialog(node.data.text.text, uid);
+                        }
+                    },
+                    {
+                        xtype: 'menuitem',
+                        text: _t('Add to ZenPack'),
+                        handler: function(){
+                            win = Ext.create('Zenoss.AddToZenPackWindow', {});
+                            win.target = getSelectedManufacturer().data.uid;
+                            win.show();
                         }
                     });
                     return menuItems;

--- a/bin/remove_CatalogServiceZenPack.sh
+++ b/bin/remove_CatalogServiceZenPack.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Removing Catalog Service"
-CATALOG_SERVICE_EGG=`find /opt/zenoss/.ZenPacks/ -name ZenPacks.zenoss.CatalogService*`
+CATALOG_SERVICE_EGG=`find /opt/zenoss/.ZenPacks/ -name ZenPacks.zenoss.CatalogService* | head -n 1`
 if [[ -z "$CATALOG_SERVICE_EGG" ]]; then
   echo "Catalog Service egg not found.  Exiting removal script."
   exit


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28341

`find /opt/zenoss/.ZenPacks/ -name ZenPacks.zenoss.CatalogService*` caused the issue in ZEN-28341, as a system could have multiple versions of CatalogService ZenPack, but during investigation, I discovered a few more problems with the migration and fixed those up.