### PR TITLE
Add alias ID naming restrictions.

### DIFF
--- a/Products/ZenModel/RRDDataPointAlias.py
+++ b/Products/ZenModel/RRDDataPointAlias.py
@@ -1,85 +1,85 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2009, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
-
-__doc__="""RRDDataPointAlias
+"""RRDDataPointAlias
 
 Create a simple level of indirection for normalization of data.  An alias is
 a pair of a name and an rpn formula.  The formula should convert the datapoint
 to the form represented by the name.
+"""
 
-$Id:$"""
+from AccessControl import Permissions
+
 import Globals
-from AccessControl import ClassSecurityInfo, Permissions
 
 from Products.ZenUtils.ZenTales import talesEvalStr
 from Products.ZenRelations.RelSchema import ToOne, ToManyCont
 from Products.ZenModel.ZenModelRM import ZenModelRM
 from Products.ZenModel.ZenPackable import ZenPackable
 from Products.ZenUtils.deprecated import deprecated
+from Products.ZenUtils.Utils import unused
 
+unused(Globals)
 
 ALIAS_DELIMITER = ','
 EVAL_KEY = '__EVAL:'
 
+
 @deprecated
-def manage_addDataPointAlias( context, id, formula=None ):
+def manage_addDataPointAlias(context, id, formula=None):
     """
     Add a datapoint alias to the datapoint given
     """
-    alias = RRDDataPointAlias( id )
+    alias = RRDDataPointAlias(id)
     alias.formula = formula
-    context.aliases._setObject( id, alias )
-    return context.aliases._getOb( id )
+    context.aliases._setObject(id, alias)
+    return context.aliases._getOb(id)
+
 
 class RRDDataPointAlias(ZenModelRM, ZenPackable):
-    
+
     meta_type = 'RRDDataPointAlias'
     formula = None
-    
+
     _properties = (
-        {'id':'formula', 'type':'string', 'mode':'w'},
-        )
+        {'id': 'formula', 'type': 'string', 'mode': 'w'},
+    )
 
-    _relations = ZenPackable._relations + (
-        ("datapoint", ToOne(ToManyCont,"Products.ZenModel.RRDDataPoint","aliases")),
-        )
-
+    _relations = ZenPackable._relations + ((
+        "datapoint",
+        ToOne(ToManyCont, "Products.ZenModel.RRDDataPoint", "aliases")
+    ),)
 
     # Screen action bindings (and tab definitions)
-    factory_type_information = ( 
-    { 
-        'immediate_view' : 'editRRDDataPoint',
-        'actions'        :
-        ( 
-            { 'id'            : 'edit'
-            , 'name'          : 'Data Point'
-            , 'action'        : 'editRRDDataPoint'
-            , 'permissions'   : ( Permissions.view, )
-            },
-        )
-    },
-    )
+    factory_type_information = ({
+        'immediate_view': 'editRRDDataPoint',
+        'actions': ({
+            'id':          'edit',
+            'name':        'Data Point',
+            'action':      'editRRDDataPoint',
+            'permissions': (Permissions.view,)
+        },)
+    },)
 
     def evaluate(self, context):
         """
         Evaluate the formula with the given context so that the resulting
         rpn can be applied to the datapoint value.  There are two possible
         layers of evaluation: python and then TALES evaluation.  Both use the
-        name 'here' to name the passed context.  See testRRDDataPointAlias for
-        examples of usage.
+        name 'here' to name the passed context.  See testRRDDataPointAlias
+        for examples of usage.
         """
         if self.formula:
             formula = self.formula
-            if formula.startswith( EVAL_KEY ):
-                formula = formula[ len( EVAL_KEY ): ]
-                formula = str( eval( formula, { 'here' : context } ) )    
-            return talesEvalStr( formula, context ) 
+            if formula.startswith(EVAL_KEY):
+                formula = formula[len(EVAL_KEY):]
+                formula = str(eval(formula, {'here': context}))
+            return talesEvalStr(formula, context)
         else:
             return None

--- a/Products/ZenModel/RRDDataPointAlias.py
+++ b/Products/ZenModel/RRDDataPointAlias.py
@@ -14,6 +14,7 @@ a pair of a name and an rpn formula.  The formula should convert the datapoint
 to the form represented by the name.
 """
 
+import re
 from AccessControl import Permissions
 
 import Globals
@@ -30,12 +31,22 @@ unused(Globals)
 ALIAS_DELIMITER = ','
 EVAL_KEY = '__EVAL:'
 
+_validAliasIDPattern = re.compile("^[\w]+$")
+
+
+def _validateAliasID(id):
+    id = str(id).strip()
+    if _validAliasIDPattern.match(id) is None:
+        raise ValueError("Invalid value for DataPoint alias ID: %s" % (id,))
+    return id
+
 
 @deprecated
 def manage_addDataPointAlias(context, id, formula=None):
     """
     Add a datapoint alias to the datapoint given
     """
+    id = _validateAliasID(id)
     alias = RRDDataPointAlias(id)
     alias.formula = formula
     context.aliases._setObject(id, alias)
@@ -66,6 +77,10 @@ class RRDDataPointAlias(ZenModelRM, ZenPackable):
             'permissions': (Permissions.view,)
         },)
     },)
+
+    def __init__(self, id):
+        id = _validateAliasID(id)
+        super(RRDDataPointAlias, self).__init__(id)
 
     def evaluate(self, context):
         """

