### PR TITLE
ZEN-30092: exclude device list from component group details

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -1275,6 +1275,8 @@ Ext.onReady(function () {
             {
                 id: 'device_grid',
                 text: 'Devices',
+                // do not show on component groups
+                contextRegex: '^(?!/zport/dmd/ComponentGroup)',
                 listeners: {
                     render: updateNavTextWithCount
                 }


### PR DESCRIPTION
The component group details offers to display a list of devices.
Use regex to exclude device menu option from component group
details.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30092?focusedCommentId=129288&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-129288)