### PR TITLE
Set a default batch size for maintenance windows.

### DIFF
--- a/Products/ZenEvents/zenactiond.py
+++ b/Products/ZenEvents/zenactiond.py
@@ -220,7 +220,7 @@ class ZenActionD(ZCmdBase):
             dest='maintenceWindowCycletime', default=60, type="int",
             help="How often to check to see if there are any maintenance windows to execute")
         self.parser.add_option('--maintenance-window-batch-size',
-            dest='maintenceWindowBatchSize', default=None, type="int",
+            dest='maintenceWindowBatchSize', default=200, type="int",
             help="How many devices update per one transaction on maintenance windows execution")
 
         self.parser.add_option("--workerid", dest='workerid', type='int', default=None,


### PR DESCRIPTION
No maintenance window default value is currently set which causes zenactiond to try to update all devices in a maintenance window in a single transaction. For customers with large numbers of devices in main windows, the transaction often fails with timeouts or conflict errors.

This was not an issue when we moved production state to btree storage in late 2016, which is why batching was disabled, but in Thebe, production state moved back to the solr index, so we need to go back to batching by default.