### PR TITLE
ZEN-28699: regex work again without any escaping

### DIFF
--- a/Products/Zuul/catalog/model_catalog_tool.py
+++ b/Products/Zuul/catalog/model_catalog_tool.py
@@ -119,7 +119,6 @@ class ModelCatalogTool(object):
         permissions_query = None
 
         partial_queries = []
-
         if query:
             """
             # if query is a dict, we convert it to AdvancedQuery
@@ -141,9 +140,9 @@ class ModelCatalogTool(object):
             for key, value in globFilters.iteritems():
                 if key in available_indexes:
                     if user_filters_query:
-                        user_filters_query = And(query, MatchRegexp(key, '*%s*' % value))
+                        user_filters_query = And(query, MatchRegexp(key, '.*%s.*' % value))
                     else:
-                        user_filters_query = MatchRegexp(key, '*%s*' % value)
+                        user_filters_query = MatchRegexp(key, '.*%s.*' % value)
                 else:
                     not_indexed_user_filters[key] = value
 


### PR DESCRIPTION
If you search on with the help of regex it was not working
and if there was an escape character it was causing
a ModelCatalogError flare message.
Make regex compatible with re.compile function.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-28699)

related PR https://github.com/zenoss/modelindex/pull/72