### PR TITLE
ZEN-29241 Remove Log Scale Option

### DIFF
--- a/Products/ZenModel/skins/zenmodel/editGraphDefinition.pt
+++ b/Products/ZenModel/skins/zenmodel/editGraphDefinition.pt
@@ -94,17 +94,6 @@
         </td>
     </tr>
     <tr>
-        <td class="tableheader">Logarithmic Scale</td>
-        <td class="tablevalues" tal:condition="here/isManager">
-        <select class="tablevalues" name="log:boolean">
-            <option tal:repeat="e python:(True,False)" tal:content="e"
-            tal:attributes="value e; selected python:e==here.log"/>
-        </select>
-        </td>
-      <td class="tablevalues" tal:condition="not:here/isManager" 
-            tal:content="here/log"/>
-    </tr>
-    <tr>
         <td class="tableheader">Base 1024</td>
         <td class="tablevalues" tal:condition="here/isManager">
         <select class="tablevalues" name="base:boolean">


### PR DESCRIPTION
Remove unused/unsupported Logarithmic scale option from graph report options.

port from https://github.com/zenoss/zenoss-prodbin/pull/2894