### PR TITLE
ZEN-29237 Multigraph Datapoint Limit

### DIFF
--- a/Products/ZenModel/skins/zenmodel/editGraphPoint.pt
+++ b/Products/ZenModel/skins/zenmodel/editGraphPoint.pt
@@ -91,16 +91,6 @@
       <td class="tablevalues" tal:condition="not:here/isManager"
         tal:content="here/rpn"/>
     </tr>
-    <tr tal:condition="python: here.aqBaseHasAttr('limit')">
-        <td class="tableheader">Limit</td>
-        <td class="tablevalues" tal:condition="here/isManager">
-        <input class="tablevalues" type="text" name="limit" size="40"
-            tal:attributes="value here/limit" />
-        </td>
-      <td class="tablevalues" tal:condition="not:here/isManager"
-        tal:content="here/limit"/>
-    </tr>
-
     <tr tal:condition="python: here.aqBaseHasAttr('start')">
         <td class="tableheader">Start</td>
         <td class="tablevalues" tal:condition="here/isManager">


### PR DESCRIPTION
Removes unused limit input field from datapoint customization panel.
port https://github.com/zenoss/zenoss-prodbin/pull/2904