### PR TITLE
ZEN-28765: sort templates in a right order

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -721,9 +721,16 @@ class DeviceFacade(TreeFacade):
 
     def _getBoundTemplates(self, uid, isBound):
         obj = self._getObject(uid)
-        for template in obj.getAvailableTemplates():
-            if (template.id in obj.zDeviceTemplates) == isBound:
-                yield template
+        templates = (
+            template
+            for template in obj.getAvailableTemplates()
+            if (template.id in obj.zDeviceTemplates) == isBound
+        )
+        if isBound:
+            templates = sorted(
+                templates, key=lambda x: obj.zDeviceTemplates.index(x.id)
+            )
+        return templates
 
     def setBoundTemplates(self, uid, templateIds):
         obj = self._getObject(uid)


### PR DESCRIPTION
When you reorder templates in a 'Bind Templates' window
an order of selected wasn't shown after you reopen a window.
Sort templates according to zDeviceTemplates property.

this is cherry-picking from https://github.com/zenoss/zenoss-prodbin/pull/2776

[JIRA](https://jira.zenoss.com/browse/ZEN-28765)