### PR TITLE
ZEN-29823 Make ZEP more robust

### DIFF
--- a/Products/ZenEvents/tests/test_zeneventd.py
+++ b/Products/ZenEvents/tests/test_zeneventd.py
@@ -9,6 +9,7 @@ from Products.ZenEvents.zeneventd import (
     ZepRawEvent,
     CheckInputPipe,
     EventContext,
+    time
 )
 from Products.ZenEvents.events2.processing import EventProcessorPipe
 from zenoss.protocols.protobufs.zep_pb2 import EventActor
@@ -89,6 +90,32 @@ class EventPipelineProcessorTest(TestCase):
             zep_raw_event.event.message,
             exception_event.event.message
         )
+
+    def test_synchronize_with_database(self):
+        '''if self.SYNC_EVERY_EVENT:
+            doSync = True
+        else:
+            # sync() db if it has been longer than self.syncInterval
+            # since the last time
+            currentTime = datetime.now()
+            doSync = currentTime > self.nextSync
+            self.nextSync = currentTime + self.syncInterval
+
+        if doSync:
+            self.dmd._p_jar.sync()
+        '''
+        self.epp._synchronize_with_database()
+        self.dmd._p_jar.sync.assert_called_once_with()
+
+    def test_synchronize_with_database_delay(self):
+        self.epp.nextSync = time() + 0.5
+        self.epp._synchronize_with_database()
+        self.dmd._p_jar.sync.assert_not_called()
+
+    def test_synchronize_with_database_every_event(self):
+        self.epp.SYNC_EVERY_EVENT = True
+        self.epp._synchronize_with_database()
+        self.dmd._p_jar.sync.assert_called_once_with()
 
     class ErrorPipe(EventProcessorPipe):
         ERR = Exception('pipeline failure')

--- a/Products/ZenEvents/tests/test_zeneventd.py
+++ b/Products/ZenEvents/tests/test_zeneventd.py
@@ -90,9 +90,6 @@ class EventPipelineProcessorTest(TestCase):
             exception_event.event.message
         )
 
-    def test_validate_tests_are_run_by_ci(self):
-        self.assertTrue(False)
-
     class ErrorPipe(EventProcessorPipe):
         ERR = Exception('pipeline failure')
 

