### PR TITLE
Fixes ZEN-29607

### DIFF
--- a/Products/ZenCallHome/ZenossAppData.py
+++ b/Products/ZenCallHome/ZenossAppData.py
@@ -237,7 +237,7 @@ class ZenossResourceData(object):
                 adapter.processDevice(stats)
             found_linked = False
             for name, adapter in getAdapters((device,), IDeviceLink):
-                if adapter.linkedDevice():
+                if adapter.linkedDevice() and adapter.linkedDevice().device().getProductionState() > 0:
                     key = "%s - %s" % (LINKED_DEVICES, name)
                     if key not in stats:
                         stats[key] = 0


### PR DESCRIPTION
The problem is when a vSphere endpoint is decommissioned there's no action to crawl the linked guest relationships and unlink them which causes this to append these to the list of linked guests. To get around this just becomes a quick lookup against the parent device of the link (which is the vSphere endpoint) and consider its production state, preventing previously linked guests who's vSphere endpoint have been set to decommissioned (or lower, in the case of custom prod states) from being counted in the MR calculation