### PR TITLE
Improve SNMP varbind capture.

### DIFF
--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 
 from struct import pack
@@ -31,6 +32,80 @@ class DecodersUnitTest(BaseTestCase):
         self.assertEqual(
             decode_snmp_value(value),
             '2017-12-20T11:50:50.800+06:05'
+        )
+
+    def test_decode_bad_timezone(self):
+        value = pack(">HBBBBBBBBB", 2017, 12, 20, 11, 50, 50, 8, 0, 0, 0)
+        dttm = decode_snmp_value(value)
+        self.assertEqual(dttm[:23], "2017-12-20T11:50:50.800")
+        self.assertRegexpMatches(
+            dttm[23:], "^[+-][01][0-9]:[0-5][0-9]$"
+        )
+
+    def test_decode_invalid_timezone(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 50, 8, '=', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_incomplete_datetime(self):
+        value = pack(">HBBBBBB", 2017, 12, 20, 11, 50, 50, 8)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_month_high(self):
+        value = pack(">HBBBBBBsBB", 2017, 13, 20, 11, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_month_low(self):
+        value = pack(">HBBBBBBsBB", 2017, 0, 20, 11, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_day_high(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 32, 11, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_day_low(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 0, 11, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_hour(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 24, 50, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_minute(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 60, 50, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_bad_second(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 61, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
+        )
+
+    def test_decode_leap_second(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 60, 8, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), '2017-12-20T11:50:60.800+06:05'
+        )
+
+    def test_decode_bad_decisecond(self):
+        value = pack(">HBBBBBBsBB", 2017, 12, 20, 11, 50, 50, 10, '+', 6, 5)
+        self.assertEqual(
+            decode_snmp_value(value), "BASE64:" + base64.b64encode(value)
         )
 
     def test_decode_value_ipv4(self):
@@ -137,144 +212,114 @@ class TestOid2Name(BaseTestCase):
 
 class TestDecodeSnmpV1(BaseTestCase):
 
-    def makePacket(self):
+    def makeInputs(self, trapType=6, oidMap={}, variables=()):
         pckt = FakePacket()
         pckt.version = SNMPv1
         pckt.host = "localhost"
         pckt.port = 162
-        pckt.variables = ()
+        pckt.variables = variables
         pckt.community = ""
         pckt.enterprise_length = 0
 
         # extra fields for SNMPv1 packets
         pckt.agent_addr = [192, 168, 24, 4]
-        pckt.trap_type = 6
+        pckt.trap_type = trapType
         pckt.specific_type = 5
         pckt.enterprise = "1.2.3.4"
         pckt.enterprise_length = len(pckt.enterprise)
         pckt.community = "community"
-        return pckt
 
-    def test_SnmpVersion(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        self.assertEqual(result["snmpVersion"], "1")
+        return pckt, MockTrapTask(oidMap)
 
     def test_NoAgentAddr(self):
-        pckt = self.makePacket()
+        pckt, task = self.makeInputs()
         del pckt.agent_addr
-        task = MockTrapTask({})
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(result["device"], "localhost")
 
-    def test_HasAgentAddr(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
+    def test_FieldsNoMappingUsed(self):
+        pckt, task = self.makeInputs()
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+
         self.assertEqual(result["device"], "192.168.24.4")
-
-    def test_SnmpV1Enterprise(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["snmpVersion"], "1")
         self.assertEqual(result["snmpV1Enterprise"], "1.2.3.4")
-
-    def test_SnmpV1GenericTrapType(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(result["snmpV1GenericTrapType"], 6)
-
-    def test_SnmpV1SpecificTrap(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(result["snmpV1SpecificTrap"], 5)
-
-    def test_EnterpriseOIDWithoutExtraZero(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "1.2.3.4.5")
         self.assertEqual(result["oid"], "1.2.3.4.5")
 
     def test_EnterpriseOIDWithExtraZero(self):
-        pckt = self.makePacket()
-        oidMap = {"1.2.3.4.0.5": "testing"}
-        task = MockTrapTask(oidMap)
+        pckt, task = self.makeInputs(oidMap={"1.2.3.4.0.5": "testing"})
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "testing")
         self.assertEqual(result["oid"], "1.2.3.4.0.5")
 
-    def test_TrapTypeDecoding(self):
-        pckt = self.makePacket()
-        task = MockTrapTask({})
-
-        pckt.trap_type = 0
+    def test_TrapType0(self):
+        pckt, task = self.makeInputs(trapType=0)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "coldStart")
         self.assertEqual(result["snmpV1GenericTrapType"], 0)
 
-        pckt.trap_type = 1
+    def test_TrapType1(self):
+        pckt, task = self.makeInputs(trapType=1)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "warmStart")
         self.assertEqual(result["snmpV1GenericTrapType"], 1)
 
-        pckt.trap_type = 2
+    def test_TrapType2(self):
+        pckt, task = self.makeInputs(trapType=2)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "snmp_linkDown")
         self.assertEqual(result["snmpV1GenericTrapType"], 2)
 
-        pckt.trap_type = 3
+    def test_TrapType3(self):
+        pckt, task = self.makeInputs(trapType=3)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "snmp_linkUp")
         self.assertEqual(result["snmpV1GenericTrapType"], 3)
 
-        pckt.trap_type = 4
+    def test_TrapType4(self):
+        pckt, task = self.makeInputs(trapType=4)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "authenticationFailure")
         self.assertEqual(result["snmpV1GenericTrapType"], 4)
 
-        pckt.trap_type = 5
+    def test_TrapType5(self):
+        pckt, task = self.makeInputs(trapType=5)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "egpNeighorLoss")
         self.assertEqual(result["snmpV1GenericTrapType"], 5)
 
-        pckt.trap_type = 6
+    def test_TrapType6(self):
+        pckt, task = self.makeInputs(trapType=6)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(eventType, "1.2.3.4.5")
         self.assertEqual(result["snmpV1GenericTrapType"], 6)
 
     def test_VarBindOneValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
+        pckt, task = self.makeInputs(variables=(
             ((1, 2, 6, 7), "foo"),
-        )
-        task = MockTrapTask({})
+        ))
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         self.assertEqual(result["1.2.6.7"], "foo")
 
     def test_VarBindMultiValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
+        pckt, task = self.makeInputs(variables=(
             ((1, 2, 6, 7), "foo"),
             ((1, 2, 6, 7), "bar"),
             ((1, 2, 6, 7), "baz"),
-        )
-        task = MockTrapTask({})
+        ))
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
         self.assertEqual(totalVarKeys, 1)
         self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
 
     def test_UnknownMultiVarBind(self):
-        pckt = self.makePacket()
-        pckt.variables = (
+        pckt, task = self.makeInputs(variables=(
             ((1, 2, 6, 0), "foo"),
             ((1, 2, 6, 1), "bar"),
-        )
-        task = MockTrapTask({})
+        ))
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
         self.assertEqual(totalVarKeys, 2)
@@ -284,12 +329,10 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["1.2.6.1"], "bar")
 
     def test_NamedVarBindOneValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 7), "foo"),
