### PR TITLE
Bump version to 5.3.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -7,7 +7,7 @@
 # a value like "support/5.2.x" is NOT valid because it will result in an
 # incorrect file name when full value of ARTIFACT is expanded by make.
 #
-VERSION  ?= 5.3.1
+VERSION  ?= 5.3.2
 BUILD_NUMBER ?= DEV
 BRANCH ?= support-5.3.x
 


### PR DESCRIPTION
The tip of support/5.3.x should be versioned as 5.3.2 now that we're in the process of releasing a hotfix for ZEN-28477 as 5.3.1