### PR TITLE
ZEN-28116: filter components by their production state for config

### DIFF
--- a/Products/ZenModel/ComponentGroup.py
+++ b/Products/ZenModel/ComponentGroup.py
@@ -50,9 +50,7 @@ class ComponentGroup(ComponentOrganizer):
     def getSubComponents(self):
         cat = IModelCatalogTool(self)
         # @TODO: Can we avoid NOTs ?
-        query = And(Not(Eq('objectImplements', 'Products.ZenModel.MaintenanceWindow.MaintenanceWindow')),
-                    Not(Eq('objectImplements', 'Products.ZenModel.ComponentGroup.ComponentGroup')),
-                    Not(Eq('objectImplements', 'Products.ZenModel.Device.Device')))
+        query = Eq('objectImplements', 'Products.ZenModel.DeviceComponent.DeviceComponent')
         brains = cat.search(query=query)
         children = []
         for brain in brains:

--- a/Products/ZenModel/ComponentGroup.py
+++ b/Products/ZenModel/ComponentGroup.py
@@ -50,7 +50,8 @@ class ComponentGroup(ComponentOrganizer):
     def getSubComponents(self):
         cat = IModelCatalogTool(self)
         # @TODO: Can we avoid NOTs ?
-        query = And(Not(Eq('objectImplements', 'Products.ZenModel.ComponentGroup.ComponentGroup')),
+        query = And(Not(Eq('objectImplements', 'Products.ZenModel.MaintenanceWindow.MaintenanceWindow')),
+                    Not(Eq('objectImplements', 'Products.ZenModel.ComponentGroup.ComponentGroup')),
                     Not(Eq('objectImplements', 'Products.ZenModel.Device.Device')))
         brains = cat.search(query=query)
         children = []

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -509,9 +509,9 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         Return list of monitored DeviceComponents on this device.
         Wrapper method for getDeviceComponents
         """
-        return self.getDeviceComponents(monitored=True,
+        components = self.getDeviceComponents(monitored=True,
                                         collector=collector, type=type)
-
+        return filter(lambda x: x.getProductionState() >= x.zProdStateThreshold, components)
 
     security.declareProtected(ZEN_VIEW, 'getReportableComponents')
     def getReportableComponents(self, collector=None, type=None):

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -228,7 +228,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
     renameInProgress = False
     # ZEN-28849: set a default production state for devices
     privateattr_productionState = DEFAULT_PRODSTATE
-    privateattr_preMWProductionState = DEFAULT_PRODSTATE
+    _preMWProductionState = DEFAULT_PRODSTATE
 
     # Flag indicating whether device is in process of creation
     _temp_device = False

--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -555,6 +555,11 @@ class MaintenanceWindow(ZenModelRM):
 
         def _setProdState(devices_batch):
             for device in devices_batch:
+                # In case we try to move Component Group into MW
+                # some of objects in CG may not have production state
+                # we skip them.
+                if not hasattr(device, "privateattr_productionState"):
+                    continue
                 if ending:
                     # Note: If no maintenance windows apply to a device, then the
                     #       device won't exist in minDevProdStates

--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -551,15 +551,13 @@ class MaintenanceWindow(ZenModelRM):
         #       following takes into account our window state too.
         #       Conversely, self.end() ends the window before calling this code.
         devices = self.fetchDevices()
-        minDevProdStates = self.fetchDeviceMinProdStates( devices )
+        minDevProdStates = self.fetchDeviceMinProdStates(devices)
 
         def _setProdState(devices_batch):
             for device in devices_batch:
                 # In case we try to move Component Group into MW
                 # some of objects in CG may not have production state
                 # we skip them.
-                if not hasattr(device, "privateattr_productionState"):
-                    continue
                 if ending:
                     # Note: If no maintenance windows apply to a device, then the
                     #       device won't exist in minDevProdStates
@@ -579,7 +577,7 @@ class MaintenanceWindow(ZenModelRM):
                     continue
 
                 # ZEN-13197: skip decommissioned devices
-                if device.getPreMWProductionState() < 300:
+                if device.getPreMWProductionState() and device.getPreMWProductionState() < 300:
                     continue
 
                 self._p_changed = 1
@@ -594,7 +592,10 @@ class MaintenanceWindow(ZenModelRM):
                     maintenanceWindow=self.displayName(),
                     productionState=newProductionState,
                     oldData_={'productionState':oldProductionState})
-                device.setProdState(minProdState, maintWindowChange=True)
+                if minProdState is None:
+                    device.resetProductionState()
+                else:
+                    device.setProdState(minProdState, maintWindowChange=True)
 
         if inTransaction:
             processFunc = transact(_setProdState)

--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -584,7 +584,11 @@ class MaintenanceWindow(ZenModelRM):
                 # Changes the current state for a device, but *not*
                 # the preMWProductionState
                 oldProductionState = self.dmd.convertProdState(device.getProductionState())
-                newProductionState = self.dmd.convertProdState(minProdState)
+                # When MW ends Components will acquire production state from device
+                if not minProdState:
+                    newProductionState = "Acquired from parent"
+                else:
+                    newProductionState = self.dmd.convertProdState(minProdState)
                 log.info("MW %s changes %s's production state from %s to %s",
                          self.displayName(), device.id, oldProductionState,
                          newProductionState)

--- a/Products/ZenModel/ManagedEntity.py
+++ b/Products/ZenModel/ManagedEntity.py
@@ -74,10 +74,10 @@ class ManagedEntity(ZenModelRM, DeviceResultInt, EventView, MetricMixin,
         self.privateattr_productionState = state
 
     def getPreMWProductionState(self):
-        return self.privateattr_preMWProductionState
+        return getattr(self, '_preMWProductionState', None)
 
     def setPreMWProductionState(self, state):
-        self.privateattr_preMWProductionState = state
+        self._preMWProductionState = state
 
     def resetProductionState(self):
         # The Device class should override this and set a default value
@@ -87,7 +87,7 @@ class ManagedEntity(ZenModelRM, DeviceResultInt, EventView, MetricMixin,
             pass
 
         try:
-            del self.privateattr_preMWProductionState
+            del self._preMWProductionState
         except AttributeError:
             pass
 

--- a/Products/ZenModel/tests/testDeviceClass.py
+++ b/Products/ZenModel/tests/testDeviceClass.py
@@ -181,24 +181,18 @@ class TestDeviceClass(ZenModelBaseTest):
 
     def testMoveDevicesRetainsComponentProductionStateAcquisition(self):
         self.dev._setProductionState(99)
-        self.dev.setPreMWProductionState(98)
         self.dev.os.addIpInterface('eth0', True)
         self.dmd.Devices.moveDevices('/Server', 'testdev')
         
         # Component production state is the same (acquired from device)
         component = self.dmd.Devices.Server.devices.testdev.os.interfaces()[0]
         newProdState = component.getProductionState()
-        newPreMWProdState = component.getPreMWProductionState()
         self.assertEqual(newProdState, 99)
-        self.assertEqual(newPreMWProdState, 98)
 
         # Component production state still acquires from device
         self.dev._setProductionState(59)
-        self.dev.setPreMWProductionState(58)
         newProdState = component.getProductionState()
-        newPreMWProdState = component.getPreMWProductionState()
         self.assertEqual(newProdState, 59)
-        self.assertEqual(newPreMWProdState, 58)
 
     def testMoveDevicesWithPotentialCaseIssue(self):
         self.dmd.Devices.createInstance( 'TESTDEV' )


### PR DESCRIPTION
MW wasn't working for Component Group.
Some of the objects n the component group may not
have production state attribute, skip them.
When creating device config for cllector daemon
filter components by their production state in the
same way as devices are.