### PR TITLE
ZEN-29553: SSH Linux: Wrong password will create an event "SSH login …

### DIFF
--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -386,11 +386,11 @@ class SshPerformanceCollectionTask(BaseTask):
 
         self.manage_ip_event = {
             'eventClass': Cmd_Fail,
-            'component': 'command',
             'device': self._devId,
             'summary': 'IP address not set, collection will be attempted\
                         with host name',
             'component' : COLLECTOR_NAME,
+            'eventKey': 'Empty_IP_address'
         }
 
     def __str__(self):


### PR DESCRIPTION
…to * with username * failed" that will auto-clear and reappear