### PR TITLE
Better syntax highlight colors

### DIFF
--- a/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
+++ b/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
@@ -9680,6 +9680,8 @@ $menu-icon-unchecked: 'menu/unchecked.gif';
   color: #fafafa; }
 .x-window-body .x-panel-body td {
   color: black; }
+.x-window-body .x-panel-body pre {
+    color: #d4d4d4; }
 .x-window-body .x-fieldset {
   border: none; }
 .x-window-body .x-fieldset-header {

--- a/Products/ZenUI3/browser/resources/css/zenoss.css
+++ b/Products/ZenUI3/browser/resources/css/zenoss.css
@@ -2076,19 +2076,19 @@ img.europaGraphGear.spinnerino {
 /* syntax highlighting classes */
 
 span.syntax-number  {
-    color: brown;
+  color: #ceb24f;
 }
 
 span.syntax-string  {
-    color: green;
+  color: #96b781;
 }
 
 span.syntax-boolean {
-    color: blue;
+  color: #9bc1ef;
 }
 
 span.syntax-text  {
-    color: white;
+  color: #9786c4;
 }
 
 .grid-action.checked.enabled {


### PR DESCRIPTION
Crayola colors be gone! More professional color scheme for "show definition" modals and the like. This has bugged me far too long and needs to be changed.