### PR TITLE
ZEN-29333 Allow to update distribution if other version already exists

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -637,7 +637,7 @@ def AddDistToWorkingSet(distPath):
     """
     zpDists = []
     for d in pkg_resources.find_distributions(distPath):
-        pkg_resources.working_set.add(d)
+        pkg_resources.working_set.add(d, replace=True)
         pkg_resources.require(d.project_name)
         if d.project_name.startswith('ZenPacks.'):
             zpDists.append(d)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29333
Upgrade of ZPs will fail if custom ZP installed on pre-upgrade system requires higher version of some dependency than to-upgrade package contains.
https://github.com/pypa/setuptools/blob/master/pkg_resources/__init__.py#L776