### PR TITLE
ZEN-26277: Error decoding twisted.python.failure exceptions

### DIFF
--- a/Products/ZenUtils/Exceptions.py
+++ b/Products/ZenUtils/Exceptions.py
@@ -6,8 +6,7 @@
 # License.zenoss under the directory where your Zenoss product is installed.
 #
 ##############################################################################
-from exceptions import ImportError, Exception
-from zope.dottedname.resolve import resolve
+from exceptions import Exception
 
 
 class ZentinelException(Exception):
@@ -27,53 +26,20 @@ class ZenResolveExceptionError(ZentinelException):
 
 
 def resolveException(failure):
-    """
-    Resolves a twisted.python.failure into the remote exception type that was
-    initially raised.
-    """
-
-    # return the original exception
-    if isinstance(failure.value, Exception):
-        return failure.value
-
-    # try to rebuild the exception from its type string
-    if isinstance(failure.type, str):
-        return _resolve_exception_by_type(failure)
-
-    # last ditch attempt: raise the original exception and return its value
-    try:
-        failure.raiseException()
-    except Exception as err:
-        return err
-
-
-def _resolve_exception_by_type(failure):
-    if failure.type in special_resolvers:
-        return special_resolvers[failure.type](failure)
-
-    try:
-        exctype = resolve(failure.type)
-        return exctype(failure.value, failure.tb)
-    except ImportError:
-        return ZenResolveExceptionError(
-            failure.value,
-            failure.tb,
-            failure.__dict__
-        )
-
-
-# special resolvers for Exceptions that require additional args
-def _resolve_twisted_spread_pb_RemoteError(failure):
-    '''special resolution steps for twisted RemoteErrors
+    '''Given a twisted.python.failure
+    return the remote exception type that was initially raised.
     '''
-    err_type = resolve(failure.type)
-    return err_type(
-        remoteType=failure.remoteType(),
-        value=failure.getErrorMessage(),
-        remoteTraceback=failure.getTracebackObject()
-    )
 
+    try:
+        # return the original exception
+        if isinstance(failure.value, Exception):
+            return failure.value
 
-special_resolvers = {
-    'twisted.spread.pb.RemoteError': _resolve_twisted_spread_pb_RemoteError,
-}
+        # raise the original exception capture and return it
+        try:
+            failure.raiseException()
+        except Exception as err:
+            return err
+
+    except Exception:
+        return ZenResolveExceptionError(failure)

--- a/Products/ZenUtils/Exceptions.py
+++ b/Products/ZenUtils/Exceptions.py
@@ -10,11 +10,6 @@ from exceptions import ImportError, Exception
 from zope.dottedname.resolve import resolve
 
 
-from twisted.python.failure import Failure
-import logging
-log = logging.getLogger("zen.Exceptions")
-
-
 class ZentinelException(Exception):
     """Root of all Zentinel Exceptions"""
     pass
@@ -32,9 +27,10 @@ class ZenResolveExceptionError(ZentinelException):
 
 
 def resolveException(failure):
-    '''given a twisted.python.failure
-    return the exception that was initially raised.
-    '''
+    """
+    Resolves a twisted.python.failure into the remote exception type that was
+    initially raised.
+    """
 
     # return the original exception
     if isinstance(failure.value, Exception):
@@ -42,16 +38,16 @@ def resolveException(failure):
 
     # try to rebuild the exception from its type string
     if isinstance(failure.type, str):
-        return _resolve_exception_string(failure)
+        return _resolve_exception_by_type(failure)
 
     # last ditch attempt: raise the original exception and return its value
     try:
         failure.raiseException()
-    except Exception as e:
-        return e
+    except Exception as err:
+        return err
 
 
-def _resolve_exception_string(failure):
+def _resolve_exception_by_type(failure):
     if failure.type in special_resolvers:
         return special_resolvers[failure.type](failure)
 
@@ -67,8 +63,6 @@ def _resolve_exception_string(failure):
 
 
 # special resolvers for Exceptions that require additional args
-
-
 def _resolve_twisted_spread_pb_RemoteError(failure):
     '''special resolution steps for twisted RemoteErrors
     '''

--- a/Products/ZenUtils/tests/testExceptions.py
+++ b/Products/ZenUtils/tests/testExceptions.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 
-from Products.ZenUtils.Exceptions import resolveException, ZentinelException, ZenPathError
+from unittest import TestCase
+
+from Products.ZenUtils.Exceptions import (
+    resolveException, ZentinelException, ZenPathError, ZenResolveExceptionError
+)
 from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
-class Failure(object):
+from twisted.spread.pb import RemoteError
+from twisted.python.failure import Failure
+
+
+class DummyFailure(object):
     def __init__(self):
         self.value = None
         self.type = None
@@ -13,30 +21,63 @@ class Failure(object):
     def raiseException(self):
         raise self.raise_value, self.type, self.tb
 
-class ExceptionTestCases(BaseTestCase):
-    def test_resolveException_with_exception_value(self):
-        failure = Failure()
-        failure.value = ZentinelException()
-        self.assertIs( failure.value, resolveException( failure))
+
+class ExceptionTestCases(TestCase): #BaseTestCase):
+
+    def test_resolveException(self):
+        exception = RuntimeError('genric exception')
+        twisted_failure = Failure(exception)
+        out = resolveException(twisted_failure)
+        self.assertIs(out, exception)
 
     def test_resolveException_with_exception_string(self):
-        failure = Failure()
+        '''LEGASY: twisted.python.Failure requires a valid exception
+        '''
+        failure = DummyFailure()
         failure.type = "Products.ZenUtils.Exceptions.ZenPathError"
-        self.assertIsInstance( resolveException( failure), ZenPathError)
+        out = resolveException(failure)
+        expected = ZenPathError(failure.value, failure.tb)
+        self.assertIsInstance(out, ZenPathError)
+        self.assertEqual(out.args, expected.args)
+        self.assertEqual(out.message, expected.message)
 
     def test_resolveException_with_exception_string_with_import_error(self):
-        failure = Failure()
+        '''LEGASY: twisted.python.Failure requires a valid exception                                 
+        '''
+        failure = DummyFailure()
         failure.value = "value"
         failure.tb = "tb"
         failure.type = "Products.ZenUtils.Exceptions.UnknownError"
-        actual = resolveException( failure)
-        self.assertIsInstance( actual, Exception)
-        self.assertEquals( ("value", "tb"), actual.args)
+        out = resolveException(failure)
+        expected = ZenResolveExceptionError(
+            failure.value, failure.tb, failure.__dict__
+        )
+        self.assertIsInstance(out, Exception)
+        self.assertEquals(out.args, ("value", "tb", failure.__dict__))
 
     def test_resolveException_with_raiseException(self):
-        failure = Failure()
+        failure = DummyFailure()
         failure.raise_value = RuntimeError()
-        self.assertIs( failure.raise_value, resolveException( failure))
+        self.assertIs(failure.raise_value, resolveException(failure))
+
+    def test_resolveException_handles_twisted_spread_pb_RemoteError(self):
+        error = RemoteError('remoteType', 'value', 'remoteTraceback')
+        failure = Failure(error)
+        #failure.type = 'twisted.spread.pb.RemoteError'
+        out = resolveException(failure)
+        self.assertEqual(out, error)
+
+    def test_resolveException_provides_usefull_exception_for_unknown(self):
+        failure = DummyFailure()
+        failure.type = 'some.unknown.exception'
+        out = resolveException(failure)
+        expected = ZenResolveExceptionError(
+            failure.value, failure.tb, failure.__dict__
+        )
+        self.assertIsInstance(out, ZenResolveExceptionError)
+        self.assertEqual(out.args, expected.args)
+
+
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
ZEN-26277: zenmodeler: TypeError: __init__() takes exactly 4 arguments (3 given)
ZEN-29059: Modelling can fail with cryptic traceback