### PR TITLE
Log invalid alias names.

### DIFF
--- a/Products/ZenModel/RRDDataPointAlias.py
+++ b/Products/ZenModel/RRDDataPointAlias.py
@@ -14,6 +14,7 @@ a pair of a name and an rpn formula.  The formula should convert the datapoint
 to the form represented by the name.
 """
 
+import logging
 import re
 from AccessControl import Permissions
 
@@ -28,6 +29,8 @@ from Products.ZenUtils.Utils import unused
 
 unused(Globals)
 
+LOG = logging.getLogger("zen.RRDDataPointAlias")
+
 ALIAS_DELIMITER = ','
 EVAL_KEY = '__EVAL:'
 
@@ -37,7 +40,7 @@ _validAliasIDPattern = re.compile("^[\w]+$")
 def _validateAliasID(id):
     id = str(id).strip()
     if _validAliasIDPattern.match(id) is None:
-        raise ValueError("Invalid value for DataPoint alias ID: %s" % (id,))
+        LOG.warn("Invalid value for DataPoint alias ID: %s", id)
     return id
 
 

--- a/Products/ZenModel/tests/testRRDDataPointAlias.py
+++ b/Products/ZenModel/tests/testRRDDataPointAlias.py
@@ -59,21 +59,6 @@ class TestRRDDataPointAlias(ZenModelBaseTest):
         self.assert_(alias.id == aliasName)
         self.assert_(alias.formula == aliasFormula)
 
-    def testInvalidAliasId(self):
-        with self.assertRaises(ValueError):
-            RRDDataPointAlias('an alias')
-
-        with self.assertRaises(ValueError):
-            RRDDataPointAlias('an$alias')
-
-        t = createTemplate(self.dmd)
-        ds0 = t.datasources()[0]
-        dp0 = ds0.datapoints()[0]
-        with self.assertRaises(ValueError):
-            manage_addDataPointAlias(dp0, 'an alias', '')
-        with self.assertRaises(ValueError):
-            manage_addDataPointAlias(dp0, 'an$alias', '')
-
     def testTrimmedAliasId(self):
         alias = RRDDataPointAlias(' alias1')
         self.assert_(alias.id == 'alias1')
@@ -91,6 +76,10 @@ class TestRRDDataPointAlias(ZenModelBaseTest):
         self.assert_(alias2.id == 'alias2')
         alias3 = manage_addDataPointAlias(dp0, ' alias3 ', '')
         self.assert_(alias3.id == 'alias3')
+
+    def testAliasWithUnderbar(self):
+        alias = RRDDataPointAlias('alias_1')
+        self.assert_(alias.id == 'alias_1')
 
     def testNoFormula(self):
         alias = RRDDataPointAlias('alias1')


### PR DESCRIPTION
For the moment, invalid alias names are logged rather than raising an exception. This will allow existing ZenPacks to successfully install.

Fixes ZEN-28830.