### PR TITLE
ZEN-30304: Hide the flickering Adobe Flash box when loading pages

### DIFF
--- a/Products/ZenUI3/browser/resources/css/zen-cse.css
+++ b/Products/ZenUI3/browser/resources/css/zen-cse.css
@@ -2234,6 +2234,11 @@ BYE BYE BORDERS
         text-align: right;
     }
 
+    /* ZEN-30304: hide empty flash player that produce swfobject.js for its internal need */
+    .z-cse body > object[type="application/x-shockwave-flash"]:not([data]) {
+      visibility: hidden;
+    }
+
 /*
         =====================================================================================
         DARK THEME


### PR DESCRIPTION
The problem was that the [swfobject.js](https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenUI3/browser/resources/js/swfobject/2.2/swfobject.js) library [has functionality](https://github.com/swfobject/swfobject/blob/9e0104326a8913918f2170f15a69d60624c4bf68/swfobject/src/swfobject.js#L193) that creates empty Flash Player in order to detect its version for non-Internet Explorer browsers.