### PR TITLE
ZEN-29337 Allow to update distribution if other version already exists

### DIFF
--- a/Products/ZenUtils/ZenPackCmd.py
+++ b/Products/ZenUtils/ZenPackCmd.py
@@ -637,7 +637,7 @@ def AddDistToWorkingSet(distPath):
     """
     zpDists = []
     for d in pkg_resources.find_distributions(distPath):
-        pkg_resources.working_set.add(d)
+        pkg_resources.working_set.add(d, replace=True)
         pkg_resources.require(d.project_name)
         if d.project_name.startswith('ZenPacks.'):
             zpDists.append(d)


### PR DESCRIPTION
port https://github.com/zenoss/zenoss-prodbin/pull/2929
https://jira.zenoss.com/browse/ZEN-29337