### PR TITLE
ZEN-29026 Use exactMatch during finding records in store

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/controller/AddDeviceController.js
@@ -234,7 +234,7 @@
 
             // allow either commas to separate or new lines or both
             hosts = this.parseHosts(values.hosts);
-            var displayDeviceClass = typeGrid.getStore().findRecord('value', deviceClass).get('shortdescription');
+            var displayDeviceClass = typeGrid.getStore().findRecord('value', deviceClass, 0, false, true, true).get('shortdescription');
             // go through each host and add a record
             Ext.Array.each(hosts, function(host){
                 if (Ext.isEmpty(host)) {


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29026

We need to search for exact value:
```
>>> typeGrid.getStore().findRecord('value', deviceClass).get('shortdescription')
"/Server/Linux/Dell"
>>> typeGrid.getStore().findRecord('value', deviceClass, 0, false, true, true).get('shortdescription') 
"Linux Server (SNMP)"
```