### PR TITLE
ZEN-28610 Removing audit logs from '/authorization/login' path

### DIFF
--- a/Products/ZenUtils/patches/pasmonkey.py
+++ b/Products/ZenUtils/patches/pasmonkey.py
@@ -142,7 +142,7 @@ def validate(self, request, auth='', roles=_noroles):
 
     anonymous = self._createAnonymousUser(plugins)
     if self._authorizeUser(anonymous, accessed, container, name, value, roles):
-        if name == 'login':
+        if name == 'login' and '/authorization/login' not in request.environ.get('PATH_INFO', ''):
             username_ = request.form.get('__ac_name', 'Unknown')
             audit('UI.Authentication.Failed', username_=username_, ipaddress=ipaddress)
         return anonymous


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28610
port https://github.com/zenoss/zenoss-prodbin/pull/2720