### PR TITLE
ZEN-30170 Finish fixing zemib.

### DIFF
--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -54,6 +54,7 @@ import logging
 import os
 import sys
 import tempfile
+import transaction
 
 import Globals
 
@@ -208,6 +209,11 @@ class ZenMib(ZCmdBase):
                 )
 
             processor.run()
+
+            if not self.options.nocommit:
+                transaction.commit()
+            else:
+                self.log.warn("Changes not saved (--nocommit was specified)")
         except Exception as ex:
             _logException(self.log, "Failure: %s", ex)
 

--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -120,7 +120,7 @@ class MIBFileProcessor(BaseProcessor):
 
         # Add the directories of the MIB-files-to-load to the set of
         # paths to search for MIB file dependencies.
-        paths.extend(set(os.path.dirname(mf.filename) for mf in mibfiles))
+        paths.extend(_unique(os.path.dirname(mf.filename) for mf in mibfiles))
 
         loaderArgs = (self._moduleMgr, self._organizer)
 

--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -110,12 +110,16 @@ class MIBFileProcessor(BaseProcessor):
         self._savepath = \
             options.pythoncodedir if options.keeppythoncode else None
         self._mibdepsdir = options.mibdepsdir
-        self._mibdir = options.mibsdir
+        self._mibsdir = options.mibsdir
         self._mibfiles = mibfiles
 
     def run(self):
         mibfiles = self._getMIBFiles()
         paths = [zenPath("share", "mibs"), self._mibdepsdir]
+
+        # Add the directories of the MIB-files-to-load to the set of
+        # paths to search for MIB file dependencies.
+        paths.extend(set(os.path.dirname(mf.filename) for mf in mibfiles))
 
         loaderArgs = (self._moduleMgr, self._organizer)
 
@@ -260,7 +264,7 @@ class ZenMib(ZCmdBase):
         self.parser.add_option(
             '--keeppythoncode', dest='keeppythoncode',
             action='store_true', default=False,
-            help="Don't commit the MIB to the DMD after loading"
+            help="Save the generated Python code"
         )
         self.parser.add_option(
             '--pythoncodedir', dest='pythoncodedir',

--- a/Products/ZenUtils/mib/smidump.py
+++ b/Products/ZenUtils/mib/smidump.py
@@ -27,7 +27,12 @@ class SMIConfigFile(object):
 
         @param path {sequence} The paths to put into the config file.
         """
-        self._path = ':'.join(path)
+        paths = set(path)
+        if log.getEffectiveLevel() <= logging.DEBUG:
+            log.debug(
+                "MIB file dependency search path(s): %s", ', '.join(paths)
+            )
+        self._path = ':'.join(paths)
         self._file = NamedTemporaryFile()
         self._makeConfig()
 

--- a/Products/ZenUtils/mib/smidump.py
+++ b/Products/ZenUtils/mib/smidump.py
@@ -1,6 +1,7 @@
 import logging
 import re
 
+from collections import OrderedDict
 from itertools import chain
 from tempfile import NamedTemporaryFile
 from subprocess import Popen, PIPE
@@ -27,7 +28,7 @@ class SMIConfigFile(object):
 
         @param path {sequence} The paths to put into the config file.
         """
-        paths = set(path)
+        paths = list(OrderedDict.fromkeys(path))
         if log.getEffectiveLevel() <= logging.DEBUG:
             log.debug(
                 "MIB file dependency search path(s): %s", ', '.join(paths)


### PR DESCRIPTION
Three changes in three separate commits:
1. Actually commit the changes unless `--nocommit` is specified
2. Add the directory of the specified MIB file as a MIB file search path
3. Log results of adding/updating MIBs in ZODB.

Fixes ZEN-30170.