### PR TITLE
ZEN-29562: Cannot upgrade MultiRealmIP Zenpack from 2.2.2 to 2.2.3

### DIFF
--- a/bin/fix_MultiRealmIPZenPack.sh
+++ b/bin/fix_MultiRealmIPZenPack.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+ZP_NAME=MultiRealmIP
+FIXED_VERSION=2.2.4
+EGG=`find /opt/zenoss/ZenPacks/ -name ZenPacks.zenoss.${ZP_NAME}* | head -n 1`
+
+function version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+
+if [[ -z "$EGG" ]]; then
+  exit
+else
+  CURRENT_VERSION=$(echo $EGG| cut -d'-' -f 2)
+  if version_gt $FIXED_VERSION $CURRENT_VERSION; then
+    echo "ZenPacks.zenoss.${ZP_NAME}-${CURRENT_VERSION}-py2.7.egg needs patching. Issue ZEN-29562"
+    FILE_TO_PATCH=$EGG/ZenPacks/zenoss/${ZP_NAME}/__init__.py
+    patch -N $FILE_TO_PATCH <<__EOF__
+--- __init__.py
++++ __init__.py
+@@ -47,8 +47,6 @@ Important Methods that are changed are:
+
+ """
+
+-__import__('pkg_resources').declare_namespace(__name__)
+-
+ import Globals
+ import os
+ import os.path
+__EOF__
+  fi
+fi
+


### PR DESCRIPTION
```
...
...
INFO:zen.ZenPackCmd:Successfully restored zenpacks!
/opt/zenoss/Products/ZenUtils/MySqlZodbFactory.py:172: UserWarning: poll_interval is ignored
  storage = relstorage.storage.RelStorage(adapter, **relstoreParams)
INFO:zen.migrate:Installing AddLagAndZEPEventClasses (200.1.1)
2018-02-16 12:52:58 INFO zen.migrate: Installing AddLagAndZEPEventClasses (200.1.1)
INFO:zen.migrate:Installing AddMemcachedForSessions (200.1.1)
2018-02-16 12:52:58 INFO zen.migrate: Installing AddMemcachedForSessions (200.1.1)
INFO:zen.migrate:Found 1 services named 'memcached'.
2018-02-16 12:52:58 INFO zen.migrate: Found 1 services named 'memcached'.
2018-02-16 12:52:58 INFO zen.migrate: Loading Reports
INFO:zen.migrate:Loading Reports
2018-02-16 12:53:00 INFO zen.migrate: Committing changes
2018-02-16 12:53:00 INFO zen.migrate: Migration successful
time="2018-02-16T12:53:53Z" level=info msg="Loaded delegate keys from file" keyfile="/etc/serviced/delegate.keys" location="localkeys.go:320" logger=auth 
ZenPacks.zenoss.MultiRealmIP-2.2.3-py2.7.egg needs patching. Issue ZEN-29562
patching file /opt/zenoss/ZenPacks/ZenPacks.zenoss.MultiRealmIP-2.2.3-py2.7.egg/ZenPacks/zenoss/MultiRealmIP/__init__.py
8lzjjn7opnvip1fjezipdbj18_20180216-125428.198
Script done, file is /var/log/serviced/script-2018-02-16-123919-root.log
Looking up service Zenoss.resmgr
Service Zenoss.resmgr has version 6.1.1
Set new version 6.1.1
Saving new version of Zenoss.resmgr
[root@ip-10-111-23-147 6.1.x]#
[root@ip-10-111-23-147 6.1.x]# wget http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.MultiRealmIP/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.egg
--2018-02-16 12:58:16--  http://jenkins.zenosslabs.com/view/0%20-%20Master/job/master-ZenPacks.zenoss.MultiRealmIP/lastSuccessfulBuild/artifact/dist/ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.egg
Resolving jenkins.zenosslabs.com (jenkins.zenosslabs.com)... 10.111.1.64
Connecting to jenkins.zenosslabs.com (jenkins.zenosslabs.com)|10.111.1.64|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 39774 (39K) [application/octet-stream]
Saving to: ‘ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.egg’

100%[=========================================================================================================================================>] 39 774      --.-K/s   in 0s      

2018-02-16 12:58:16 (83,9 MB/s) - ‘ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.egg’ saved [39774/39774]
[root@ip-10-111-23-147 6.1.x]# serviced service run zope zenpack-manager install ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.eggtime="2018-02-16T12:58:36Z" level=info msg="Loaded delegate keys from file" keyfile="/etc/serviced/delegate.keys" location="localkeys.go:320" logger=auth 
2018/02/16 12:58:41.384088 tls.go:200: WARN SSL/TLS verifications disabled.
/opt/zenoss/Products/ZenUtils/MySqlZodbFactory.py:172: UserWarning: poll_interval is ignored
  storage = relstorage.storage.RelStorage(adapter, **relstoreParams)
INFO:zen.ZenPackCMD:Previous ZenPack exists with same name ZenPacks.zenoss.MultiRealmIP
INFO:zen.ZenPackCMD:installing zenpack ZenPacks.zenoss.MultiRealmIP; launching process
/opt/zenoss/Products/ZenUtils/MySqlZodbFactory.py:172: UserWarning: poll_interval is ignored
  storage = relstorage.storage.RelStorage(adapter, **relstoreParams)
2018-02-16 12:59:02,975 INFO zen.HookReportLoader: Loading reports from /opt/zenoss/ZenPacks/ZenPacks.zenoss.MultiRealmIP-2.2.4-py2.7.egg/ZenPacks/zenoss/MultiRealmIP/reports
2018-02-16 12:59:03,143 INFO zenoss.model_catalog_reindexer: Performing soft reindex on model_catalog. Params = root:'/zport/dmd/Networks' / idxs:'('iprealm',)' / types:'Products.Zuul.catalog.indexable.IpAddressIndexable'
2018-02-16 12:59:03,518 INFO zenoss.model_catalog_reindexer: Reindexing took 0.375274896622 seconds.
[root@ip-10-111-23-147 6.1.x]# 
```