### PR TITLE
Add new healthcheck for imported memcached_session service

### DIFF
--- a/bin/healthchecks/memcached_session_answering
+++ b/bin/healthchecks/memcached_session_answering
@@ -1,0 +1,11 @@
+#! /bin/sh
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2014, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+sh -c 'echo stats && sleep 2' | nc 127.0.0.1 11212 | grep -q uptime


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29001

Adds a new healthcheck that gets used by services importing memcached_session on port 11212.