### PR TITLE
ZEN-22112 All on same graph check issues flare

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/ComponentGraphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/ComponentGraphPanel.js
@@ -214,21 +214,22 @@
         updateGraphs: function() {
             var meta_type = this.compType, uid = this.uid,
                 graphId = this.graphId, allOnSame = this.allOnSame.checked;
-            Zenoss.remote.DeviceRouter.getComponentGraphs({
-                uid: uid,
-                meta_type: meta_type,
-                graphId: graphId,
-                allOnSame: allOnSame
-            }, function(response){
-                if (response.success) {
-                    var graphs=[], fn;
-                    this.removeAll();
-                    fn = ZC.getComponentGraphRenderer(meta_type);
-                    graphs = fn(meta_type, uid, graphId, allOnSame, response.data);
-                    this.add(graphs);
-                }
-            }, this);
-
+            if (graphId != undefined) {
+                Zenoss.remote.DeviceRouter.getComponentGraphs({
+                    uid: uid,
+                    meta_type: meta_type,
+                    graphId: graphId,
+                    allOnSame: allOnSame
+                }, function(response){
+                    if (response.success) {
+                        var graphs=[], fn;
+                        this.removeAll();
+                        fn = ZC.getComponentGraphRenderer(meta_type);
+                        graphs = fn(meta_type, uid, graphId, allOnSame, response.data);
+                        this.add(graphs);
+                    }
+                }, this);
+            }
         }
     });
 

--- a/Products/ZenUI3/browser/resources/js/zenoss/form/ComponentGraphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/ComponentGraphPanel.js
@@ -214,7 +214,7 @@
         updateGraphs: function() {
             var meta_type = this.compType, uid = this.uid,
                 graphId = this.graphId, allOnSame = this.allOnSame.checked;
-            if (graphId != undefined) {
+            if (graphId !== undefined) {
                 Zenoss.remote.DeviceRouter.getComponentGraphs({
                     uid: uid,
                     meta_type: meta_type,


### PR DESCRIPTION
Yellow flare issued after checking "all on same graph" checkbox on components graph panel when device contains no components.   Now checks for valid component ID before trying to update graph.