### PR TITLE
ZEN-29115: Json api DeviceManagementRouter addMaintWindow() method do…

### DIFF
--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -125,7 +125,6 @@ class MaintenanceWindow(ZenModelRM):
 
     security = ClassSecurityInfo()
 
-
     REPEAT = "Never/Daily/Every Weekday/Weekly/Monthly: day of month/Monthly: day of week".split('/')
     NEVER, DAILY, EVERY_WEEKDAY, WEEKLY, MONTHLY, NTHWDAY = REPEAT
     DAYS = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
@@ -240,6 +239,7 @@ class MaintenanceWindow(ZenModelRM):
             return v
 
         oldAuditData = self.getAuditData()
+        prodStates = dict((key, value) for (key,value) in self.dmd.getProdStateConversions())
         msgs = []
         self.enabled = bool(enabled)
         if startDateTime:
@@ -260,6 +260,13 @@ class MaintenanceWindow(ZenModelRM):
                              0, 0, 0, -1))
         if repeat not in self.REPEAT:
             msgs.append('\'repeat\' has wrong value.')
+        if not isinstance(enabled, bool):
+            msgs.append('\'enabled\' has wrong value, use true or false.')
+        if not (startProductionState in prodStates.values() or
+            prodStates.get(startProductionState, None)):
+            msgs.append('\'startProductionState\' has wrong value.')
+        elif isinstance(startProductionState, str):
+            startProductionState = prodStates[startProductionState]
         if not msgs:
             durationDays = makeInt(durationDays, 'Duration days',
                                         minv=0)

--- a/Products/Zuul/facades/devicemanagementfacade.py
+++ b/Products/Zuul/facades/devicemanagementfacade.py
@@ -26,7 +26,9 @@ class DeviceManagementFacade(ZuulFacade):
         newMw = None
         obj = self._getObject(params['uid'])
                         
-        id = params['name'].strip()    
+        id = params['name'].strip()
+        if not id:
+            raise Exception('Missing Maintenance Window name.')
         obj.manage_addMaintenanceWindow(id)
         maintenanceWindows = (IInfo(s) for s in obj.maintenanceWindows())
         try:


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29115
Fixes:
- invalid value for enabled throws exception instead of clean error response 
- able to add an invalid prod state
- api returned success when attempt to add MW without a name value (it did not add, but api returned success)