### PR TITLE
ZEN-28105 Do not monitor interface if admin status is down

### DIFF
--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -542,6 +542,17 @@ class IpInterface(OSComponent, Layer2Linkable):
         return []
 
 
+    def monitored(self):
+        '''
+        Return True if this instance should be monitored. False
+        otherwise.
+        '''
+        if self.adminStatus > 1:
+            return False
+        else:
+            return super(IpInterface, self).monitored()
+
+
     def snmpIgnore(self):
         """
         Ignore interface that are administratively down.

--- a/Products/ZenReports/tests/testInterfacePlugin.py
+++ b/Products/ZenReports/tests/testInterfacePlugin.py
@@ -21,6 +21,7 @@ def createInterface( device, id, speed, inputOctets, outputOctets,
     device.os.addIpInterface( id, False )
     interface = device.os.interfaces._getOb( id )
     interface.speed=speed
+    interface.adminStatus = 1
     interface.ifInputOctets_ifInputOctets=inputOctets
     interface.ifOutputOctets_ifOutputOctets=outputOctets
     for key, value in properties.iteritems():


### PR DESCRIPTION
ports from https://github.com/zenoss/zenoss-prodbin/pull/2559 and https://github.com/zenoss/zenoss-prodbin/pull/2567
[Jira](https://jira.zenoss.com/browse/ZEN-28105)