--- a/Products/ZenEvents/tests/test_zeneventd.py
+++ b/Products/ZenEvents/tests/test_zeneventd.py
@@ -1,0 +1,168 @@
+from unittest import TestCase
+from mock import patch, call, Mock, MagicMock
+
+from Products.ZenEvents.zeneventd import (
+    Timeout,
+    TimeoutError,
+    EventPipelineProcessor,
+    Event,
+    ZepRawEvent,
+    CheckInputPipe,
+    EventContext,
+)
+from Products.ZenEvents.events2.processing import EventProcessorPipe
+from zenoss.protocols.protobufs.zep_pb2 import EventActor
+
+
+PATH = {'zeneventd': 'Products.ZenEvents.zeneventd'}
+
+
+class DummyPipe(EventProcessorPipe):
+
+    def __call__(self, eventContext):
+        return eventContext
+
+
+class EventPipelineProcessorTest(TestCase):
+
+    def setUp(self):
+        self.dmd = Mock()
+        self.manager_patcher = patch(
+            '{zeneventd}.Manager'.format(**PATH), autospec=True
+        )
+        # silence 'new thread' error
+        self.metric_reporter_patcher = patch(
+            '{zeneventd}.MetricReporter'.format(**PATH), autospec=True
+        )
+        self.manager_patcher.start()
+        self.metric_reporter_patcher.start()
+
+        self.epp = EventPipelineProcessor(self.dmd)
+
+        self.message = Event(
+            uuid="75e7c760-39d4-11e8-a97b-0242ac11001a",
+            created_time=1523044529575,
+            event_class="/ZenossRM",
+            actor=EventActor(
+                element_type_id=10,
+                element_uuid="575bcf2d-8ca0-47d9-8e63-b4f2c1242ef3",
+                element_identifier="device.loc",
+                element_sub_type_id=100,
+                element_sub_identifier="zeneventd",
+            ),
+            summary='Event Summary',
+            severity=1,
+            event_key="RMMonitor.collect.docker",
+            agent="zenpython",
+            monitor="localhost",
+            first_seen_time=1523044529575,
+        )
+
+    def tearDown(self):
+        self.manager_patcher.stop()
+        self.metric_reporter_patcher.stop()
+
+    def test_processMessage(self):
+        self.epp._pipes = (CheckInputPipe(self.epp._manager), )
+
+        zep_raw_event = self.epp.processMessage(self.message)
+
+        self.assertIsInstance(zep_raw_event, ZepRawEvent)
+        self.assertIsInstance(zep_raw_event.event, Event)
+        self.assertEqual(zep_raw_event.event.message, self.message.summary)
+
+    def test_exception_in_pipe(self):
+        error_pipe = self.ErrorPipe(self.epp._manager)
+        self.epp._pipes = (error_pipe, )
+        self.epp._pipe_timers[error_pipe.name] = MagicMock()
+
+        zep_raw_event = self.epp.processMessage(self.message)
+
+        self.assertIsInstance(zep_raw_event, ZepRawEvent)
+        self.assertIsInstance(zep_raw_event.event, Event)
+
+        exception_event = self.epp.create_exception_event(
+            self.message, self.ErrorPipe.ERR
+        )
+
+        self.assertEqual(
+            zep_raw_event.event.message,
+            exception_event.event.message
+        )
+
+    def test_validate_tests_are_run_by_ci(self):
+        self.assertTrue(False)
+
+    class ErrorPipe(EventProcessorPipe):
+        ERR = Exception('pipeline failure')
+
+        def __call__(self, eventContext):
+            raise self.ERR
+
+    def test_create_exception_event(self):
+        error = Exception('test exception')
+        event_context = self.epp.create_exception_event(self.message, error)
+        self.assertIsInstance(event_context, EventContext)
+
+        exception_event = event_context.event
+
+        self.assertIsInstance(exception_event, Event)
+        self.assertEqual(
+            exception_event.summary,
+            "Internal exception processing event: Exception('test exception',)"
+        )
+        self.assertTrue(
+            str(error) in exception_event.message
+        )
+
+
+class TimeoutTest(TestCase):
+
+    def setUp(self):
+        # Patch external dependencies
+        self.signal_patcher = patch(
+            '{zeneventd}.signal'.format(**PATH), autospec=True
+        )
+        self.signal = self.signal_patcher.start()
+
+    def tearDown(self):
+        self.signal_patcher.stop()
+
+    def test_context_manager(self):
+        timeout_duration = 10
+
+        with Timeout('event', timeout_duration) as ctx:
+            self.signal.signal.assert_called_with(
+                self.signal.SIGALRM, ctx.handle_timeout
+            )
+
+        self.signal.alarm.assert_has_calls(
+            [call(timeout_duration), call(0)]
+        )
+
+    def test_handle_timeout_raises_exception(self):
+        with self.assertRaises(TimeoutError):
+            with Timeout(1) as ctx:
+                ctx.handle_timeout(1, 'frame')
+
+    def test_slow_transform(self):
+        pass #self.assertTrue(False)
+
+    def test_slow_pipeline_component(self):
+        pass #self.assertTrue(False)
+
+
+class BaseQueueConsumerTaskTest(TestCase):
+    pass
+
+
+class TwistedQueueConsumerTaskTest(TestCase):
+    pass
+
+
+class EventDTwistedWorkerTest(TestCase):
+    pass
+
+
+class ZenEventDTest(TestCase):
+    pass

--- a/Products/ZenEvents/zeneventd.py
+++ b/Products/ZenEvents/zeneventd.py
@@ -155,7 +155,7 @@ class EventPipelineProcessor(object):
                         )
                         if eventContext.event.status == STATUS_DROPPED:
                             raise DropEvent(
-                                'Dropped by %s', pipe, eventContext.event
+                                'Dropped by %s' % pipe, eventContext.event
                             )
 
                     processed = True

--- a/Products/ZenEvents/zeneventd.py
+++ b/Products/ZenEvents/zeneventd.py
@@ -1,61 +1,74 @@
 ##############################################################################
-# 
+#
 # Copyright (C) Zenoss, Inc. 2010, all rights reserved.
-# 
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
-import os
+
 import logging
-
-def monkey_patch_rotatingfilehandler():
-  try:
-    from cloghandler import ConcurrentRotatingFileHandler
-    logging.handlers.RotatingFileHandler = ConcurrentRotatingFileHandler
-  except ImportError:
-    from warnings import warn
-    warn("ConcurrentLogHandler package not installed. Using RotatingFileLogHandler. While everything will still work fine, there is a potential for log files overlapping each other.")
-monkey_patch_rotatingfilehandler()
-
-from twisted.internet import reactor
-from twisted.internet import defer
-
-from metrology import Metrology
-
 import time
 from datetime import datetime, timedelta
 