+        pckt, task = self.makeInputs(
+            variables=(((1, 2, 6, 7), "foo"),),
+            oidMap={"1.2.6.7": "testVar"}
         )
-        oidMap = {"1.2.6.7": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 1)
@@ -297,14 +340,14 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar"], "foo")
 
     def test_NamedVarBindMultiValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            ),
+            oidMap={"1.2.6.7": "testVar"}
         )
-        oidMap = {"1.2.6.7": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 1)
@@ -312,12 +355,10 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar"], "foo,bar,baz")
 
     def test_PartialNamedVarBindOneValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 7), "foo"),
+        pckt, task = self.makeInputs(
+            variables=(((1, 2, 6, 7), "foo"),),
+            oidMap={"1.2.6": "testVar"}
         )
-        oidMap = {"1.2.6": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 2)
@@ -327,14 +368,14 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "7")
 
     def test_PartialNamedVarBindMultiValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            ),
+            oidMap={"1.2.6": "testVar"}
         )
-        oidMap = {"1.2.6": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 2)
@@ -344,14 +385,14 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "7,7,7")
 
     def test_PartialNamedMultiVarBind(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 1), "bar"),
-            ((1, 2, 6, 2), "baz"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 1), "bar"),
+                ((1, 2, 6, 2), "baz"),
+            ),
+            oidMap={"1.2.6": "testVar"}
         )
-        oidMap = {"1.2.6": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 4)
@@ -365,12 +406,10 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "0,1,2")
 
     def test_PartialNamedVarBindNoneValue(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 0), None),
+        pckt, task = self.makeInputs(
+            variables=(((1, 2, 6, 0), None),),
+            oidMap={"1.2.6.0": "testVar"}
         )
-        oidMap = {"1.2.6.0": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 1)
@@ -378,14 +417,14 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar"], "None")
 
     def test_PartialNamedMultiVarBindOrder(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 3), "baz"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 3), "baz"),
+            ),
+            oidMap={"1.2.6": "testVar"}
         )
-        oidMap = {"1.2.6": "testVar"}
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 4)
@@ -399,22 +438,22 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "0,7,3")
 
     def test_ifentry_trap(self):
-        pckt = self.makePacket()
-        pckt.variables = (
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
-            ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
+                ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
+            ),
+            oidMap={
+                "1.3.6.1.2.1.2.2.1.1": "ifIndex",
+                "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
+                "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
+                "1.3.6.1.2.1.2.2.1.2": "ifDescr",
+                "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
+            }
         )
-        oidMap = {
-            "1.3.6.1.2.1.2.2.1.1": "ifIndex",
-            "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
-            "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
-            "1.3.6.1.2.1.2.2.1.2": "ifDescr",
-            "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
-        }
-        task = MockTrapTask(oidMap)
         eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))
@@ -469,18 +508,19 @@ class TestDecodeSnmpV2(BaseTestCase):
         "1.3.6.1.6.3.1.1.5.6": "egpNeighborLoss",
     }
 
-    def makePacket(self, trapType):
+    def makePacket(self, trapOID, variables=()):
         pckt = FakePacket()
         pckt.version = SNMPv2
         pckt.host = "localhost"
         pckt.port = 162
 
-        if isinstance(trapType, (str, unicode)):
-            trapType = tuple(map(int, trapType.split('.')))
+        if isinstance(trapOID, (str, unicode)):
+            trapOID = tuple(map(int, trapOID.split('.')))
         pckt.variables = [
             ((1, 3, 6, 1, 2, 1, 1, 3, 0), 5342),
-            ((1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0), trapType)
+            ((1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0), trapOID)
         ]
+        pckt.variables.extend(variables)
         pckt.community = "public"
         pckt.enterprise_length = 0
         return pckt
@@ -490,17 +530,17 @@ class TestDecodeSnmpV2(BaseTestCase):
         oidMap.update(extraOidMap)
         return MockTrapTask(oidMap)
 
-    def test_SnmpVersion(self):
-        pckt = self.makePacket("1.2.3")
-        task = self.makeTask()
+    def makeInputs(
+            self, trapOID="1.3.6.1.6.3.1.1.5.1", variables=(), extraOidMap={}):
+        pckt = self.makePacket(trapOID=trapOID, variables=variables)
+        task = self.makeTask(extraOidMap=extraOidMap)
+        return pckt, task
+
+    def test_UnknownTrapType(self):
+        pckt, task = self.makeInputs(trapOID="1.2.3")
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertIn("snmpVersion", result)
         self.assertEqual(result["snmpVersion"], "2")
-
-    def test_UnknownTrapType(self):
-        pckt = self.makePacket("1.2.3")
-        task = self.makeTask()
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertEqual(eventType, "1.2.3")
         self.assertIn("snmpVersion", result)
         self.assertIn("oid", result)
@@ -510,60 +550,59 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["device"], "localhost")
 
     def test_KnownTrapType(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
-        task = self.makeTask()
+        pckt, task = self.makeInputs(trapOID="1.3.6.1.6.3.1.1.5.1")
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertIn("oid", result)
         self.assertEqual(eventType, "coldStart")
         self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.1")
 
     def test_TrapAddressOID(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
-        pckt.variables.append((
-            (1, 3, 6, 1, 6, 3, 18, 1, 3), "192.168.51.100"
-        ))
-        task = self.makeTask({
-            "1.3.6.1.6.3.18.1.3": "snmpTrapAddress"
-        })
+        pckt, task = self.makeInputs(
+            trapOID="1.3.6.1.6.3.1.1.5.1",
+            variables=(
+                ((1, 3, 6, 1, 6, 3, 18, 1, 3), "192.168.51.100"),
+            ),
+            extraOidMap={
+                "1.3.6.1.6.3.18.1.3": "snmpTrapAddress"
+            }
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertIn("snmpTrapAddress", result)
         self.assertEqual(result["snmpTrapAddress"], "192.168.51.100")
         self.assertEqual(result["device"], "192.168.51.100")
 
     def test_RenamedLinkDown(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        task = self.makeTask()
+        pckt, task = self.makeInputs(trapOID="1.3.6.1.6.3.1.1.5.3")
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertIn("oid", result)
         self.assertEqual(eventType, "snmp_linkDown")
         self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.3")
 
     def test_RenamedLinkUp(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.4")
-        task = self.makeTask()
+        pckt, task = self.makeInputs(trapOID="1.3.6.1.6.3.1.1.5.4")
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertIn("oid", result)
         self.assertEqual(eventType, "snmp_linkUp")
         self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.4")
 
     def test_VarBindMultiValue(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
-        ))
-        task = self.makeTask()
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            )
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
 
     def test_UnknownMultiVarBind(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
-        pckt.variables.extend((
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 1), "bar"),
-        ))
-        task = self.makeTask()
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 1), "bar"),
+            )
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
         self.assertEqual(totalVarKeys, 2)
