### PR TITLE
ZEN-28551 Correct error handling in case target component was not found

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -124,9 +124,10 @@ class DeviceFacade(TreeFacade):
             for i, b in enumerate(comps):
                 if '/'.join(b._object.getPrimaryPath())==componentUid:
                     return i
-        for i, b in enumerate(brains):
-            if b.getPath() == componentUid:
-                return i
+        else:
+            for i, b in enumerate(brains):
+                if b.getPath() == componentUid:
+                    return i
 
     def _filterComponents(self, comps, keys, query):
         """


### PR DESCRIPTION
[Jira](https://jira.zenoss.com/browse/ZEN-28551)

Add checker to prevent TypeError in case link from grid of some component redirects user to different device instead of some component