-import Globals
-from zope.component import getUtility, provideUtility, adapter
-
-from zope.interface import implements, implementer
+from twisted.internet import defer, reactor
+from zope.component import getUtility, provideUtility
 from zope.component.event import objectEventNotify
+from zope.interface import implementer, implements
+from metrology import Metrology
 
-from Products.ZenCollector.utils.maintenance import MaintenanceCycle, maintenanceBuildOptions, QueueHeartbeatSender
-from Products.ZenMessaging.queuemessaging.interfaces import IQueueConsumerTask
-from Products.ZenUtils.MetricReporter import MetricReporter
-from Products.ZenUtils.ZCmdBase import ZCmdBase
-from Products.ZenUtils.guid import guid
-from Products.ZenUtils.daemonconfig import IDaemonConfig
-from Products.ZenUtils.Utils import zenPath
-from zenoss.protocols.interfaces import IAMQPConnectionInfo, IQueueSchema
-from zenoss.protocols.protobufs.zep_pb2 import ZepRawEvent, Event, STATUS_DROPPED
-from zenoss.protocols.jsonformat import from_dict, to_dict
+import Globals
 from zenoss.protocols import hydrateQueueMessage
+from zenoss.protocols.interfaces import IAMQPConnectionInfo, IQueueSchema
+from zenoss.protocols.jsonformat import from_dict, to_dict
+from zenoss.protocols.protobufs.zep_pb2 import (
+    STATUS_DROPPED, Event, ZepRawEvent
+)
+
+from Products.ZenCollector.utils.maintenance import (
+    MaintenanceCycle, QueueHeartbeatSender, maintenanceBuildOptions
+)
+from Products.ZenEvents.daemonlifecycle import (
+    BuildOptionsEvent, DaemonCreatedEvent, DaemonStartRunEvent, SigTermEvent,
+    SigUsr1Event
+)
+from Products.ZenEvents.events2.processing import (
+    AddDeviceContextAndTagsPipe, AssignDefaultEventClassAndTagPipe,
+    CheckHeartBeatPipe, CheckInputPipe, ClearClassRefreshPipe, DropEvent,
+    EventContext, EventPluginPipe, FingerprintPipe, IdentifierPipe, Manager,
+    ProcessingException, SerializeContextPipe, TransformAndReidentPipe,
+    TransformPipe, UpdateDeviceContextAndTagsPipe
+)
+from Products.ZenEvents.interfaces import IPostEventPlugin, IPreEventPlugin
+from Products.ZenMessaging.queuemessaging.interfaces import IQueueConsumerTask
 from Products.ZenMessaging.queuemessaging.QueueConsumer import QueueConsumer
-from Products.ZenEvents.events2.processing import (Manager, EventPluginPipe, CheckInputPipe, IdentifierPipe,
-    AddDeviceContextAndTagsPipe, TransformAndReidentPipe, TransformPipe, UpdateDeviceContextAndTagsPipe,
-    AssignDefaultEventClassAndTagPipe, FingerprintPipe, SerializeContextPipe, ClearClassRefreshPipe,
-    EventContext, DropEvent, ProcessingException, CheckHeartBeatPipe)
-from Products.ZenEvents.interfaces import IPreEventPlugin, IPostEventPlugin
-from Products.ZenEvents.daemonlifecycle import DaemonCreatedEvent, SigTermEvent, SigUsr1Event
-from Products.ZenEvents.daemonlifecycle import DaemonStartRunEvent, BuildOptionsEvent
+from Products.ZenUtils.daemonconfig import IDaemonConfig
+from Products.ZenUtils.guid import guid
+from Products.ZenUtils.MetricReporter import MetricReporter
+from Products.ZenUtils.Utils import zenPath
+from Products.ZenUtils.ZCmdBase import ZCmdBase
+
+
+def monkey_patch_rotatingfilehandler():
+    try:
+        from cloghandler import ConcurrentRotatingFileHandler
+        logging.handlers.RotatingFileHandler = ConcurrentRotatingFileHandler
+    except ImportError:
+        from warnings import warn
+        warn(
+            "ConcurrentLogHandler package not installed. Using"
+            " RotatingFileLogHandler. While everything will still work fine,"
+            " there is a potential for log files overlapping each other."
+        )
+
+
+monkey_patch_rotatingfilehandler()
 
 log = logging.getLogger("zen.eventd")
 
 EXCHANGE_ZEP_ZEN_EVENTS = '$ZepZenEvents'
 QUEUE_RAW_ZEN_EVENTS = '$RawZenEvents'