@@ -573,11 +612,12 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["1.2.6.1"], "bar")
 
     def test_NamedVarBindOneValue(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.append(
-            ((1, 2, 6, 7), "foo"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+            ),
+            extraOidMap={"1.2.6.7": "testVar"}
         )
-        task = self.makeTask({"1.2.6.7": "testVar"})
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 1)
@@ -585,13 +625,14 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar"], "foo")
 
     def test_NamedVarBindMultiValue(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
-        ))
-        task = MockTrapTask({"1.2.6.7": "testVar"})
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            ),
+            extraOidMap={"1.2.6.7": "testVar"}
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 1)
@@ -599,11 +640,12 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar"], "foo,bar,baz")
 
     def test_PartialNamedVarBindOneValue(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.append(
-            ((1, 2, 6, 7), "foo"),
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+            ),
+            extraOidMap={"1.2.6": "testVar"}
         )
-        task = MockTrapTask({"1.2.6": "testVar"})
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 2)
@@ -613,13 +655,14 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "7")
 
     def test_PartialNamedVarBindMultiValue(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
-        ))
-        task = MockTrapTask({"1.2.6": "testVar"})
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            ),
+            extraOidMap={"1.2.6": "testVar"}
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 2)
@@ -629,13 +672,14 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "7,7,7")
 
     def test_PartialNamedMultiVarBind(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 1), "bar"),
-            ((1, 2, 6, 2), "baz"),
-        ))
-        task = MockTrapTask({"1.2.6": "testVar"})
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 1), "bar"),
+                ((1, 2, 6, 2), "baz"),
+            ),
+            extraOidMap={"1.2.6": "testVar"}
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 4)
@@ -661,13 +705,14 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar"], "None")
 
     def test_PartialNamedMultiVarBindOrder(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 3), "baz"),
-        ))
-        task = MockTrapTask({"1.2.6": "testVar"})
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 3), "baz"),
+            ),
+            extraOidMap={"1.2.6": "testVar"}
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
         totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
         self.assertEqual(totalVarKeys, 4)
@@ -681,22 +726,22 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(result["testVar.sequence"], "0,7,3")
 
     def test_ifentry_trap(self):
-        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
-        pckt.variables.extend((
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
-            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
-            ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
-        ))
-        oidMap = {
-            "1.3.6.1.2.1.2.2.1.1": "ifIndex",
-            "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
-            "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
-            "1.3.6.1.2.1.2.2.1.2": "ifDescr",
-            "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
-        }
-        task = MockTrapTask(oidMap)
+        pckt, task = self.makeInputs(
+            variables=(
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
+                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
+                ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
+            ),
+            extraOidMap={
+                "1.3.6.1.2.1.2.2.1.1": "ifIndex",
+                "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
+                "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
+                "1.3.6.1.2.1.2.2.1.2": "ifDescr",
+                "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
+            }
+        )
         eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))

--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -1,7 +1,13 @@
-from Products.ZenTestCase.BaseTestCase import BaseTestCase
-from Products.ZenEvents.zentrap import decode_snmp_value
+import logging
 
 from struct import pack
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+from Products.ZenEvents.zentrap import (
+    decode_snmp_value, TrapTask, FakePacket, SNMPv1, SNMPv2
+)
+
+log = logging.getLogger("test_zentrap")
 
 
 class DecodersUnitTest(BaseTestCase):
@@ -70,8 +76,670 @@ class DecodersUnitTest(BaseTestCase):
         )
 
 
