### PR TITLE
ZEN-29451: fail the upgrade when CatalogService zenpack was not removed

### DIFF
--- a/bin/remove_CatalogServiceZenPack.sh
+++ b/bin/remove_CatalogServiceZenPack.sh
@@ -12,11 +12,13 @@ echo "Found Catalog Service egg at $CATALOG_SERVICE_EGG"
 #show log only if something goes wrong
 tmp_output="/tmp/"`cat /dev/urandom | tr -cd 'a-f0-9' | head -c 32`
 /opt/zenoss/bin/zenpack --remove ZenPacks.zenoss.CatalogService  > $tmp_output 2>&1
-if [[ ! $? -eq 0 ]]; then
-    echo "Couldn't remove CatalogService zenpack"
+status=$?
+if [[ ! $status -eq 0 ]]; then
     cat $tmp_output
     rm $tmp_output
-    exit
+    echo "Couldn't remove CatalogService zenpack"
+    echo "You should remove CatalogService zenpack manually before starting the upgrade"
+    exit $status
 fi
 rm $tmp_output
 echo "Successfully removed Catalog Service"


### PR DESCRIPTION
During the upgrade if a traceback occurs at a certain time
the Catalog Service fails to remove, but the upgrade proceeds.
When CatalogService fails to remove while upgrade process,
fail the whole process and give a message to a user to
manually remove CatalogService zenpack before the upgrade.