### PR TITLE
ZEN-29341 Device Tree refresh moves focus away from device class panel

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/SubselectionPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/SubselectionPanel.js
@@ -636,6 +636,12 @@
                     this.setHeight((height * nodes.length) + 35);
                 }
             }, this);
+            // ZEN-29341 set default selected element to keep focus
+            // after device tree refresh
+            var selectionModel = this.treepanel.getSelectionModel();
+            if (!selectionModel.getLastSelected()) {
+                selectionModel.select(0);
+            };
             this.doLayout();
 
 

--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -487,6 +487,9 @@ Ext.define('Zenoss.DeviceDetailNav', {
             target: 'detail_card_panel',
             menuIds: ['More','Add','TopLevel','Manage'],
             hasComponents: false,
+            viewConfig: {
+                preserveScrollOnRefresh: true
+            },
             listeners:{
                 render: function() {
                     this.setContext(UID);

--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -265,14 +265,6 @@ function refreshTreePanel() {
     Ext.each(Ext.ComponentQuery.query('HierarchyTreePanel'), function(tree) {
         tree.refresh();
     });
-    var selModel = getSelectionModel();
-    if (selModel.tree) {
-        var tree = Ext.getCmp(selModel.tree);
-        var selectedNode = selModel.getSelectedNode();
-        if (tree && selectedNode) {
-            tree.selectByToken(selectedNode.internalId);
-        }
-    }
 }
 
 


### PR DESCRIPTION
[Jira](https://jira.zenoss.com/browse/ZEN-29462)