### PR TITLE
Fix Auth0 to use silent authentication, checking for callback errors.

### DIFF
--- a/Products/ZenUI3/browser/templates/base-new.pt
+++ b/Products/ZenUI3/browser/templates/base-new.pt
@@ -86,7 +86,7 @@
                                     </a>
                                 </div>
                                 <div id="sign-out-link">
-                                    <a href="/zport/dmd/logoutUser">sign out</a>
+                                    <a href="/zport/dmd/logoutUser">Logout</a>
                                 </div>
                                 <div>
                                     <div id="help-icon-container">

--- a/Products/ZenUtils/Auth0/Auth0.py
+++ b/Products/ZenUtils/Auth0/Auth0.py
@@ -15,11 +15,10 @@ from Products.PluggableAuthService.interfaces.plugins import (IExtractionPlugin,
                                                               IRolesPlugin)
 from Products.PluggableAuthService.plugins.BasePlugin import BasePlugin
 from Products.PluggableAuthService.utils import classImplements
-from Products.ZenUtils.AuthUtils import getJWKS, publicKeysFromJWKS, getBearerToken
+from Products.ZenUtils.AuthUtils import getJWKS, publicKeysFromJWKS
 from Products.ZenUtils.CSEUtils import getZenossURI
 from Products.ZenUtils.GlobalConfig import getGlobalConfiguration
 from Products.ZenUtils.PASUtils import activatePluginForInterfaces, movePluginToTop
-from Products.ZenUtils.Utils import getQueryArgsFromRequest
 
 import base64
 import httplib
@@ -41,6 +40,7 @@ _AUTH0_CONFIG = {
         'tenant': None,
         'connection': None
     }
+
 
 def getAuth0Conf():
     """Return a dictionary containing Auth0 configuration or None
@@ -101,7 +101,7 @@ class Auth0(BasePlugin):
         return Auth0.cache['keys'].setdefault(key_id, None)
 
     @staticmethod
-    def storeIdToken(id_token, session, conf):
+    def storeIdToken(id_token, session, conf, refresh_token):
         """ Save the important parts of the token in session storage.
             Returns the corresponding SessionInfo object.
         """
@@ -118,10 +118,12 @@ class Auth0(BasePlugin):
                              audience=conf['clientid'],
                              issuer=conf['tenant'])
 
-        sessionInfo = session.setdefault(Auth0.session_key, SessionInfo())
+        sessionInfo = SessionInfo()
         sessionInfo.userid = payload['sub'].encode('utf8').split('|')[-1]
         sessionInfo.expiration = payload['exp']
         sessionInfo.roles = payload['https://zenoss.com/roles']
+        sessionInfo.refreshToken = refresh_token
+        session.set(Auth0.session_key, sessionInfo)
         return sessionInfo
 
 
@@ -156,7 +158,7 @@ class Auth0(BasePlugin):
         id_token = resp_data.get('id_token')
         log.debug('Token refreshed')
 
-        return Auth0.storeIdToken(id_token, session, conf)
+        return Auth0.storeIdToken(id_token, session, conf, refresh_token)
 
 
     def resetCredentials(self, request, response):
@@ -199,7 +201,7 @@ class Auth0(BasePlugin):
             log.debug('Token expired - attempting to refresh')
             sessionInfo = Auth0._refreshToken(request.SESSION, conf)
 
-        if not sessionInfo.userid:
+        if not sessionInfo or not sessionInfo.userid:
             log.debug('No Auth0 session - not directing to Auth0 login')
             return {}
 
@@ -239,14 +241,15 @@ class Auth0(BasePlugin):
         }
         state = base64.urlsafe_b64encode(json.dumps(state_obj))
 
-        request['RESPONSE'].redirect("%sauthorize?" % conf['tenant'] +
-                                     "response_type=code&" +
-                                     "client_id=%s&" % conf['clientid'] +
-                                     "connection=%s&" % conf['connection'] +
-                                     "state=%s&" % state +
-                                     "scope=openid offline_access&" +
-                                     "redirect_uri=%s/zport/Auth0Callback" % zenoss_uri,
-                                     lock=1)
+        uri = "%sauthorize?" % conf['tenant'] + \
+              "response_type=code&" + \
+              "client_id=%s&" % conf['clientid'] + \
+              "state=%s&" % state + \
+              "scope=openid offline_access&" + \
+              "prompt=none&" + \
+              "redirect_uri=%s/zport/Auth0Callback" % zenoss_uri
+
+        request['RESPONSE'].redirect(uri, lock=1)
         return True
 
     def getRolesForPrincipal(self, principal, request=None):

--- a/Products/ZenUtils/Auth0/Auth0Callback.py
+++ b/Products/ZenUtils/Auth0/Auth0Callback.py
@@ -20,7 +20,6 @@ import urllib
 
 log = logging.getLogger('Auth0')
 
-
 class Auth0Callback(BrowserView):
     """
     Auth0 redirects to this callback after a login attempt.
