### PR TITLE
Remove zodb_zencatalogservice endpoint imports

### DIFF
--- a/Products/ZenModel/migrate/addSolrService.py
+++ b/Products/ZenModel/migrate/addSolrService.py
@@ -85,10 +85,12 @@ class AddSolrService(Migrate.Step):
                     svc.healthChecks.remove(hc)
                     changed = True
 
-            # Get rid of erroneous "solr" endpoints that some older migrations added
-            for ep in svc.endpoints:
-                if ep.purpose == 'import' and ep.application == 'solr':
-                    svc.endpoints.remove(ep)
+            # Get rid of erroneous "solr" endpoints that some older migrations added and the "zodb_zencatalogservice" endpoint import that zenimpactstate may have
+            eps_to_remove = filter(lambda ep: ep.purpose == 'import' and (ep.application == 'solr' or ep.application == 'zodb_zencatalogservice'), svc.endpoints)
+
+            for ep in eps_to_remove:
+                changed = True
+                svc.endpoints.remove(ep)
 
             for ep in svc.endpoints:
                 if ep.purpose == 'import' and ep.application == 'zodb_.*':

--- a/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5_badSolrEP.json
+++ b/Products/ZenModel/migrate/tests/zenoss-resmgr-5.1.5_badSolrEP.json
@@ -2779,6 +2779,33 @@
            "EndpointName": ""
          },
          "PortList": null
+       },
+       {
+         "Name": "zencatalogservice",
+         "Purpose": "import",
+         "Protocol": "tcp",
+         "PortNumber": 8085,
+         "PortTemplate": "",
+         "VirtualAddress": "",
+         "Application": "zodb_zencatalogservice",
+         "ApplicationTemplate": "zodb_zencatalogservice",
+         "AddressConfig": {
+           "Port": 0,
+           "Protocol": ""
+         },
+         "VHosts": null,
+         "VHostList": [],
+         "AddressAssignment": {
+           "ID": "",
+           "AssignmentType": "",
+           "HostID": "",
+           "PoolID": "",
+           "IPAddr": "",
+           "Port": 0,
+           "ServiceID": "",
+           "EndpointName": ""
+         },
+         "PortList": []
        }
      ],
      "Tasks": null,


### PR DESCRIPTION
resolves issue that caused ZEN-27842 to be re-opened.

See also https://jira.zenoss.com/browse/IMP-243