### PR TITLE
ZEN-25765: add stats of the task to event message

### DIFF
--- a/Products/ZenCollector/scheduler.py
+++ b/Products/ZenCollector/scheduler.py
@@ -183,6 +183,9 @@ class CallableTask(object):
                  'component': os.path.basename(sys.argv[0]).replace('.py', ''), },
                 device=self.task._devId,
                 summary="Missed run: {}".format(self.task.name),
+                message=self._scheduler._displayStateStatistics(
+                    '', self.taskStats.states
+                ),
                 severity=Event.Warning, eventKey=self.task.name)
             self.task.missed = True
         except Exception:


### PR DESCRIPTION
If the Missed Run happen we put stats of the
corresponding task into the event message.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-25765)