### PR TITLE
Add zCommandCollectionInterval by default

### DIFF
--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -102,6 +102,7 @@ Z_PROPERTIES = [
     ('zCommandSearchPath', [], 'lines', 'Command Search Path', 'Sets the path to search for any commands.'),
     ('zCommandExistanceTest', 'test -f %s', 'string', 'Command Existance Test', ''),
     ('zCommandPath', '/usr/local/zenoss/libexec', 'string', 'Command Path', 'Sets the default path where ZenCommand plug-ins are installed on the local Resource Manager box (or on a remote box where SSH is used to run the command).'),
+    ('zCommandCollectionInterval', 300, 'int', 'Command Collection Interval', 'Defines, in seconds, the default collection interval for command datasources.'),
     ('zTelnetLoginRegex', 'ogin:.$', 'string', 'Telnet Login', 'Regular expression to match the login prompt.'),
     ('zTelnetPasswordRegex', 'assword:', 'string', 'Telnet Password Regex', 'Regular expression to match the password prompt.'),
     ('zTelnetSuccessRegexList', ['\\$.$', '\\#.$'], 'lines', 'Telnet Success Regex', 'List of regular expressions to match the command prompt.'),


### PR DESCRIPTION
The fix for ZEN-28507 required adding a new standard zProperty:
zCommandCollectionInterval. However, the commit that added it (72aa56d)
left it out of the standard zProperty list. This prevents it from being
available for unit tests.

Refs ZPS-2559.