--- a/Products/ZenModel/tests/testRRDDataPointAlias.py
+++ b/Products/ZenModel/tests/testRRDDataPointAlias.py
@@ -1,12 +1,11 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
-
 
 import os, sys
 if __name__ == '__main__':
@@ -15,99 +14,113 @@ if __name__ == '__main__':
 
 from ZenModelBaseTest import ZenModelBaseTest
 from Products.ZenModel.Device import manage_createDevice
-from Products.ZenModel.RRDDataPointAlias import RRDDataPointAlias,\
-            EVAL_KEY, manage_addDataPointAlias
-from Products.ZenModel.tests.RRDTestUtils import *
+from Products.ZenModel.RRDDataPointAlias import (
+    RRDDataPointAlias, EVAL_KEY, manage_addDataPointAlias
+)
+from Products.ZenModel.tests.RRDTestUtils import createTemplate
+
 
 def createDevice(dmd, deviceId):
-    return manage_createDevice( dmd, deviceId )
+    return manage_createDevice(dmd, deviceId)
+
 
 class TestRRDDataPointAlias(ZenModelBaseTest):
-    
+
+    def afterSetUp(self):
+        ZenModelBaseTest.afterSetUp(self)
+        self.device = createDevice(self.dmd, 'testdevice')
+        self.device.rackSlot = 5
+
+    def beforeTearDown(self):
+        self.device.deleteDevice()
+        del self.device
+        ZenModelBaseTest.beforeTearDown(self)
 
     def testCreate(self):
         name = 'testalias'
         formula = 'testformula'
-        alias = RRDDataPointAlias( name )
+        alias = RRDDataPointAlias(name)
         alias.formula = formula
-        self.assert_( alias.id == name )
-        self.assert_( alias.formula == formula )
-        
+        self.assert_(alias.id == name)
+        self.assert_(alias.formula == formula)
+
         name2 = 'testalias2'
-        alias = RRDDataPointAlias( name2 )
-        self.assert_( alias.id == name2 )
-        self.assert_( alias.formula is None )
-    
+        alias = RRDDataPointAlias(name2)
+        self.assert_(alias.id == name2)
+        self.assert_(alias.formula is None)
+
     def testCreateByMethod(self):
         aliasName = 'testalias3'
         aliasFormula = 'testformula2'
-        t = createTemplate( self.dmd )
+        t = createTemplate(self.dmd)
         ds0 = t.datasources()[0]
         dp0 = ds0.datapoints()[0]
-        alias = manage_addDataPointAlias( dp0, aliasName, aliasFormula )
-        self.assert_( alias.id == aliasName )
-        self.assert_( alias.formula == aliasFormula )
-        
-    
-    def testEvaluate(self):
-        device = createDevice( self.dmd, 'testdevice')
-        device.rackSlot = 5
-        
-        # No formula
-        alias = RRDDataPointAlias( 'alias1' )
-        self.assert_( alias.evaluate( device ) is None )
-        
+        alias = manage_addDataPointAlias(dp0, aliasName, aliasFormula)
+        self.assert_(alias.id == aliasName)
+        self.assert_(alias.formula == aliasFormula)
+
+    def testNoFormula(self):
+        alias = RRDDataPointAlias('alias1')
+        self.assert_(alias.evaluate(self.device) is None)
+
+    def testEmptyFormula(self):
         # Empty formula
-        alias = RRDDataPointAlias( 'alias2' )
+        alias = RRDDataPointAlias('alias2')
         alias.formula = ''
-        self.assert_( alias.evaluate( device ) is None )
-        
+        self.assert_(alias.evaluate(self.device) is None)
+
+    def testSimpleRPNFormula(self):
         # Simple RPN formula
         simpleRpn = '100,/'
-        alias = RRDDataPointAlias( 'alias3' )
+        alias = RRDDataPointAlias('alias3')
         alias.formula = simpleRpn
-        self.assert_( alias.evaluate( device ) == simpleRpn )
-        
+        self.assert_(alias.evaluate(self.device) == simpleRpn)
+
+    def testSingleSubstitution(self):
         # Single substitution
         singleSubstitution = '100,*,${here/rackSlot},/'
-        alias = RRDDataPointAlias( 'alias4' )
+        alias = RRDDataPointAlias('alias4')
         alias.formula = singleSubstitution
-        self.assert_( alias.evaluate( device ) == '100,*,5,/' )
-        
+        self.assert_(alias.evaluate(self.device) == '100,*,5,/')
+
+    def testMultipleSubstitution(self):
         # Multiple substitution
-        multiSubstitution = '100,*,3,${here/rackSlot},LT,10,20,IF,${here/rackSlot},*'
-        alias = RRDDataPointAlias( 'alias5' )
+        multiSubstitution = \
+            '100,*,3,${here/rackSlot},LT,10,20,IF,${here/rackSlot},*'
+        alias = RRDDataPointAlias('alias5')
         alias.formula = multiSubstitution
