### PR TITLE
Added in comments to show examples of the last two grok patterns

### DIFF
--- a/Products/ZenModel/migrate/data/nginx_error-6.0.0.conf
+++ b/Products/ZenModel/migrate/data/nginx_error-6.0.0.conf
@@ -4,6 +4,8 @@ grok {
     # Matches messages like the messages below:
     # 2017/08/30 20:17:37 [error] 85#0: *41 upstream prematurely closed connection while reading response header from upstream, client: 172.17.42.1, server: , request: "HEAD /ping/status/performance HTTP/1.1", upstream: "http://127.0.0.1:8888/ping/status", host: "localhost:8080"
     # 2017/08/31 14:58:09 [notice] 4802#0: signal process started
+    # request: "GET /ws/metrics/store HTTP/1.1"
+    # upstream: "http://127.0.0.1:8443/ws/metrics/store"
 
     match => { "message" => [
         "^(?<datetime>%{YEAR}[./-]%{MONTHNUM}[./-]%{MONTHDAY}[- ]%{TIME}) \[%{LOGLEVEL:loglevel}\] %{POSINT:pid}#%{NUMBER:tid}: %{DATA:message}",


### PR DESCRIPTION
This simple change just adds two comment lines to further clarify the log filter test cases per a request. https://jira.zenoss.com/browse/CC-3874
