### PR TITLE
Add a script to optionally force reindex during upgrades

### DIFF
--- a/bin/upgrade_reindex.sh
+++ b/bin/upgrade_reindex.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Only force a reindex if we're upgrading from < 6.x. The upgrade script provides the top level service name as an argument.
+#
+
+# Get the major version number of the given service
+MAJOR=$(cat /opt/zenoss/Products/ZenModel/ZVersion.py | grep VERSION | awk -F '"' '{print $2}' | cut -d"." -f1)
+TOPSERVICE=$@
+
+# Resmgr/Core upgraded to Solr in version 6.0.0.  UCSPM will probably upgrade to Solr in 3.x
+if [[ "${TOPSERVICE}" == "ucspm" ]]; then
+  SOLRVERSION=3
+else
+  SOLRVERSION=6
+fi
+
+# Only force a catalog reindex if the current major version of RM is less than 6.
+if [[ $MAJOR -lt $SOLRVERSION ]]; then
+    /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
+fi


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29061
Called from the upgrade with the top-level service name as the argument.  Checks if the major version is prior to the addition of Solr to conditionally force a catalog reindex.