### PR TITLE
ZEN-29575 Set max size for metrics to default value

### DIFF
--- a/Products/ZenHub/metricpublisher/publisher.py
+++ b/Products/ZenHub/metricpublisher/publisher.py
@@ -142,7 +142,7 @@ class RedisListPublisher(BasePublisher):
                  buflen=defaultMetricBufferSize,
                  pubfreq=defaultPublishFrequency,
                  channel=defaultMetricsChannel,
-                 maxOutstandingMetrics=defaultMetricBufferSize):
+                 maxOutstandingMetrics=defaultMaxOutstandingMetrics):
         super(RedisListPublisher, self).__init__(buflen, pubfreq)
         self._batch_size = INITIAL_REDIS_BATCH
         self._host = host


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29575
port https://github.com/zenoss/zenoss-prodbin/pull/3050