-        self.assert_( alias.evaluate( device ) == '100,*,3,5,LT,10,20,IF,5,*' )
-        
+        self.assert_(alias.evaluate(self.device) == '100,*,3,5,LT,10,20,IF,5,*')
+
+    def testNoContext(self):
         # Evaluation (no context)
-        evaluationNoContext = EVAL_KEY + '"100,*," + str( len("12345") ) + ",/"'
-        alias = RRDDataPointAlias( 'alias6' )
+        evaluationNoContext = EVAL_KEY + '"100,*," + str(len("12345")) + ",/"'
+        alias = RRDDataPointAlias('alias6')
         alias.formula = evaluationNoContext
-        self.assert_( alias.evaluate( device ) == '100,*,5,/' )
-        
+        self.assert_(alias.evaluate(self.device) == '100,*,5,/')
+
+    def testWithContext(self):
         # Evaluation (use context)
         evaluationWithContext = EVAL_KEY + \
-            '"100,*," + str( len("12345") * here.rackSlot ) + ",/"'
-        alias = RRDDataPointAlias( 'alias7' )
+            '"100,*," + str(len("12345") * here.rackSlot) + ",/"'
+        alias = RRDDataPointAlias('alias7')
         alias.formula = evaluationWithContext
-        self.assert_( alias.evaluate( device ) == '100,*,25,/' )
-        
+        self.assert_(alias.evaluate(self.device) == '100,*,25,/')
+
+    def testPythonAndTalesContext(self):
         # Evaluation (use context in python and TALES)
         evaluationWithContextUsedTwice = EVAL_KEY + \
-          '"100,*,${here/rackSlot},/," + str( here.rackSlot ) + ",*"'
-        alias = RRDDataPointAlias( 'alias8' )
+            '"100,*,${here/rackSlot},/," + str(here.rackSlot) + ",*"'
+        alias = RRDDataPointAlias('alias8')
         alias.formula = evaluationWithContextUsedTwice
-        self.assert_( alias.evaluate( device ) == '100,*,5,/,5,*' )
-        
-        
-        
-        
+        self.assert_(alias.evaluate(self.device) == '100,*,5,/,5,*')
+
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestRRDDataPointAlias))
     return suite
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     framework()

--- a/Products/ZenModel/tests/testRRDDataPointAlias.py
+++ b/Products/ZenModel/tests/testRRDDataPointAlias.py
@@ -59,6 +59,39 @@ class TestRRDDataPointAlias(ZenModelBaseTest):
         self.assert_(alias.id == aliasName)
         self.assert_(alias.formula == aliasFormula)
 
+    def testInvalidAliasId(self):
+        with self.assertRaises(ValueError):
+            RRDDataPointAlias('an alias')
+
+        with self.assertRaises(ValueError):
+            RRDDataPointAlias('an$alias')
+
+        t = createTemplate(self.dmd)
+        ds0 = t.datasources()[0]
+        dp0 = ds0.datapoints()[0]
+        with self.assertRaises(ValueError):
+            manage_addDataPointAlias(dp0, 'an alias', '')
+        with self.assertRaises(ValueError):
+            manage_addDataPointAlias(dp0, 'an$alias', '')
+
+    def testTrimmedAliasId(self):
+        alias = RRDDataPointAlias(' alias1')
+        self.assert_(alias.id == 'alias1')
+        alias = RRDDataPointAlias('alias1 ')
+        self.assert_(alias.id == 'alias1')
+        alias = RRDDataPointAlias(' alias1 ')
+        self.assert_(alias.id == 'alias1')
+
+        t = createTemplate(self.dmd)
+        ds0 = t.datasources()[0]
+        dp0 = ds0.datapoints()[0]
+        alias1 = manage_addDataPointAlias(dp0, ' alias1', '')
+        self.assert_(alias1.id == 'alias1')
+        alias2 = manage_addDataPointAlias(dp0, 'alias2 ', '')
+        self.assert_(alias2.id == 'alias2')
+        alias3 = manage_addDataPointAlias(dp0, ' alias3 ', '')
+        self.assert_(alias3.id == 'alias3')
+
     def testNoFormula(self):
         alias = RRDDataPointAlias('alias1')
         self.assert_(alias.evaluate(self.device) is None)

--- a/Products/ZenUI3/browser/resources/js/zenoss/form/alias.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/alias.js
@@ -39,7 +39,8 @@
                  aliasType: 'id',
                  xtype: 'textfield',
                  width:'150',
-                 value: id
+                 value: id,
+                 regex: /^[\w]+$/
              },{
                  aliasType: 'formula',
                  xtype: 'textfield',


### PR DESCRIPTION
These changes have the application enforce the restrictions that have been followed by convention.
The most common violation of the restriction, leading and trailing whitespace in ID of the alias, is handled automatically.  If the alias ID is valid after trimming whitespace from the ends, then the alias is saved using the trimmed value.

Fixes ZEN-28817 and ANA-304.