### PR TITLE
ZEN-30108: When clicking the link from a Server to it's VM

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/LinkField.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/LinkField.js
@@ -27,6 +27,8 @@ Ext.define("Zenoss.form.LinkField", {
     },
     setValue: function(value) {
         var origValue = value;
+        var linkMatch = value.match(/(?:<a href=")(.+)(?:">)/);
+        var nameMatch = value.match(/(?:<a href=.*">)(.+)(?:<\/a)/);
         if (Ext.isEmpty(value)) {
             value = _t('None');
         } else {
@@ -37,7 +39,13 @@ Ext.define("Zenoss.form.LinkField", {
                 });
                 value = items.join('<br/>');
             } else {
-                value = Zenoss.render.link(value);
+                if (linkMatch && nameMatch) {
+                    var link = linkMatch[1];
+                    var name = nameMatch[1];
+                    value = Zenoss.render.link(null, link, name);
+                } else {
+                    value = Zenoss.render.link(value);
+                }
             }
         }
         this.callParent([value]);


### PR DESCRIPTION
This line causes the issue:
https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenUI3/browser/resources/js/zenoss/Renderers.js#L291
url comes here as:
```
<a href="/zport/dmd/Devices/vSphere/devices/qa-vcenter1.zenoss.loc/vms/VirtualMachine_vm-65">Virtual Machine 'testrail' on qa-vcenter1.zenoss.loc</a>
```
When line 291 is executed url becomes:
```
/cz1/<a href="/zport/dmd/Devices/vSphere/devices/qa-vcenter1.zenoss.loc/vms/VirtualMachine_vm-65">Virtual Machine 'testrail' on qa-vcenter1.zenoss.loc</a>
```
To fix the issue we need to pass into line 281 `link` and `name`:
https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenUI3/browser/resources/js/zenoss/form/LinkField.js#L40
https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenUI3/browser/resources/js/zenoss/Renderers.js#L281
After that, in line 291 we will get an url like:
```
/cz1/zport/dmd/Devices/vSphere/devices/qa-vcenter1.zenoss.loc/vms/VirtualMachine_vm-65
```
and line 294 will return a correct link:
```
>  Zenoss.render.link(null, link, name);
<- "<a class="z-entity" href="/cz1/zport/dmd/Devices/vSphere/devices/qa-vcenter1.zenoss.loc/vms/VirtualMachine_vm-65">Virtual Machine &#39;testrail&#39; on qa-vcenter1.zenoss.loc</a>"
```