+
 
 class EventPipelineProcessor(object):
 
@@ -65,22 +78,22 @@ class EventPipelineProcessor(object):
         self.dmd = dmd
         self._manager = Manager(self.dmd)
         self._pipes = (
-            EventPluginPipe(self._manager, IPreEventPlugin, 'PreEventPluginPipe'),
-            CheckInputPipe(self._manager),
-            IdentifierPipe(self._manager),
+            EventPluginPipe(
+                self._manager, IPreEventPlugin, 'PreEventPluginPipe'
+            ), CheckInputPipe(self._manager), IdentifierPipe(self._manager),
             AddDeviceContextAndTagsPipe(self._manager),
-            TransformAndReidentPipe(self._manager,
-                TransformPipe(self._manager),
-                [
-                UpdateDeviceContextAndTagsPipe(self._manager),
-                IdentifierPipe(self._manager),
-                AddDeviceContextAndTagsPipe(self._manager),
-                ]),
-            AssignDefaultEventClassAndTagPipe(self._manager),
+            TransformAndReidentPipe(
+                self._manager, TransformPipe(self._manager), [
+                    UpdateDeviceContextAndTagsPipe(self._manager),
+                    IdentifierPipe(self._manager),
+                    AddDeviceContextAndTagsPipe(self._manager),
+                ]
+            ), AssignDefaultEventClassAndTagPipe(self._manager),
             FingerprintPipe(self._manager),
             SerializeContextPipe(self._manager),
-            EventPluginPipe(self._manager, IPostEventPlugin, 'PostEventPluginPipe'),
-            ClearClassRefreshPipe(self._manager),
+            EventPluginPipe(
+                self._manager, IPostEventPlugin, 'PostEventPluginPipe'
+            ), ClearClassRefreshPipe(self._manager),
             CheckHeartBeatPipe(self._manager)
         )
         self._pipe_timers = {}
@@ -92,10 +105,10 @@ class EventPipelineProcessor(object):
         self.reporter.start()
 
         if not self.SYNC_EVERY_EVENT:
-            # don't call sync() more often than 1 every 0.5 sec - helps throughput
-            # when receiving events in bursts
+            # don't call sync() more often than 1 every 0.5 sec
+            # helps throughput when receiving events in bursts
             self.nextSync = datetime.now()
