### PR TITLE
Create an inactivity timer to reload the console to avoid unbounded

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EvConsole.js
@@ -225,4 +225,28 @@ Ext.onReady(function(){
             });
     }
 
+    // ZEN-28542: memory leak, unclear if it's from our extensions to
+    // Ext or Ext itself. Set up activity listeners and reload the page
+    // after 1 hour of inactivity.
+    var timeoutID;
+    var body = Ext.getBody();
+    body.on('mousemove', resetInactive);
+    body.on('keydown', resetInactive);
+
+    function resetInactive() {
+        clearTimeout(timeoutID);
+        startInactive();
+    }
+
+    function startInactive() {
+        timeoutID = setTimeout(doReload, 1000 * 60 * 60);
+    }
+
+    function doReload() {
+        grid.destroy();
+        window.location.reload();
+    }
+
+    startInactive();
+
 });


### PR DESCRIPTION
Create an inactivity timer to reload the console to avoid unbounded memory usage.

Not a "surgical" memory leak fix, but after looking at heap dumps and allocation profiles, it's unclear where the leakage is coming from. There are detached DOM nodes present, but hard to say where those are getting referenced. Observing and calling destroy() on the grid and reloading hourly kept memory usage level over a weekend.