### PR TITLE
ZEN-29810: Error decoding twisted.python.failure exceptions (#3064)

### DIFF
--- a/Products/ZenUtils/Exceptions.py
+++ b/Products/ZenUtils/Exceptions.py
@@ -1,48 +1,45 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2007, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
-import sys
-from exceptions import ImportError, Exception
-from zope.dottedname.resolve import resolve
+from exceptions import Exception
 
 
-class ZentinelException(Exception): 
+class ZentinelException(Exception):
     """Root of all Zentinel Exceptions"""
     pass
 
 
-class ZenPathError(ZentinelException): 
+class ZenPathError(ZentinelException):
     """When walking a path something along the way wasn't found."""
     pass
 
 
+class ZenResolveExceptionError(ZentinelException):
+    '''failed to resolve exception from twisted.python.failure.Failure
+    '''
+    pass
+
+
 def resolveException(failure):
-    """
-    Resolves a twisted.python.failure into the remote exception type that was
-    initially raised.
-    """
+    '''Given a twisted.python.failure
+    return the remote exception type that was initially raised.
+    '''
 
-    #raise the original exception
-    excvalue = failure.value
-    if isinstance(excvalue, Exception):
-        return excvalue
-
-    #if the original exception is a string, assume it defines a python exception
-    exctype = failure.type
-    if isinstance(exctype, basestring):
-        try:
-            exctype = resolve(failure.type)
-        except ImportError:
-            exctype = Exception
-        return exctype(excvalue, failure.tb)
-
-    #raise the original exception and return its value
     try:
-        failure.raiseException()
-    except:
-        return sys.exc_info()[1]
+        # return the original exception
+        if isinstance(failure.value, Exception):
+            return failure.value
+
+        # raise the original exception capture and return it
+        try:
+            failure.raiseException()
+        except Exception as err:
+            return err
+
+    except Exception:
+        return ZenResolveExceptionError(failure)


### PR DESCRIPTION
Fixes ZEN-29810, ZEN-26277, ZEN-29059

* RED: add test for twisted.spread.pb.RemoteError
* REFACTOR: test using actual Twisted Failure object
* GREEN: add handler for twisted.spread.pb.RemoteError
* REFACTOR: cleanup unittests
* REFACTOR: Remove special decoding of type strings

* if resolveException fails, wrap the failure object in a
ZenResolveExceptionError and return that.
* A twisted python failure should never have its type attribute set as a
string, it will cause an error if you try to construct one that way.