### PR TITLE
Clicking the Zenoss Logo redirects to the base

### DIFF
--- a/Products/ZenUI3/browser/templates/base-new.pt
+++ b/Products/ZenUI3/browser/templates/base-new.pt
@@ -74,10 +74,9 @@
             <div class="bg">
                 <div class="bg-leftcap">
                     <div class="bg-tile">
-                        <div class="bg-logo"></div>
+                        <a class="external-link bg-logo" href="/" rel="nofollow"></a>
                         <div id="primarynav">
                             <ul tal:content="structure provider:primarynav"/>
-                            <div id="nav-zc"><a href="/">Zenoss Cloud</a></div>
                             <div id="header-extra">
                                 <div id="searchbox-container"></div>
                                 <div id="saved-search-container"></div>


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-30079

Clicking the Zenoss Logo redirects to /, which is Zenoss cloud for a CSE.  The "Zenoss Cloud" link is now redundant and should be removed.

![image](https://user-images.githubusercontent.com/15878956/40203244-4875f67c-59ea-11e8-96bc-ce88c3945da1.png)
