### PR TITLE
ZEN-30198 - RM Monitor Fails if Database Credentials are Changed

### DIFF
--- a/bin/metrics/mysqlmetrics.sh
+++ b/bin/metrics/mysqlmetrics.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-mysql -s --skip-column-names -B <<SQL
+if [ $1 = "mariadb-model" ]
+  then
+     DB="zodb"
+  else
+    DB="zep"
+fi
+
+/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --usedb $DB --execsql=<<SQL
 USE information_schema;
 
 SELECT

--- a/bin/metrics/storagestats.py
+++ b/bin/metrics/storagestats.py
@@ -43,7 +43,7 @@ class StorageMetricGatherer(MetricGatherer):
         ts = time.time()
         tags = {'zenoss_storage': self.name}
         try:
-            response = subprocess.check_output([self.METRICS_QUERY])
+            response = subprocess.check_output([self.METRICS_QUERY, self.name])
         except Exception as e:
             log.error("Error gathering mysql storage info: %s" % e)
             return []


### PR DESCRIPTION
Fixes ZEN-30198 by executing model and events databases sql via the ZenDB class, which automatically fetches creds from global.conf.