### PR TITLE
ZEN-29178: set buffer attribute of store to false

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/process.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/process.js
@@ -706,6 +706,7 @@ Ext.define("Zenoss.SequenceStore", {
             directFn: router.getSequence,
             pageSize: 1000,
             scrollToLoadBuffer: 0,
+            buffered: false,
             root: 'data'
         });
         this.callParent(arguments);


### PR DESCRIPTION
If you move  a sequence located at the top to the very bottom
it moves back to its starting location after moving it.
This was happening since data was buffered and then restored
to the original list.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-29178)