@@ -36,40 +35,53 @@ class Auth0Callback(BrowserView):
         args = getQueryArgsFromRequest(self.request)
         state_arg = args.get('state')
         code = args.get('code')
+        error = args.get('error', None)
+
+        if error:
+            log.debug('Auth0 error response: {}'.format(error))
 
         domain = conf['tenant'].replace('https://', '').replace('/', '')
 
-        data = {
-            "grant_type": "authorization_code",
-            "client_id": conf['clientid'],
-            "client_secret": conf['client-secret'],
-            "code": code,
-            "audience": "%s/userinfo" % domain,
-            "scope": "openid profile",
-            "redirect_uri": "%s/zport/Auth0Callback" % zenoss_uri
-        }
+        if error:
+            # We need to make a new request to authorize without the
+            # prompt parameter so that auth0 presents a login screen.
+            uri = "%sauthorize?" % conf['tenant'] + \
+                  "response_type=code&" + \
+                  "client_id=%s&" % conf['clientid'] + \
+                  "state=%s&" % state_arg + \
+                  "scope=openid offline_access&" + \
+                  "redirect_uri=%s/zport/Auth0Callback" % zenoss_uri
+            return self.request.response.redirect(uri)
+        else:
+            data = {
+                "grant_type": "authorization_code",
+                "client_id": conf['clientid'],
+                "client_secret": conf['client-secret'],
+                "code": code,
+                "audience": "%s/userinfo" % domain,
+                "scope": "openid profile",
+                "redirect_uri": "%s/zport/Auth0Callback" % zenoss_uri
+            }
 
-        resp_string = ''
-        conn = httplib.HTTPSConnection(domain)
-        headers = {"content-type": "application/json"}
-        try:
-            conn.request('POST', '/oauth/token', json.dumps(data), headers)
-            resp_string = conn.getresponse().read()
-        except Exception as a:
-            log.error('Unable to obtain token from Auth0: %s', a)
-            return self.request.response.redirect(zenoss_uri + zport_dmd)
+            conn = httplib.HTTPSConnection(domain)
+            headers = {"content-type": "application/json"}
+            try:
+                conn.request('POST', '/oauth/token', json.dumps(data), headers)
+                resp_string = conn.getresponse().read()
+            except Exception as a:
+                log.error('Unable to obtain token from Auth0: %s', a)
+                return self.request.response.redirect(zenoss_uri + zport_dmd)
 
-        resp_data = json.loads(resp_string)
-        refresh_token = resp_data.get('refresh_token')
-        id_token = resp_data.get('id_token')
+            resp_data = json.loads(resp_string)
+            refresh_token = resp_data.get('refresh_token')
+            id_token = resp_data.get('id_token')
 
-        sessionInfo = Auth0.storeIdToken(id_token, self.request.SESSION, conf)
-        sessionInfo.refreshToken = refresh_token
+            Auth0.storeIdToken(id_token, self.request.SESSION, conf, refresh_token)
 
-        came_from = json.loads(base64.b64decode(urllib.unquote(state_arg)))['came_from']
-        virtual_root = getCSEConf().get('virtualroot', '')
-        if virtual_root and \
-            virtual_root not in came_from \
-            and zport_dmd in came_from:
-            came_from = came_from.replace(zport_dmd, virtual_root + zport_dmd)
-        return self.request.response.redirect(came_from)
+            came_from = json.loads(base64.b64decode(urllib.unquote(state_arg)))['came_from']
+            virtual_root = getCSEConf().get('virtualroot', '')
+            if virtual_root and \
+                virtual_root not in came_from \
+                and zport_dmd in came_from:
+                came_from = came_from.replace(zport_dmd, virtual_root + zport_dmd)
+            return self.request.response.redirect(came_from)


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-29947

There were problems with the method used to authenticate with Auth0, and the errors were never caught.  This updates the challenge to use silent authentication, catching the error to present a login screen from Auth0 on error.  Now, authenticating from either Zing or CZ will allow access to the other, and logging out of CZ actually works (previously an automatic renewal happened), fixing SSO.

Changed the "Sign out" to "Logout" to match the ZING UI (per Smouse request)

Single-Sign-Off does **not** work yet.  Each UI logout is independent.  I'll create a new ticket to address this related, but separate, problem.