### PR TITLE
Fix the callback url to not include :443 when using the std port

### DIFF
--- a/Products/ZenUtils/CSEUtils.py
+++ b/Products/ZenUtils/CSEUtils.py
@@ -41,7 +41,8 @@ def getZingURI(request):
     cse_conf = getCSEConf()
     zenoss_uri = "https://"
     if cse_conf and all(cse_conf.values()):
-        zenoss_uri += "{}.{}:{}".format(cse_conf['vhost'], cse_conf['zing-host'], cse_conf['zing-port'])
+        port = "" if cse_conf['zing-port'] == "443" else ":{}".format(cse_conf['zing-port'])
+        zenoss_uri += "{}.{}{}".format(cse_conf['vhost'], cse_conf['zing-host'], port)
     else:
         # HTTP_X_FORWARDED_HOST should handle vhost
         zenoss_uri += request.environ.get("HTTP_X_FORWARDED_HOST") or \


### PR DESCRIPTION
Don't include the port in the callback url to Auth0 unless the port is something other than 443 (dev environments).