### PR TITLE
ZEN-29494: RM upgrade fails on dependencies for zenpacks that don't start ZenPacks.zenoss

### DIFF
--- a/Products/ZenUtils/zenpack.py
+++ b/Products/ZenUtils/zenpack.py
@@ -445,7 +445,7 @@ class ZenPackCmd(ZenScriptBase):
         # Respect the source of the pack
         zpsToSort = {}
 
-        pattern = '(ZenPacks\.zenoss\.[a-zA-Z\.]*)'
+        pattern = '(ZenPacks\.(?:[a-zA-Z]+\.?){2,})'
         for zpId,zpDetails in zpsToRestore.items():
             if zpDetails[2] == ZPSource.disk:
                 zp = get_distribution(zpId)


### PR DESCRIPTION
…migration scripts ...