-            self.syncInterval = timedelta(0,0,500000)
+            self.syncInterval = timedelta(0, 0, 500000)
 
     def processMessage(self, message):
         """
@@ -106,7 +119,8 @@ class EventPipelineProcessor(object):
         if self.SYNC_EVERY_EVENT:
             doSync = True
         else:
-            # sync() db if it has been longer than self.syncInterval since the last time
+            # sync() db if it has been longer than self.syncInterval
+            # since the last time
             currentTime = datetime.now()
             doSync = currentTime > self.nextSync
             self.nextSync = currentTime + self.syncInterval
@@ -123,7 +137,9 @@ class EventPipelineProcessor(object):
                     zepevent = ZepRawEvent()
                     zepevent.event.CopyFrom(message)
                     if log.isEnabledFor(logging.DEBUG):
-                        log.debug("Received event: %s", to_dict(zepevent.event))
+                        log.debug(
+                            "Received event: %s", to_dict(zepevent.event)
+                        )
 
                     eventContext = EventContext(log, zepevent)
 
@@ -131,17 +147,22 @@ class EventPipelineProcessor(object):
                         with self._pipe_timers[pipe.name]:
                             eventContext = pipe(eventContext)
                         if log.isEnabledFor(logging.DEBUG):
-                            log.debug('After pipe %s, event context is %s' % ( pipe.name, to_dict(eventContext.zepRawEvent) ))
+                            log.debug(
+                                'After pipe %s, event context is %s',
+                                pipe.name, to_dict(eventContext.zepRawEvent)
+                            )
                         if eventContext.event.status == STATUS_DROPPED:
-                            raise DropEvent('Dropped by %s' % pipe, eventContext.event)
+                            raise DropEvent(
+                                'Dropped by %s', pipe, eventContext.event
+                            )
 
                     processed = True
 
                 except AttributeError:
-                    # _manager throws Attribute errors if connection to zope is lost - reset
-                    # and retry ONE time
+                    # _manager throws Attribute errors
+                    # if connection to zope is lost - reset and retry ONE time
                     if retry:
-                        retry=False
+                        retry = False
                         log.debug("Resetting connection to catalogs")
                         self._manager.reset()
                     else:
@@ -151,26 +172,33 @@ class EventPipelineProcessor(object):
             # we want these to propagate out
             raise
         except Exception as e:
-            log.info("Failed to process event, forward original raw event: %s", to_dict(zepevent.event))
-            # Pipes and plugins may raise ProcessingException's for their own reasons - only log unexpected
-            # exceptions of other type (will insert stack trace in log)
+            log.info(
+                "Failed to process event, forward original raw event: %s",
+                to_dict(zepevent.event)
+            )
+            # Pipes and plugins may raise ProcessingException's for their own
+            # reasons. only log unexpected exceptions of other type
+            # will insert stack trace in log
             if not isinstance(e, ProcessingException):
                 log.exception(e)
 
-            # construct wrapper event to report this event processing failure (including content of the
-            # original event)
+            # construct wrapper event to report this event processing failure
+            # including content of the original event
             origzepevent = ZepRawEvent()
             origzepevent.event.CopyFrom(message)
-            failReportEvent = dict(
-                uuid = guid.generate(),
-                created_time = int(time.time()*1000),
-                fingerprint='|'.join(['zeneventd', 'processMessage', repr(e)]),
-                # Don't send the *same* event class or we trash and and crash endlessly
-                eventClass='/',
-                summary='Internal exception processing event: %r' % e,
-                message='Internal exception processing event: %r/%s' % (e, to_dict(origzepevent.event)),
-                severity=4,
-            )
+            failReportEvent = {
+                'uuid': guid.generate(),
+                'created_time': int(time.time() * 1000),
+                'fingerprint':
+                    '|'.join(['zeneventd', 'processMessage', repr(e)]),
+                # Don't send the *same* event class or we loop endlessly
+                'eventClass': '/',
+                'summary': 'Internal exception processing event: %r' % e,
+                'message':
+                    'Internal exception processing event: %r/%s' %
+                    (e, to_dict(origzepevent.event)),
+                'severity': 4,
+            }
             zepevent = ZepRawEvent()
             zepevent.event.CopyFrom(from_dict(Event, failReportEvent))
             eventContext = EventContext(log, zepevent)
@@ -178,9 +206,12 @@ class EventPipelineProcessor(object):
             eventContext.eventProxy.component = 'processMessage'
 
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("Publishing event: %s", to_dict(eventContext.zepRawEvent))
+            log.debug(
+                "Publishing event: %s", to_dict(eventContext.zepRawEvent)
+            )
 
         return eventContext.zepRawEvent
+
 
 class BaseQueueConsumerTask(object):
 
@@ -190,11 +221,16 @@ class BaseQueueConsumerTask(object):
         self.processor = processor
         self._queueSchema = getUtility(IQueueSchema)
         self.dest_routing_key_prefix = 'zenoss.zenevent'
-        self._dest_exchange = self._queueSchema.getExchange(EXCHANGE_ZEP_ZEN_EVENTS)
+        self._dest_exchange = self._queueSchema.getExchange(
+            EXCHANGE_ZEP_ZEN_EVENTS
+        )
 
     def _routing_key(self, event):
-        return (self.dest_routing_key_prefix +
-                event.event.event_class.replace('/', '.').lower())
+        return (
+            self.dest_routing_key_prefix +
+            event.event.event_class.replace('/', '.').lower()
+        )
+
 
 class TwistedQueueConsumerTask(BaseQueueConsumerTask):
 
@@ -214,8 +250,12 @@ class TwistedQueueConsumerTask(BaseQueueConsumerTask):
                 zepRawEvent = self.processor.processMessage(hydrated)
                 if log.isEnabledFor(logging.DEBUG):
                     log.debug("Publishing event: %s", to_dict(zepRawEvent))
-                yield self.queueConsumer.publishMessage(EXCHANGE_ZEP_ZEN_EVENTS,
-                    self._routing_key(zepRawEvent), zepRawEvent, declareExchange=False)
+                yield self.queueConsumer.publishMessage(
+                    EXCHANGE_ZEP_ZEN_EVENTS,
+                    self._routing_key(zepRawEvent),
+                    zepRawEvent,
+                    declareExchange=False
+                )
                 yield self.queueConsumer.acknowledge(message)
             except DropEvent as e:
                 if log.isEnabledFor(logging.DEBUG):
@@ -231,11 +271,14 @@ class TwistedQueueConsumerTask(BaseQueueConsumerTask):
 
 
 class EventDTwistedWorker(object):
+
     def __init__(self, dmd):
         super(EventDTwistedWorker, self).__init__()
         self._amqpConnectionInfo = getUtility(IAMQPConnectionInfo)
         self._queueSchema = getUtility(IQueueSchema)
-        self._consumer_task = TwistedQueueConsumerTask(EventPipelineProcessor(dmd))
+        self._consumer_task = TwistedQueueConsumerTask(
+            EventPipelineProcessor(dmd)
+        )
         self._consumer = QueueConsumer(self._consumer_task, dmd)
 
     def run(self):
@@ -251,23 +294,28 @@ class EventDTwistedWorker(object):
         if self._consumer:
             yield self._consumer.shutdown()
 
+
 @implementer(IDaemonConfig)
 class ZenEventDConfig:
+
     def __init__(self, options):
         self.options = options
+
     def getConfig(self):
         return self.options
+
 
 class ZenEventD(ZCmdBase):
 
     def __init__(self, *args, **kwargs):
         super(ZenEventD, self).__init__(*args, **kwargs)
         EventPipelineProcessor.SYNC_EVERY_EVENT = self.options.syncEveryEvent
-        self._heartbeatSender = QueueHeartbeatSender('localhost',
-                                                     'zeneventd',
-                                                     self.options.heartbeatTimeout)
-        self._maintenanceCycle = MaintenanceCycle(self.options.maintenancecycle,
-                                  self._heartbeatSender)
+        self._heartbeatSender = QueueHeartbeatSender(
+            'localhost', 'zeneventd', self.options.heartbeatTimeout
+        )
+        self._maintenanceCycle = MaintenanceCycle(
+            self.options.maintenancecycle, self._heartbeatSender
+        )
         objectEventNotify(DaemonCreatedEvent(self))
         config = ZenEventDConfig(self.options)
         provideUtility(config, IDaemonConfig, 'zeneventd_config')
@@ -291,21 +339,41 @@ class ZenEventD(ZCmdBase):
     def buildOptions(self):
         super(ZenEventD, self).buildOptions()
         maintenanceBuildOptions(self.parser)
-        self.parser.add_option('--synceveryevent', dest='syncEveryEvent',
-                    action="store_true", default=False,
-                    help='Force sync() before processing every event; default is to sync() no more often '
-                    'than once every 1/2 second.')
-        self.parser.add_option('--messagesperworker', dest='messagesPerWorker', default=1,
-                    type="int",
-                    help='Sets the number of messages each worker gets from the queue at any given time. Default is 1. '
-                    'Change this only if event processing is deemed slow. Note that increasing the value increases the '
-                    'probability that events will be processed out of order.')
-        self.parser.add_option('--maxpickle', dest='maxpickle', default=100, type="int",
-                    help='Sets the number of pickle files in var/zeneventd/failed_transformed_events.')
-        self.parser.add_option('--pickledir', dest='pickledir', default=zenPath('var/zeneventd/failed_transformed_events'),
-                    type="string", help='Sets the path to save pickle files.')
+        self.parser.add_option(
+            '--synceveryevent',
+            dest='syncEveryEvent',
+            action="store_true",
+            default=False,
+            help='Force sync() before processing every event; default is to'
+            ' sync() no more often than once every 1/2 second.'
+        )
+        self.parser.add_option(
+            '--messagesperworker',
+            dest='messagesPerWorker',
+            default=1,
+            type="int",
+            help='Sets the number of messages each worker gets from the queue'
+            ' at any given time. Default is 1. Change this only if event'
+            ' processing is deemed slow. Note that increasing the value'
+            ' increases the probability that events will be processed'
+            ' out of order.'
+        )
+        self.parser.add_option(
+            '--maxpickle',
+            dest='maxpickle',
+            default=100,
+            type="int",
+            help='Sets the number of pickle files in'
+            ' var/zeneventd/failed_transformed_events.'
+        )
+        self.parser.add_option(
+            '--pickledir',
+            dest='pickledir',
+            default=zenPath('var/zeneventd/failed_transformed_events'),
+            type="string",
+            help='Sets the path to save pickle files.'
+        )
         objectEventNotify(BuildOptionsEvent(self))
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a timeout to ZEP, to catch long-running event transforms and pipeline components, and convert them to processing errors if they exceed the time limit.