### PR TITLE
Set a default production state for devices

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -226,6 +226,9 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
     priority = 3
     macaddresses = None
     renameInProgress = False
+    # ZEN-28849: set a default production state for devices
+    privateattr_productionState = DEFAULT_PRODSTATE
+    privateattr_preMWProductionState = DEFAULT_PRODSTATE
 
     # Flag indicating whether device is in process of creation
     _temp_device = False


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28849
For upgraded devices that have never had a production state set on them, give them a default production state attribute.