### PR TITLE
Don't allow attempts to add the same RMMonitor device twice.

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -637,6 +637,9 @@ class DeviceFacade(TreeFacade):
             if brain.getObject().getPerformanceServerName() == collector:
                 return brain.getObject()
 
+    def getDeviceByName(self, deviceName):
+        return self.context.Devices.findDeviceByIdExact(deviceName)
+
     @info
     def setCollector(self, uids, collector, moveData=False, asynchronous=True):
         # Keep 'moveData' in signature even though it's unused now

--- a/Products/Zuul/routers/device.py
+++ b/Products/Zuul/routers/device.py
@@ -1554,14 +1554,17 @@ class DeviceRouter(TreeRouter):
             title = deviceName
 
         # the device name is used as part of the URL, so any unicode characters
-        # will be stripped before saving. Pre-empt this and make the device name
+        # will be stripped before saving. Preempt this and make the device name
         # safe prior to the uniqueness check.
         safeDeviceName = organizer.prepId(deviceName)
 
-        device = facade.getDeviceByIpAddress(safeDeviceName, collector, manageIp)
-        if device and organizer.getZ('zUsesManageIp', True):
-            return DirectResponse.fail(deviceUid=device.getPrimaryId(),
-                                       msg="Device %s already exists. <a href='%s'>Go to the device</a>" % (deviceName, device.getPrimaryId()))
+        deviceByIp = facade.getDeviceByIpAddress(safeDeviceName, collector, manageIp)
+        deviceByName = facade.getDeviceByName(safeDeviceName)
+        if deviceByIp and organizer.getZ('zUsesManageIp', True) \
+                or deviceByName and deviceClass == deviceByName.getDeviceClassName():
+            primaryId = deviceByName.getPrimaryId() if deviceByName.getDeviceClassName() == deviceClass else deviceByIp.getPrimaryId()
+            return DirectResponse.fail(deviceUid=primaryId,
+                                       msg="Device %s already exists. <a href='%s'>Go to the device</a>" % (deviceName, primaryId))
 
         if isinstance(systemPaths, basestring):
             systemPaths = [systemPaths]


### PR DESCRIPTION
This now will stop attempts to add the same RMMonitor twice, but still lets most device classes use manageIp the way they used to.