### PR TITLE
ZEN-28293: add code to redact method, invoke from router

### DIFF
--- a/Products/ZenUtils/Redactor.py
+++ b/Products/ZenUtils/Redactor.py
@@ -1,0 +1,48 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+""" Redactor
+
+Redact fields from dictionaries within arbitrarily complex objects.
+Useful for removing passwords from objects when logging.
+"""
+
+
+def keymatch(k, v, candidates=[]):
+    """
+    Default Callback for redact function.
+    :param k: dictionary item key
+    :param v: dictionary item value
+    :param candidates: list of candidate strings
+    :return: "<REDACTED>" if k is in candidate list. Else, v
+    """
+    if k in candidates:
+        return "<REDACTED>"
+    return v
+
+
+def redact(obj, names=[], callback=keymatch):
+    """
+    Replace specific (e.g. password) fields in a complex data structure
+    Iterates recursively through obj, looking for dictionary entries with a
+    key matching the 'name' parameter.
+    Any dictionary entries matching 'name' have their values replaced
+    with the result of a call to callback.
+    :param obj: The data structure to redact
+    :param names: Array of names of dictionary key to redact
+    :param callback: Function to replace dictionary values.
+    :return: copy of object with redactions done as appropriate
+    """
+    if isinstance(obj, dict):
+        return {k: redact(callback(k, v, names), names, callback)
+                for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [redact(elem, names, callback) for elem in obj]
+    else:
+        return obj

--- a/Products/ZenUtils/extdirect/router.py
+++ b/Products/ZenUtils/extdirect/router.py
@@ -11,6 +11,8 @@ import inspect
 import os
 import logging
 import time
+
+from Products.ZenUtils.Redactor import redact
 from Products.ZenUtils.jsonutils import json, unjson
 import transaction
 from uuid import uuid4
@@ -182,7 +184,7 @@ class DirectRouter(object):
             response.result = _targetfn(**data)
         except Exception as e:
             import traceback
-            log.info("Direct request failed: {0}: {1[action]}.{1[method]} {1[data]}".format(e, directRequest))
+            log.info("Direct request failed: {0}: {1[action]}.{1[method]} {1[data]}".format(e, redact(directRequest, ["managerPassword"])))
             log.info("DirectRouter suppressed the following exception (Response {0}):\n{1}".format(response.uuid, traceback.format_exc()))
             response.result = DirectResponse.exception(e)
 

--- a/Products/ZenUtils/tests/test_redactor.py
+++ b/Products/ZenUtils/tests/test_redactor.py
@@ -1,0 +1,250 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+"""Tests for Products.ZenUtils.Redactor module."""
+
+import unittest
+
+from Products.ZenUtils import Redactor
+
+
+class TestRedactor(unittest.TestCase):
+    def test_redact_simple_object_returns_object2(self):
+        subj = "hello"
+        tr = Redactor.redact(subj)
+        self.assertEqual(tr, subj, "redact simple object should return object")
+
+    def test_simple_list2(self):
+        subj = ["hello", 1, 2, 3, "password"]
+        tr = Redactor.redact(subj)
+        self.assertEqual(tr, subj, "redact list should return list")
+
+    def test_simple_dict_no_match2(self):
+        subj = {"foo": "bar", "baz": 1, "bletch": "a thing"}
+        tr = Redactor.redact(subj)
+        self.assertEqual(tr, subj,
+                         "redact nonmatching dict should return dict")
+
+    def test_redact_complicated_object2(self):
+        subj = [
+            "foo",
+            {
+                "bar": "baz",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            ["sublist", 1, 2, "password"],
+        ]
+        tr = Redactor.redact(subj)
+        self.assertEqual(tr, subj, "complicated object should return same")
+
+    def test_redact_simple_dict2(self):
+        subj = {"foo": "something", "bar": 25, "password": "it is a secret"}
+        expected = {"foo": "something", "bar": 25, "password": "<REDACTED>"}
+        tr = Redactor.redact(subj, "password")
+        self.assertEqual(tr, expected,
+                         "password should be redacted in simple dictionary")
+
+    def test_redact_complicated_obj2(self):
+        subj = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "itsasecret",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            ["sublist", 1, 2],
+        ]
+        expected = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "<REDACTED>",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            ["sublist", 1, 2],
+        ]
+        tr = Redactor.redact(subj, "password")
+        self.assertEqual(tr, expected,
+                         "password should be redacted in complex object")
+
+    def test_redact_multimatch2(self):
+        subj = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "itsasecret",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            {
+                "la": "la",
+                "password": "anotherone",
+                "blah": "blah value"
+            },
+            ["sublist", 1, 2],
+        ]
+        expected = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "<REDACTED>",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            {
+                "la": "la",
+                "password": "<REDACTED>",
+                "blah": "blah value"
+            },
+            ["sublist", 1, 2],
+        ]
+        tr = Redactor.redact(subj, "password")
+        self.assertEqual(tr, expected,
+                         "password should be redacted in complex object")
+
+    def test_redact_multimatch_multitarget2(self):
+        subj = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "itsasecret",
+                "A": 1,
+                "B": [1, 2, 'ABC']
+            },
+            {
+                "la": "la",
+                "password": "anotherone",
+                "blah": "blah value"
+            },
+            ["sublist", 1, 2],
+        ]
+        expected = [
+            "foo",
+            {
+                "bar": "baz",
+                "password": "<REDACTED>",
+                "A": 1,
+                "B": "<REDACTED>"
+            },
+            {
+                "la": "la",
+                "password": "<REDACTED>",
+                "blah": "blah value"
+            },
+            ["sublist", 1, 2],
+        ]
+        tr = Redactor.redact(subj, ["password", "B"])
+        self.assertEqual(tr, expected,
+                         "password should be redacted in complex object")
+
+    def test_sample_case2(self):
+        subj = [
+            {
+                "mapLDAPGroupsToZenossRoles": "True",
+                "managerDN": "cn=admin,dc=zenoss-testing,dc=zenoss,dc=loc",
+                "defaultUserRoles": [
+                    "ZenUser"
+                ],
+                "userBaseDN": "dc=Users",
+                "activeDirectory": "True",
+                "managerPassword": "mypassword",
+                "servers": [
+                    {
+                        "ssl": "False",
+                        "host": "test-ldap-1.zenoss.loc",
+                        "port": "389",
+                        "self_signed_cert": "False"
+                    }
+                ],
+                "loginNameAttr": "cn",
+                "newId": "test-ldap-1.zenoss.loc",
+                "extraUserFilter": "(cn=Organization.blah)",
+                "extraGroupFilter": "(cn=something)",
+                "schemaMappings": [
+                    {
+                        "friendlyName": "Canonical Name",
+                        "ldapMapToName": "",
+                        "ldapattr": "cn",
+                        "multivalued": "False"
+                    },
+                    {
+                        "friendlyName": "Email Address",
+                        "ldapMapToName": "email",
+                        "ldapattr": "mail",
+                        "multivalued": "False"
+                    },
+                    {
+                        "friendlyName": "Last Name",
+                        "ldapMapToName": "",
+                        "ldapattr": "sn",
+                        "multivalued": "False"
+                    }
+                ],
+                "groupMappings": [],
+                "groupBaseDN": "dc=zenoss",
+                "id": "test-ldap-1.zenoss.loc"
+            }
+        ]
+        expected = [
+            {
+                "mapLDAPGroupsToZenossRoles": "True",
+                "managerDN": "cn=admin,dc=zenoss-testing,dc=zenoss,dc=loc",
+                "defaultUserRoles": [
+                    "ZenUser"
+                ],
+                "userBaseDN": "dc=Users",
+                "activeDirectory": "True",
+                "managerPassword": "<REDACTED>",
+                "servers": [
+                    {
+                        "ssl": "False",
+                        "host": "test-ldap-1.zenoss.loc",
+                        "port": "389",
+                        "self_signed_cert": "False"
+                    }
+                ],
+                "loginNameAttr": "cn",
+                "newId": "test-ldap-1.zenoss.loc",
+                "extraUserFilter": "(cn=Organization.blah)",
+                "extraGroupFilter": "(cn=something)",
+                "schemaMappings": [
+                    {
+                        "friendlyName": "Canonical Name",
+                        "ldapMapToName": "",
+                        "ldapattr": "cn",
+                        "multivalued": "False"
+                    },
+                    {
+                        "friendlyName": "Email Address",
+                        "ldapMapToName": "email",
+                        "ldapattr": "mail",
+                        "multivalued": "False"
+                    },
+                    {
+                        "friendlyName": "Last Name",
+                        "ldapMapToName": "",
+                        "ldapattr": "sn",
+                        "multivalued": "False"
+                    }
+                ],
+                "groupMappings": [],
+                "groupBaseDN": "dc=zenoss",
+                "id": "test-ldap-1.zenoss.loc"
+            }
+        ]
+        tr = Redactor.redact(subj, "managerPassword")
+        self.assertEqual(tr, expected,
+                         "password should be redacted in object from real life")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
fixes ZEN-28293.

Added redactor routine, which traverses class and replaces values of any dictionary entry whose key matches the passed-in value. Invoked this on object being logged from router.py.

# Unit test run:
```
(zenoss) [zenoss@7376edd42c15 ~]$ runtests -t unit -n TestRedactor Products.ZenUtils
==============================

Packages to be tested:
	Products.ZenUtils

==============================
Parsing /opt/zenoss/etc/zope.conf
Running tests at level 1
Running zope.testrunner.layer.UnitTests tests:
  Set up zope.testrunner.layer.UnitTests in 0.000 seconds.
  Running:
.........
  Ran 9 tests with 0 failures and 0 errors in 0.001 seconds.
Tearing down left over layers:
  Tear down zope.testrunner.layer.UnitTests in 0.000 seconds.
(zenoss) [zenoss@7376edd42c15 ~]$ 
```
# Screenshot of result:
![kibana - google chrome_004](https://user-images.githubusercontent.com/7365929/29847565-e9c12230-8ce1-11e7-8433-b0425ec26116.png)
