### PR TITLE
Check if the queue exists before creating it

### DIFF
--- a/Products/ZenMessaging/queuemessaging/publisher.py
+++ b/Products/ZenMessaging/queuemessaging/publisher.py
@@ -425,7 +425,9 @@ class BlockingQueuePublisher(object):
                 declareExchange=True):
         if createQueues:
             for queue in createQueues:
-                self._client.createQueue(queue)
+                if not self._client.queueExists(queue):
+                    self.reconnect()
+                    self._client.createQueue(queue)
         self._client.publish(exchange, routing_key, message,
                              mandatory=mandatory, headers=headers,
                              declareExchange=declareExchange)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28918

The port from develop to check if a rabbit queue exists before trying to create it.