+class MockTrapTask(TrapTask):
+
+    def __init__(self, oidMap):
+        self.oidMap = oidMap
+        self.log = log
+
+
+class TestOid2Name(BaseTestCase):
+
+    def test_NoExactMatch(self):
+        oidMap = {}
+        task = MockTrapTask(oidMap)
+        self.assertEqual(task.oid2name(".1.2.3.4"), "1.2.3.4")
+        self.assertEqual(task.oid2name(".1.2.3.4", strip=True), "1.2.3.4")
+
+    def test_HasExactMatch(self):
+        oidMap = {"1.2.3.4": "Zenoss.Test.exactMatch"}
+        task = MockTrapTask(oidMap)
+        result = task.oid2name(".1.2.3.4")
+        self.assertEqual(result, "Zenoss.Test.exactMatch")
+        result = task.oid2name(".1.2.3.4", strip=True)
+        self.assertEqual(result, "Zenoss.Test.exactMatch")
+
+    def test_NoInexactMatch(self):
+        oidMap = {"1.2.3.4": "Zenoss.Test.exactMatch"}
+        task = MockTrapTask(oidMap)
+        result = task.oid2name(".1.5.3.4", exactMatch=False)
+        self.assertEqual(result, "1.5.3.4")
+
+    def test_HasInexactMatchNotStripped(self):
+        oidMap = {
+            "1.2": "Zenoss",
+            "1.2.3": "Zenoss.Test",
+            "1.2.3.2": "Zenoss.Test.inexactMatch"
+        }
+        task = MockTrapTask(oidMap)
+        result = task.oid2name(".1.2.3.2.5", exactMatch=False)
+        self.assertEqual(result, "Zenoss.Test.inexactMatch.5")
+        result = task.oid2name(".1.2.3.2.5.6", exactMatch=False)
+        self.assertEqual(result, "Zenoss.Test.inexactMatch.5.6")
+
+    def test_HasInexactMatchStripped(self):
+        oidMap = {
+            "1.2": "Zenoss",
+            "1.2.3": "Zenoss.Test",
+            "1.2.3.2": "Zenoss.Test.inexactMatch"
+        }
+        task = MockTrapTask(oidMap)
+        result = task.oid2name(".1.2.3.2.5", exactMatch=False, strip=True)
+        self.assertEqual(result, "Zenoss.Test.inexactMatch")
+        result = task.oid2name(".1.2.3.2.5.6", exactMatch=False, strip=True)
+        self.assertEqual(result, "Zenoss.Test.inexactMatch")
+
+    def test_AcceptsTuple(self):
+        oidMap = {}
+        task = MockTrapTask(oidMap)
+        self.assertEqual(task.oid2name((1, 2, 3, 4)), "1.2.3.4")
+
+
+class TestDecodeSnmpV1(BaseTestCase):
+
+    def makePacket(self):
+        pckt = FakePacket()
+        pckt.version = SNMPv1
+        pckt.host = "localhost"
+        pckt.port = 162
+        pckt.variables = ()
+        pckt.community = ""
+        pckt.enterprise_length = 0
+
+        # extra fields for SNMPv1 packets
+        pckt.agent_addr = [192, 168, 24, 4]
+        pckt.trap_type = 6
+        pckt.specific_type = 5
+        pckt.enterprise = "1.2.3.4"
+        pckt.enterprise_length = len(pckt.enterprise)
+        pckt.community = "community"
+        return pckt
+
+    def test_SnmpVersion(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["snmpVersion"], "1")
+
+    def test_NoAgentAddr(self):
+        pckt = self.makePacket()
+        del pckt.agent_addr
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["device"], "localhost")
+
+    def test_HasAgentAddr(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["device"], "192.168.24.4")
+
+    def test_SnmpV1Enterprise(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["snmpV1Enterprise"], "1.2.3.4")
+
+    def test_SnmpV1GenericTrapType(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["snmpV1GenericTrapType"], 6)
+
+    def test_SnmpV1SpecificTrap(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["snmpV1SpecificTrap"], 5)
+
+    def test_EnterpriseOIDWithoutExtraZero(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "1.2.3.4.5")
+        self.assertEqual(result["oid"], "1.2.3.4.5")
+
+    def test_EnterpriseOIDWithExtraZero(self):
+        pckt = self.makePacket()
+        oidMap = {"1.2.3.4.0.5": "testing"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "testing")
+        self.assertEqual(result["oid"], "1.2.3.4.0.5")
+
+    def test_TrapTypeDecoding(self):
+        pckt = self.makePacket()
+        task = MockTrapTask({})
+
+        pckt.trap_type = 0
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "coldStart")
+        self.assertEqual(result["snmpV1GenericTrapType"], 0)
+
+        pckt.trap_type = 1
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "warmStart")
+        self.assertEqual(result["snmpV1GenericTrapType"], 1)
+
+        pckt.trap_type = 2
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "snmp_linkDown")
+        self.assertEqual(result["snmpV1GenericTrapType"], 2)
+
+        pckt.trap_type = 3
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "snmp_linkUp")
+        self.assertEqual(result["snmpV1GenericTrapType"], 3)
+
+        pckt.trap_type = 4
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "authenticationFailure")
+        self.assertEqual(result["snmpV1GenericTrapType"], 4)
+
+        pckt.trap_type = 5
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "egpNeighorLoss")
+        self.assertEqual(result["snmpV1GenericTrapType"], 5)
+
+        pckt.trap_type = 6
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(eventType, "1.2.3.4.5")
+        self.assertEqual(result["snmpV1GenericTrapType"], 6)
+
+    def test_VarBindOneValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+        )
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        self.assertEqual(result["1.2.6.7"], "foo")
+
+    def test_VarBindMultiValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        )
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
+
+    def test_UnknownMultiVarBind(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 1), "bar"),
+        )
+        task = MockTrapTask({})
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("1.2.6.0", result)
+        self.assertIn("1.2.6.1", result)
+        self.assertEqual(result["1.2.6.0"], "foo")
+        self.assertEqual(result["1.2.6.1"], "bar")
+
+    def test_NamedVarBindOneValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+        )
+        oidMap = {"1.2.6.7": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "foo")
+
+    def test_NamedVarBindMultiValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        )
+        oidMap = {"1.2.6.7": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "foo,bar,baz")
+
+    def test_PartialNamedVarBindOneValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+        )
+        oidMap = {"1.2.6": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.7"], "foo")
+        self.assertEqual(result["testVar.sequence"], "7")
+
+    def test_PartialNamedVarBindMultiValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        )
+        oidMap = {"1.2.6": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.7"], "foo,bar,baz")
+        self.assertEqual(result["testVar.sequence"], "7,7,7")
+
+    def test_PartialNamedMultiVarBind(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 1), "bar"),
+            ((1, 2, 6, 2), "baz"),
+        )
+        oidMap = {"1.2.6": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 4)
+        self.assertIn("testVar.0", result)
+        self.assertIn("testVar.1", result)
+        self.assertIn("testVar.2", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.0"], "foo")
+        self.assertEqual(result["testVar.1"], "bar")
+        self.assertEqual(result["testVar.2"], "baz")
+        self.assertEqual(result["testVar.sequence"], "0,1,2")
+
+    def test_PartialNamedVarBindNoneValue(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 0), None),
+        )
+        oidMap = {"1.2.6.0": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "None")
+
+    def test_PartialNamedMultiVarBindOrder(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 3), "baz"),
+        )
+        oidMap = {"1.2.6": "testVar"}
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 4)
+        self.assertIn("testVar.0", result)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.3", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.0"], "foo")
+        self.assertEqual(result["testVar.7"], "bar")
+        self.assertEqual(result["testVar.3"], "baz")
+        self.assertEqual(result["testVar.sequence"], "0,7,3")
+
+    def test_ifentry_trap(self):
+        pckt = self.makePacket()
+        pckt.variables = (
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
+            ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
+        )
+        oidMap = {
+            "1.3.6.1.2.1.2.2.1.1": "ifIndex",
+            "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
+            "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
+            "1.3.6.1.2.1.2.2.1.2": "ifDescr",
+            "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
+        }
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifIndex.143", result)
+        self.assertIn("ifIndex.sequence", result)
+        self.assertEqual(result["ifIndex.143"], "143")
+        self.assertEqual(result["ifIndex.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifAdminStatus"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifAdminStatus.143", result)
+        self.assertIn("ifAdminStatus.sequence", result)
+        self.assertEqual(result["ifAdminStatus.143"], "2")
+        self.assertEqual(result["ifAdminStatus.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifOperStatus"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifOperStatus.143", result)
+        self.assertIn("ifOperStatus.sequence", result)
+        self.assertEqual(result["ifOperStatus.143"], "2")
+        self.assertEqual(result["ifOperStatus.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifDescr"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifDescr.143", result)
+        self.assertIn("ifDescr.sequence", result)
+        self.assertEqual(result["ifDescr.143"], "F23")
+        self.assertEqual(result["ifDescr.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifAlias"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifAlias.143", result)
+        self.assertIn("ifAlias.sequence", result)
+        self.assertEqual(result["ifAlias.143"], "")
+        self.assertEqual(result["ifAlias.sequence"], "143")
+
+
+class TestDecodeSnmpV2(BaseTestCase):
+
+    baseOidMap = {
+        # Std var binds in SnmpV2 traps/notifications
+        "1.3.6.1.2.1.1.3": "sysUpTime",
+        "1.3.6.1.6.3.1.1.4.1": "snmpTrapOID",
+
+        # SnmpV2 Traps (snmpTrapOID.0 values)
+        "1.3.6.1.6.3.1.1.5.1": "coldStart",
+        "1.3.6.1.6.3.1.1.5.2": "warmStart",
+        "1.3.6.1.6.3.1.1.5.3": "linkDown",
+        "1.3.6.1.6.3.1.1.5.4": "linkUp",
+        "1.3.6.1.6.3.1.1.5.5": "authenticationFailure",
+        "1.3.6.1.6.3.1.1.5.6": "egpNeighborLoss",
+    }
+
+    def makePacket(self, trapType):
+        pckt = FakePacket()
+        pckt.version = SNMPv2
+        pckt.host = "localhost"
+        pckt.port = 162
+
+        if isinstance(trapType, (str, unicode)):
+            trapType = tuple(map(int, trapType.split('.')))
+        pckt.variables = [
+            ((1, 3, 6, 1, 2, 1, 1, 3, 0), 5342),
+            ((1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0), trapType)
+        ]
+        pckt.community = "public"
+        pckt.enterprise_length = 0
+        return pckt
+
+    def makeTask(self, extraOidMap={}):
+        oidMap = self.baseOidMap.copy()
+        oidMap.update(extraOidMap)
+        return MockTrapTask(oidMap)
+
+    def test_SnmpVersion(self):
+        pckt = self.makePacket("1.2.3")
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertIn("snmpVersion", result)
+        self.assertEqual(result["snmpVersion"], "2")
+
+    def test_UnknownTrapType(self):
+        pckt = self.makePacket("1.2.3")
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertEqual(eventType, "1.2.3")
+        self.assertIn("snmpVersion", result)
+        self.assertIn("oid", result)
+        self.assertIn("device", result)
+        self.assertEqual(result["snmpVersion"], "2")
+        self.assertEqual(result["oid"], "1.2.3")
+        self.assertEqual(result["device"], "localhost")
+
+    def test_KnownTrapType(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertIn("oid", result)
+        self.assertEqual(eventType, "coldStart")
+        self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.1")
+
+    def test_TrapAddressOID(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
+        pckt.variables.append((
+            (1, 3, 6, 1, 6, 3, 18, 1, 3), "192.168.51.100"
+        ))
+        task = self.makeTask({
+            "1.3.6.1.6.3.18.1.3": "snmpTrapAddress"
+        })
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertIn("snmpTrapAddress", result)
+        self.assertEqual(result["snmpTrapAddress"], "192.168.51.100")
+        self.assertEqual(result["device"], "192.168.51.100")
+
+    def test_RenamedLinkDown(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertIn("oid", result)
+        self.assertEqual(eventType, "snmp_linkDown")
+        self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.3")
+
+    def test_RenamedLinkUp(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.4")
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertIn("oid", result)
+        self.assertEqual(eventType, "snmp_linkUp")
+        self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.4")
+
+    def test_VarBindMultiValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        ))
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
+
+    def test_UnknownMultiVarBind(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.1")
+        pckt.variables.extend((
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 1), "bar"),
+        ))
+        task = self.makeTask()
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("1.2.6.0", result)
+        self.assertIn("1.2.6.1", result)
+        self.assertEqual(result["1.2.6.0"], "foo")
+        self.assertEqual(result["1.2.6.1"], "bar")
+
+    def test_NamedVarBindOneValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.append(
+            ((1, 2, 6, 7), "foo"),
+        )
+        task = self.makeTask({"1.2.6.7": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "foo")
+
+    def test_NamedVarBindMultiValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        ))
+        task = MockTrapTask({"1.2.6.7": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "foo,bar,baz")
+
+    def test_PartialNamedVarBindOneValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.append(
+            ((1, 2, 6, 7), "foo"),
+        )
+        task = MockTrapTask({"1.2.6": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.7"], "foo")
+        self.assertEqual(result["testVar.sequence"], "7")
+
+    def test_PartialNamedVarBindMultiValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 2, 6, 7), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 7), "baz"),
+        ))
+        task = MockTrapTask({"1.2.6": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.7"], "foo,bar,baz")
+        self.assertEqual(result["testVar.sequence"], "7,7,7")
+
+    def test_PartialNamedMultiVarBind(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 1), "bar"),
+            ((1, 2, 6, 2), "baz"),
+        ))
+        task = MockTrapTask({"1.2.6": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 4)
+        self.assertIn("testVar.0", result)
+        self.assertIn("testVar.1", result)
+        self.assertIn("testVar.2", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.0"], "foo")
+        self.assertEqual(result["testVar.1"], "bar")
+        self.assertEqual(result["testVar.2"], "baz")
+        self.assertEqual(result["testVar.sequence"], "0,1,2")
+
+    def test_PartialNamedVarBindNoneValue(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.append(
+            ((1, 2, 6, 0), None),
+        )
+        task = MockTrapTask({"1.2.6.0": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 1)
+        self.assertIn("testVar", result)
+        self.assertEqual(result["testVar"], "None")
+
+    def test_PartialNamedMultiVarBindOrder(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 2, 6, 0), "foo"),
+            ((1, 2, 6, 7), "bar"),
+            ((1, 2, 6, 3), "baz"),
+        ))
+        task = MockTrapTask({"1.2.6": "testVar"})
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+        self.assertEqual(totalVarKeys, 4)
+        self.assertIn("testVar.0", result)
+        self.assertIn("testVar.7", result)
+        self.assertIn("testVar.3", result)
+        self.assertIn("testVar.sequence", result)
+        self.assertEqual(result["testVar.0"], "foo")
+        self.assertEqual(result["testVar.7"], "bar")
+        self.assertEqual(result["testVar.3"], "baz")
+        self.assertEqual(result["testVar.sequence"], "0,7,3")
+
+    def test_ifentry_trap(self):
+        pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
+        pckt.variables.extend((
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
+            ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
+            ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
+        ))
+        oidMap = {
+            "1.3.6.1.2.1.2.2.1.1": "ifIndex",
+            "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
+            "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
+            "1.3.6.1.2.1.2.2.1.2": "ifDescr",
+            "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
+        }
+        task = MockTrapTask(oidMap)
+        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifIndex.143", result)
+        self.assertIn("ifIndex.sequence", result)
+        self.assertEqual(result["ifIndex.143"], "143")
+        self.assertEqual(result["ifIndex.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifAdminStatus"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifAdminStatus.143", result)
+        self.assertIn("ifAdminStatus.sequence", result)
+        self.assertEqual(result["ifAdminStatus.143"], "2")
+        self.assertEqual(result["ifAdminStatus.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifOperStatus"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifOperStatus.143", result)
+        self.assertIn("ifOperStatus.sequence", result)
+        self.assertEqual(result["ifOperStatus.143"], "2")
+        self.assertEqual(result["ifOperStatus.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifDescr"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifDescr.143", result)
+        self.assertIn("ifDescr.sequence", result)
+        self.assertEqual(result["ifDescr.143"], "F23")
+        self.assertEqual(result["ifDescr.sequence"], "143")
+
+        totalVarKeys = sum(1 for k in result if k.startswith("ifAlias"))
+        self.assertEqual(totalVarKeys, 2)
+        self.assertIn("ifAlias.143", result)
+        self.assertIn("ifAlias.sequence", result)
+        self.assertEqual(result["ifAlias.143"], "")
+        self.assertEqual(result["ifAlias.sequence"], "143")
+
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(DecodersUnitTest))
+    suite.addTest(makeSuite(TestOid2Name))
+    suite.addTest(makeSuite(TestDecodeSnmpV1))
+    suite.addTest(makeSuite(TestDecodeSnmpV2))
     return suite

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -7,66 +7,55 @@
 #
 ##############################################################################
 
-
-__doc__ = """zentrap
+"""zentrap
 
 Creates events from SNMP Traps.
 Currently a wrapper around the Net-SNMP C library.
 """
 
-import time
-import sys
-import socket
-import errno
 import base64
+import ctypes as c  # Magical interfacing with C code
+import errno
 import logging
+import socket
+import sys
+import time
+
 from collections import defaultdict
-from struct import unpack
 from ipaddr import IPAddress
+from struct import unpack
 
-log = logging.getLogger("zen.zentrap")
+from pynetsnmp import netsnmp, twistedsnmp
+from twisted.internet import defer
+from twisted.python.failure import Failure
+from zope.component import queryUtility, getUtility, provideUtility
+from zope.interface import implementer
 
-# Magical interfacing with C code
-import ctypes as c
+from zenoss.protocols.protobufs.zep_pb2 import SEVERITY_WARNING
 
 import Globals
-import zope.interface
-import zope.component
-
-from twisted.python.failure import Failure
-from twisted.internet import defer
-
-from Products.ZenHub.interfaces import ICollectorEventTransformer
 
 from Products.ZenCollector.daemon import CollectorDaemon
 from Products.ZenCollector.interfaces import (
-    ICollector,
-    ICollectorPreferences,
-    IEventService,
-    IScheduledTask,
-    IStatisticsService
+    ICollector, ICollectorPreferences, IEventService,
+    IScheduledTask, IStatisticsService
 )
+from Products.ZenCollector.services.config import DeviceProxy
 from Products.ZenCollector.tasks import (
-    SimpleTaskFactory,
-    SimpleTaskSplitter,
-    BaseTask,
-    TaskStates
+    SimpleTaskFactory, SimpleTaskSplitter, BaseTask, TaskStates
 )
-from Products.ZenUtils.observable import ObservableMixin
-
-
-from pynetsnmp import netsnmp, twistedsnmp
-
-from Products.ZenUtils.captureReplay import CaptureReplay
 from Products.ZenEvents.EventServer import Stats
 from Products.ZenEvents.TrapFilter import TrapFilter, TrapFilterError
 from Products.ZenEvents.ZenEventClasses import Clear, Critical
-from Products.ZenUtils.Utils import unused
-from Products.ZenCollector.services.config import DeviceProxy
+from Products.ZenHub.interfaces import ICollectorEventTransformer
 from Products.ZenHub.services.SnmpTrapConfig import User
+from Products.ZenUtils.captureReplay import CaptureReplay
+from Products.ZenUtils.observable import ObservableMixin
+from Products.ZenUtils.Utils import unused
+
 unused(Globals, DeviceProxy, User)
 
-from zenoss.protocols.protobufs.zep_pb2 import SEVERITY_WARNING
+log = logging.getLogger("zen.zentrap")
 
 # This is what struct sockaddr_in {} looks like
 family = [('family', c.c_ushort)]
@@ -89,11 +78,14 @@ class sockaddr_in6(c.Structure):
         ('scope_id', c.c_ubyte * 4),
     ]
 
-_pre_parse_factory = c.CFUNCTYPE(c.c_int,
-                                 c.POINTER(netsnmp.netsnmp_session),
-                                 c.POINTER(netsnmp.netsnmp_transport),
-                                 c.c_void_p,
-                                 c.c_int)
+
+_pre_parse_factory = c.CFUNCTYPE(
+    c.c_int,
+    c.POINTER(netsnmp.netsnmp_session),
+    c.POINTER(netsnmp.netsnmp_transport),
+    c.c_void_p,
+    c.c_int
+)
 
 # teach python that the return type of snmp_clone_pdu is a pdu pointer
 netsnmp.lib.snmp_clone_pdu.restype = netsnmp.netsnmp_pdu_p
@@ -112,13 +104,13 @@ class FakePacket(object):
         self.fake = True
 
 
+@implementer(ICollectorPreferences)
 class SnmpTrapPreferences(CaptureReplay):
-    zope.interface.implements(ICollectorPreferences)
 
     def __init__(self):
         """
-        Constructs a new PingCollectionPreferences instance and
-        provides default values for needed attributes.
+        Initializes a SnmpTrapPreferences instance and provides
+        default values for needed attributes.
         """
         self.collectorName = 'zentrap'
         self.configCycleInterval = 20  # minutes
@@ -149,45 +141,38 @@ class SnmpTrapPreferences(CaptureReplay):
             pass
         parser.add_option(
             '--trapport', '-t',
-            dest='trapport',
-            type='int',
-            default=TRAP_PORT,
+            dest='trapport', type='int', default=TRAP_PORT,
             help="Listen for SNMP traps on this port rather than the default"
         )
         parser.add_option(
             '--useFileDescriptor',
-            dest='useFileDescriptor',
-            type='int',
-            help=("Read from an existing connection "
-                  "rather than opening a new port."),
-            default=None
+            dest='useFileDescriptor', type='int', default=None,
+            help="Read from an existing connection "
+            "rather than opening a new port."
         )
         parser.add_option(
             '--trapFilterFile',
-            dest='trapFilterFile',
-            type='string',
-            help=("File that contains trap oids to keep, "
-                  "should be in $ZENHOME/etc."),
-            default=None
+            dest='trapFilterFile', type='string', default=None,
+            help="File that contains trap oids to keep, "
+            "should be in $ZENHOME/etc."
         )
 
         self.buildCaptureReplayOptions(parser)
 
     def postStartup(self):
         # Ensure that we always have an oidMap
-        daemon = zope.component.getUtility(ICollector)
+        daemon = getUtility(ICollector)
         daemon.oidMap = {}
         # add our collector's custom statistics
-        statService = zope.component.queryUtility(IStatisticsService)
+        statService = queryUtility(IStatisticsService)
         statService.addStatistic("events", "COUNTER")
 
 
 def ipv6_is_enabled():
-    "test if ipv6 is enabled"
-
+    """test if ipv6 is enabled
+    """
     # hack for ZEN-12088 - TODO: remove next line
     return False
-
     try:
         socket.socket(socket.AF_INET6, socket.SOCK_DGRAM, 0)
     except socket.error as e:
@@ -197,17 +182,19 @@ def ipv6_is_enabled():
     return True
 
 
+@implementer(IScheduledTask)
 class TrapTask(BaseTask, CaptureReplay):
     """
     Listen for SNMP traps and turn them into events
     Connects to the TrapService service in zenhub.
     """
-    zope.interface.implements(IScheduledTask)
 
-    def __init__(self, taskName, configId,
-                 scheduleIntervalSeconds=3600, taskConfig=None):
-        BaseTask.__init__(self, taskName, configId,
-                          scheduleIntervalSeconds, taskConfig)
+    def __init__(
+            self, taskName, configId, scheduleIntervalSeconds=3600,
+            taskConfig=None):
+        BaseTask.__init__(
+            self, taskName, configId, scheduleIntervalSeconds, taskConfig
+        )
         self.log = log
 
         # Needed for interface
@@ -215,15 +202,13 @@ class TrapTask(BaseTask, CaptureReplay):
         self.configId = configId
         self.state = TaskStates.STATE_IDLE
         self.interval = scheduleIntervalSeconds
-        self._daemon = zope.component.getUtility(ICollector)
-        self._eventService = zope.component.queryUtility(IEventService)
+        self._daemon = getUtility(ICollector)
+        self._eventService = queryUtility(IEventService)
         self._preferences = self._daemon
-        self._statService = zope.component.queryUtility(IStatisticsService)
+        self._statService = queryUtility(IStatisticsService)
         # For compatibility with captureReplay
         self.options = self._daemon.options
-
         self.oidMap = self._daemon.oidMap
-
         self.stats = Stats()
 
         # Command-line argument sanity checking
@@ -232,7 +217,7 @@ class TrapTask(BaseTask, CaptureReplay):
         self._replayStarted = False
         if not self.options.replayFilePrefix:
             trapPort = self._preferences.options.trapport
-            if not self._preferences.options.useFileDescriptor and trapPort < 1024:
+            if not self.options.useFileDescriptor and trapPort < 1024:
                 listen_ip = "ipv6" if ipv6_is_enabled() else "0.0.0.0"
                 # Makes call to zensocket here
                 # does an exec* so it never returns
@@ -257,10 +242,9 @@ class TrapTask(BaseTask, CaptureReplay):
                 fileno = -1
             self._pre_parse_callback = _pre_parse_factory(self._pre_parse)
             debug = self.log.isEnabledFor(logging.DEBUG)
-            self.session.awaitTraps(listening_address,
-                                    fileno,
-                                    self._pre_parse_callback,
-                                    debug)
+            self.session.awaitTraps(
+                listening_address, fileno, self._pre_parse_callback, debug
+            )
             self.session.callback = self.receiveTrap
             twistedsnmp.updateReactor()
 
@@ -292,15 +276,11 @@ class TrapTask(BaseTask, CaptureReplay):
         @return: enterprise string
         @rtype: string
         """
-        def lp2oid(ptr, length):
-            "Convert a pointer to an array of longs to an OID"
-            return '.'.join([str(ptr[i]) for i in range(length)])
-
         if hasattr(pdu, "fake"):  # Replaying a packet
-            enterprise = pdu.enterprise
-        else:
-            enterprise = lp2oid(pdu.enterprise, pdu.enterprise_length)
-        return enterprise
+            return pdu.enterprise
+        return '.'.join(
+            str(pdu.enterprise[i]) for i in range(pdu.enterprise_length)
+        )
 
     def getResult(self, pdu):
         """
@@ -312,10 +292,8 @@ class TrapTask(BaseTask, CaptureReplay):
         @rtype: dictionary
         """
         if hasattr(pdu, "fake"):  # Replaying a packet
-            variables = pdu.variables
-        else:
-            variables = netsnmp.getResult(pdu)
-        return variables
+            return pdu.variables
+        return netsnmp.getResult(pdu)
 
     def getCommunity(self, pdu):
         """
@@ -326,13 +304,11 @@ class TrapTask(BaseTask, CaptureReplay):
         @return: SNMP community
         @rtype: string
         """
-        community = ''
         if hasattr(pdu, "fake"):  # Replaying a packet
-            community = pdu.community
+            return pdu.community
         elif pdu.community_len:
-                community = c.string_at(pdu.community, pdu.community_len)
-
-        return community
+            return c.string_at(pdu.community, pdu.community_len)
+        return ''
 
     def convertPacketToPython(self, addr, pdu):
         """
@@ -392,10 +368,7 @@ class TrapTask(BaseTask, CaptureReplay):
 
         oid = oid.strip('.')
         if exactMatch:
-            if oid in self.oidMap:
-                return self.oidMap[oid]
-            else:
-                return oid
+            return self.oidMap.get(oid, oid)
 
         oidlist = oid.split('.')
         for i in range(len(oidlist), 0, -1):
@@ -406,37 +379,41 @@ class TrapTask(BaseTask, CaptureReplay):
             oid_trail = oidlist[i:]
             if len(oid_trail) > 0 and not strip:
                 return "%s.%s" % (name, '.'.join(oid_trail))
-            else:
-                return name
+            return name
 
         return oid
 
-    def _pre_parse(self, session, transport, transport_data,
-                   transport_data_length):
+    def _pre_parse(
+            self, session, transport, transport_data, transport_data_length):
         """Called before the net-snmp library parses the PDU. In the case
         where a v3 trap comes in with unkwnown credentials, net-snmp silently
         discards the packet. This method gives zentrap a way to log that these
-        packets were received to help with troubleshooting."""
+        packets were received to help with troubleshooting.
+        """
         if self.log.isEnabledFor(logging.DEBUG):
-            ipv6_socket_address = c.cast(transport_data,
-                                         c.POINTER(sockaddr_in6)
-                                         ).contents
+            ipv6_socket_address = c.cast(
+                transport_data, c.POINTER(sockaddr_in6)
+            ).contents
             if ipv6_socket_address.family == socket.AF_INET6:
                 self.log.debug(
                     "pre_parse: IPv6 %s",
-                    socket.inet_ntop(socket.AF_INET6, ipv6_socket_address.addr)
+                    socket.inet_ntop(
+                        socket.AF_INET6, ipv6_socket_address.addr
+                    )
                 )
             elif ipv6_socket_address.family == socket.AF_INET:
-                ipv4_socket_address = c.cast(transport_data,
-                                             c.POINTER(sockaddr_in)
-                                             ).contents
+                ipv4_socket_address = c.cast(
+                    transport_data, c.POINTER(sockaddr_in)
+                ).contents
                 self.log.debug(
                     "pre_parse: IPv4 %s",
                     socket.inet_ntop(socket.AF_INET, ipv4_socket_address.addr)
                 )
             else:
-                self.log.debug("pre_parse: unexpected address family: %s",
-                               ipv6_socket_address.family)
+                self.log.debug(
+                    "pre_parse: unexpected address family: %s",
+                    ipv6_socket_address.family
+                )
         return 1
 
     def receiveTrap(self, pdu):
@@ -454,27 +431,31 @@ class TrapTask(BaseTask, CaptureReplay):
             self.log.error("PDU does not contain transport data")
             return
 
-        ipv6_socket_address = c.cast(pdu.transport_data,
-                                     c.POINTER(sockaddr_in6)
-                                     ).contents
+        ipv6_socket_address = c.cast(
+            pdu.transport_data, c.POINTER(sockaddr_in6)
+        ).contents
         if ipv6_socket_address.family == socket.AF_INET6:
             if pdu.transport_data_length < c.sizeof(sockaddr_in6):
-                self.log.error("PDU transport data is too small "
-                               "for sockaddr_in6 struct.")
+                self.log.error(
+                    "PDU transport data is too small for sockaddr_in6 struct."
+                )
                 return
             ip_address = self.getPacketIp(ipv6_socket_address.addr)
         elif ipv6_socket_address.family == socket.AF_INET:
             if pdu.transport_data_length < c.sizeof(sockaddr_in):
-                self.log.error("PDU transport data is too small "
-                               "for sockaddr_in struct.")
+                self.log.error(
+                    "PDU transport data is too small for sockaddr_in struct."
+                )
                 return
-            ipv4_socket_address = c.cast(pdu.transport_data,
-                                         c.POINTER(sockaddr_in)
-                                         ).contents
+            ipv4_socket_address = c.cast(
+                pdu.transport_data, c.POINTER(sockaddr_in)
+            ).contents
             ip_address = '.'.join(str(i) for i in ipv4_socket_address.addr)
         else:
-            self.log.error("Got a packet with unrecognized network family: %s",
-                           ipv6_socket_address.family)
+            self.log.error(
+                "Got a packet with unrecognized network family: %s",
+                ipv6_socket_address.family
+            )
             return
 
         port = socket.ntohs(ipv6_socket_address.port)
@@ -535,10 +516,9 @@ class TrapTask(BaseTask, CaptureReplay):
             netsnmp.lib.snmp_free_pdu(dup)
             return result
 
-        d = defer.maybeDeferred(self.asyncHandleTrap,
-                                (ip_address, port),
-                                dup.contents,
-                                ts)
+        d = defer.maybeDeferred(
+            self.asyncHandleTrap, (ip_address, port), dup.contents, ts
+        )
         d.addBoth(cleanup)
 
     def snmpInform(self, addr, pdu):
@@ -555,12 +535,14 @@ class TrapTask(BaseTask, CaptureReplay):
         reply.contents.errindex = 0
 
         # FIXME: might need to add udp6 for IPv6 addresses
-        sess = netsnmp.Session(peername='%s:%d' % tuple(addr),
-                               version=pdu.version)
+        sess = netsnmp.Session(
+            peername='%s:%d' % tuple(addr), version=pdu.version
+        )
         sess.open()
         if not netsnmp.lib.snmp_send(sess.sess, reply):
-            netsnmp.lib.snmp_sess_perror("Unable to send inform PDU",
-                                         self.session.sess)
+            netsnmp.lib.snmp_sess_perror(
+                "Unable to send inform PDU", self.session.sess
+            )
             netsnmp.lib.snmp_free_pdu(reply)
         sess.close()
 
@@ -779,59 +761,56 @@ class Decoders:
         10      11     minutes from UTC          0..59
         """
         try:
-            # Some traps send invalid UTC times (direction/hours/minutes all zeros)
-            if value[8:] == '\x00\x00\x00':
-                value = value[:8]
-            vallen = len(value)
-            if vallen == 8 or (vallen == 11 and value[8] in ('+', '-')):
-                (year, mon, day,
-                 hour, mins, secs, dsecs) = unpack(">HBBBBBB", value[:8])
-                # Ensure valid date representation
-                if mon < 1 or mon > 12:
-                    return None
-                if day < 1 or day > 31:
-                    return None
-                if hour < 0 or hour > 23:
-                    return None
-                if mins > 60:
-                    return None
-                if secs > 60:
-                    return None
-                if dsecs > 9:
-                    return None
-                if vallen == 11:
-                    utc_dir = value[8]
-                    (utc_hours, utc_mins) = unpack(">BB", value[9:])
+            dt, tz = value[:8], value[8:]
+            if len(dt) != 8 or len(tz) != 3:
+                return None
+            (year, mon, day, hour, mins, secs, dsecs) = unpack(">HBBBBBB", dt)
+            # Ensure valid date representation
+            invalid = (
+                (mon < 1 or mon > 12),
+                (day < 1 or day > 31),
+                (hour > 23),
+                (mins > 59),
+                (secs > 60),
+                (dsecs > 9),
+            )
+            if any(invalid):
+                return None
+            (utc_dir, utc_hour, utc_min) = unpack(">cBB", tz)
+            # Some traps send invalid UTC times (direction is 0)
+            if utc_dir == '\x00':
+                tz_min = time.timezone / 60
+                if tz_min < 0:
+                    utc_dir = '-'
+                    tz_min = -tz_min
                 else:
-                    tz_mins = time.timezone / 60
-                    if tz_mins < 0:
-                        utc_dir = '-'
-                        tz_mins = -tz_mins
-                    else:
-                        utc_dir = '+'
-                    utc_hours = tz_mins / 60
-                    utc_mins = tz_mins % 60
-                return "%04d-%02d-%02dT%02d:%02d:%02d.%d00%s%02d:%02d" % (
-                    year, mon, day, hour, mins, secs,
-                    dsecs, utc_dir, utc_hours, utc_mins)
-
+                    utc_dir = '+'
+                utc_hour = tz_min / 60
+                utc_min = tz_min % 60
+            if utc_dir not in ('+', '-'):
+                return None
+            return "%04d-%02d-%02dT%02d:%02d:%02d.%d00%s%02d:%02d" % (
+                year, mon, day, hour, mins, secs,
+                dsecs, utc_dir, utc_hour, utc_min
+            )
         except TypeError:
             pass
 
     @staticmethod
     def oid(value):
-        if isinstance(value, tuple) and len(value) > 2:
-            if value[0] in [0, 1, 2] and all(isinstance(i, int) for i in value):
-                return '.'.join(map(str, value))
+        if isinstance(value, tuple) \
+                and len(value) > 2 \
+                and value[0] in (0, 1, 2) \
+                and all(isinstance(i, int) for i in value):
+            return '.'.join(map(str, value))
 
     @staticmethod
     def number(value):
-        if type(value) in [long, int]:
-            return value
+        return value if isinstance(value, (long, int)) else None
 
     @staticmethod
     def ipaddress(value):
-        for version in [socket.AF_INET, socket.AF_INET6]:
+        for version in (socket.AF_INET, socket.AF_INET6):
             try:
                 return socket.inet_ntop(version, value)
             except (ValueError, TypeError):
@@ -876,12 +855,12 @@ def decode_snmp_value(value):
         log.exception("Unexpected exception: %s", err)
 
 
+@implementer(IScheduledTask)
 class MibConfigTask(ObservableMixin):
     """
     Receive a configuration object containing MIBs and update the
     mapping of OIDs to names.
     """
-    zope.interface.implements(IScheduledTask)
 
     def __init__(self, taskName, configId,
                  scheduleIntervalSeconds=3600, taskConfig=None):
@@ -893,7 +872,7 @@ class MibConfigTask(ObservableMixin):
         self.state = TaskStates.STATE_IDLE
         self.interval = scheduleIntervalSeconds
         self._preferences = taskConfig
-        self._daemon = zope.component.getUtility(ICollector)
+        self._daemon = getUtility(ICollector)
 
         self._daemon.oidMap = self._preferences.oidMap
 
@@ -910,10 +889,7 @@ class TrapDaemon(CollectorDaemon):
 
     def __init__(self, *args, **kwargs):
         self._trapFilter = TrapFilter()
-        zope.component.provideUtility(
-            self._trapFilter,
-            ICollectorEventTransformer
-        )
+        provideUtility(self._trapFilter, ICollectorEventTransformer)
         kwargs["initializationCallback"] = self._initializeTrapFilter
         super(TrapDaemon, self).__init__(*args, **kwargs)
 


### PR DESCRIPTION
When a series of trap variables are detected, a 'sequence' event detail is added to show the order of the sequence.  E.g., given the following SNMP trap varbinds:
```
   someVar.0  Data0
   someVar.1  Data1
```
the following details are added to the event:
```
   someVar.0  Data0
   someVar.1  Data1
   someVar.sequence  0,1
```
Fixes ZEN-29016.