### PR TITLE
Use /var/zenoss/upgrade_from_version.txt

### DIFF
--- a/bin/upgrade_reindex.sh
+++ b/bin/upgrade_reindex.sh
@@ -3,8 +3,8 @@
 # Only force a reindex if we're upgrading from < 6.x. The upgrade script provides the top level service name as an argument.
 #
 
-# Get the major version number of the given service
-MAJOR=$(cat /opt/zenoss/Products/ZenModel/ZVersion.py | grep VERSION | awk -F '"' '{print $2}' | cut -d"." -f1)
+# Get the major version number that we're upgrading from.
+MAJOR=$(cat /var/zenoss/upgrade_from_version.txt | cut -d"." -f1)
 TOPSERVICE=$@
 
 # Resmgr/Core upgraded to Solr in version 6.0.0.  UCSPM will probably upgrade to Solr in 3.x
@@ -17,4 +17,6 @@ fi
 # Only force a catalog reindex if the current major version of RM is less than 6.
 if [[ $MAJOR -lt $SOLRVERSION ]]; then
     /opt/zenoss/bin/zencatalog run --createcatalog --forceindex
+else
+    echo "Upgrading from ${TOPSERVICE} major version ${MAJOR}. Skipping catalog reindex."
 fi


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29075
ZVersion.py has the to-version, not the from-version.  The current_version.txt upgrade step places /var/zenoss/upgrade_from_version.txt into the DFS, so we can use this to find out what version we're upgrading from.