### PR TITLE
Indicate whether a change event was triggered from a maintenance window.

### DIFF
--- a/Products/ZenMessaging/ChangeEvents/subscribers.py
+++ b/Products/ZenMessaging/ChangeEvents/subscribers.py
@@ -34,8 +34,9 @@ def publishRemove(ob, event):
 @adapter(IGloballyIdentifiable, IIndexingEvent)
 def publishModified(ob, event):
     publisher = getModelChangePublisher()
+
     fromMaintWindow = False
-    if event and event.idxs and len(event.idxs) == 1 and 'productionState' in event.idxs:
+    if hasattr(event, 'triggered_by_maint_window') and event.triggered_by_maint_window:
         fromMaintWindow = True
     publisher.publishModified(ob, fromMaintWindow)
 

--- a/Products/ZenModel/ManagedEntity.py
+++ b/Products/ZenModel/ManagedEntity.py
@@ -116,7 +116,9 @@ class ManagedEntity(ZenModelRM, DeviceResultInt, EventView, MetricMixin,
         """
         self._setProductionState(int(state))
 
-        notify(IndexingEvent(self.primaryAq(), ('productionState',), True))
+        indexEvent = IndexingEvent(self.primaryAq(), ('productionState',), True, )
+        indexEvent.triggered_by_maint_window = maintWindowChange
+        notify(indexEvent)
         if not maintWindowChange:
             # Saves our production state for use at the end of the
             # maintenance window.

--- a/Products/Zuul/catalog/events.py
+++ b/Products/Zuul/catalog/events.py
@@ -33,6 +33,7 @@ class IndexingEvent(object):
         self.idxs = idxs
         self.update_metadata = update_metadata
         self.triggered_by_zope_event = triggered_by_zope_event
+        self.triggered_by_maint_window = False
 
 
 def _get_object_to_index(ob):


### PR DESCRIPTION
The impact event listener can check this flag and know it should do a lighter weight productionState change rather than a full graph update for each device in the maintenance window.