### PR TITLE
Added in code to set the logging for twisted to none

### DIFF
--- a/Products/ZenUtils/ZenDaemon.py
+++ b/Products/ZenUtils/ZenDaemon.py
@@ -21,6 +21,7 @@ import socket
 import logging
 
 from twisted.python import log as twisted_log
+from twisted.logger import globalLogBeginner
 
 from Products.ZenMessaging.audit import audit
 from Products.ZenUtils.CmdBase import CmdBase
@@ -152,6 +153,9 @@ class ZenDaemon(CmdBase):
         """
         Create formating for log entries and set default log level
         """
+        # Initialize twisted logging to go nowhere. (it may be re-enabled by SIGUSR1)
+        globalLogBeginner.beginLoggingTo([lambda x: None], redirectStandardIO=False, discardBuffer=True)
+
         # Setup python logging module
         rootLog = logging.getLogger()
         rootLog.setLevel(logging.WARN)


### PR DESCRIPTION
This is a change to fix the memory leak / holding of twisted when the logger for twisted is never initialized.  https://jira.zenoss.com/browse/ZEN-28629