### PR TITLE
Check if the queue exists before creating it

### DIFF
--- a/Products/ZenMessaging/queuemessaging/publisher.py
+++ b/Products/ZenMessaging/queuemessaging/publisher.py
@@ -425,7 +425,9 @@ class BlockingQueuePublisher(object):
                 declareExchange=True):
         if createQueues:
             for queue in createQueues:
-                self._client.createQueue(queue)
+                if not self._client.queueExists(queue):
+                    self.reconnect()
+                    self._client.createQueue(queue)
         self._client.publish(exchange, routing_key, message,
                              mandatory=mandatory, headers=headers,
                              declareExchange=declareExchange)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28918

If the arguments used to create the queue are different from the arguments zenoss-protocols is trying to create it as, the create will fail and we can't connect to the queue.  If the queue exists, use the queue as-is without trying to create it.
