### PR TITLE
Verify minimum requirements for alias IDs.

### DIFF
--- a/Products/ZenModel/RRDDataPointAlias.py
+++ b/Products/ZenModel/RRDDataPointAlias.py
@@ -34,13 +34,17 @@ LOG = logging.getLogger("zen.RRDDataPointAlias")
 ALIAS_DELIMITER = ','
 EVAL_KEY = '__EVAL:'
 
-_validAliasIDPattern = re.compile("^[\w]+$")
+_validAliasIDPattern = re.compile("^[^\s]+$")
 
 
 def _validateAliasID(id):
     id = str(id).strip()
+    if len(id) > 30:
+        LOG.warn(
+            "Invalid DataPoint alias ID, exceeds 30 character limit: %s", id
+        )
     if _validAliasIDPattern.match(id) is None:
-        LOG.warn("Invalid value for DataPoint alias ID: %s", id)
+        LOG.warn("Invalid DataPoint alias ID, contains whitespace: %s", id)
     return id
 
 

--- a/Products/ZenUI3/browser/resources/js/zenoss/form/alias.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/alias.js
@@ -40,7 +40,8 @@
                  xtype: 'textfield',
                  width:'150',
                  value: id,
-                 regex: /^[\w]+$/
+                 regex: /^[^\s]+$/,
+                 maxLength: 30
              },{
                  aliasType: 'formula',
                  xtype: 'textfield',


### PR DESCRIPTION
This change checks that a datapoint alias ID contains no spaces and does not exceed 30 characters in length.  This should reduce the number of 'invalid alias' log messages when a ZenPack is installed.

The previous requirements were too strict and did not reflect the range of alias IDs that Analytics can support.

Fixes ZEN-28818.