### PR TITLE
ZEN-30227: ZenHub: Send Events directly to the rawEvents queue

### DIFF
--- a/Products/ZenHub/interceptors.py
+++ b/Products/ZenHub/interceptors.py
@@ -1,0 +1,98 @@
+
+import logging
+import cPickle as pickle
+from time import time
+
+from metrology import Metrology
+from twisted.spread import pb
+from twisted.internet import defer
+
+
+class WorkerInterceptor(pb.Referenceable):
+    """Redirect service requests to one of the worker processes. Note
+    that everything else (like change notifications) go through
+    locally hosted services."""
+
+    callTime = 0.
+
+    def __init__(self, zenhub, service):
+        self.zenhub = zenhub
+        self.service = service
+        self._serviceCalls = Metrology.meter("zenhub.serviceCalls")
+        self.log = logging.getLogger('zen.zenhub.WorkerInterceptor')
+        self._admTimer = Metrology.timer('zenhub.applyDataMap')
+        self._eventsSent = Metrology.meter("zenhub.eventsSent")
+
+    def remoteMessageReceived(self, broker, message, args, kw):
+        """Intercept requests and send them down to workers"""
+        self.log.error('remoteMessageReceived(self, broker, message, args, kw):'
+                  ' broker=%s, message=%s, args=%s, kw=%s',
+                  broker, message, args, kw)
+
+        self._serviceCalls.mark()
+        self.log.error('self.service.__class__=%s', self.service.__class__)
+        svc = str(self.service.__class__).rpartition('.')[0]
+        self.log.error('svc=%s', svc)
+        instance = self.service.instance
+        self.log.error('instance=%s', instance)
+        args = broker.unserialize(args)
+        self.log.error('args=%s', args)
+        kw = broker.unserialize(kw)
+        self.log.error('kw=%s', kw)
+        # hide the types in the args: subverting the jelly protection mechanism
+        # but the types just passed through and the worker may not have loaded
+        # the required service before we try passing types for that service
+        # PB has a 640k limit, not bytes but len of sequences. When args are
+        # pickled the resulting string may be larger than 640k, split into
+        # 100k chunks
+        pickledArgs = pickle.dumps(
+            (args, kw), pickle.HIGHEST_PROTOCOL
+        )
+        chunkedArgs = []
+        chunkSize = 102400
+        while pickledArgs:
+            chunk = pickledArgs[:chunkSize]
+            chunkedArgs.append(chunk)
+            pickledArgs = pickledArgs[chunkSize:]
+
+        start = time()
+
+        def recordTime(result):
+            # get in milliseconds
+            duration = int((time() - start) * 1000)
+            self._admTimer.update(duration)
+            return result
+
+        deferred = self.zenhub.deferToWorker(
+            svc, instance, message, chunkedArgs
+        )
+        if message == 'sendEvents':
+            if args and len(args) == 1:
+                self._eventsSent.mark(len(args[0]))
+        elif message == 'sendEvent':
+            self._eventsSent.mark()
+        elif message == 'applyDataMaps':
+            deferred.addCallback(recordTime)
+
+        return broker.serialize(deferred, self.perspective)
+
+    def remoteMessageReceived_monkey_patch(self, broker, message, args, kw):
+        # Short circuit sendEvent() calls
+
+        if message not in ('sendEvents', 'sendEvent'):
+            #return original(self, broker, message, args, kw)
+            return self.remoteMessageReceived(broker, message, args, kw)
+
+        args = broker.unserialize(args)
+        if message == 'sendEvents':
+            self.zem.sendEvents(*args)
+        elif message == 'sendEvent':
+            self.zem.sendEvent(*args)
+
+        return broker.serialize(defer.succeed("Events sent"), self.perspective)
+
+    def __getattr__(self, attr):
+        """Implement the HubService interface
+        by forwarding to the local service
+        """
+        return getattr(self.service, attr)

--- a/Products/ZenHub/tests/test_interceptors.py
+++ b/Products/ZenHub/tests/test_interceptors.py
@@ -1,0 +1,106 @@
+from unittest import TestCase
+from mock import Mock
+
+from Products.ZenHub.interceptors import (
+    WorkerInterceptor,
+    pb,
+    pickle,
+)
+
+
+class WorkerInterceptorTest(TestCase):
+
+    cap_broker = '<twisted.spread.pb.Broker instance at 0xa198680>'
+    cap_message = 'sendEvents'
+    cap_args = [
+        'tuple',
+        ['list',
+            ['dictionary',
+                ['monitor', 'localhost'],
+                ['component', 'zenstatus'],
+                ['agent', 'zenstatus'],
+                ['manager', '550b82acdec1'],
+                ['timeout', 900],
+                ['device', 'localhost'],
+                ['eventClass', '/Heartbeat']
+    ]]]
+    cap_kw = ['dictionary']
+
+    def test_remoteMessageReceived(self):
+        service = Mock(name='service')
+        service.__class__ = 'Products.ZenHub.services.EventService.EventService'
+
+        zenhub = Mock(name='zenhub instance')
+        wi = WorkerInterceptor(zenhub=zenhub, service=service)
+        wi.perspective = Mock(spec=pb.IPerspective)
+
+        broker = Mock(spec=pb.Broker)
+
+        svc = str(service.__class__).rpartition('.')[0]
+        self.assertEqual(svc, 'Products.ZenHub.services.EventService')
+
+        # unserialize args
+        cap_args = [
+            'tuple',
+            ['list',
+                ['dictionary',
+                    ['monitor', 'localhost'],
+                    ['component', 'zenstatus'],
+                    ['agent', 'zenstatus'],
+                    ['manager', '550b82acdec1'],
+                    ['timeout', 900],
+                    ['device', 'localhost'],
+                    ['eventClass', '/Heartbeat']
+        ]]]
+        unserialized_args = ([{
+            'monitor': 'localhost',
+            'component': 'zenstatus',
+            'agent': 'zenstatus',
+            'manager': '550b82acdec1',
+            'timeout': 900,
+            'device': 'localhost',
+            'eventClass': '/Heartbeat'
+        }],)
+
+        broker.unserialize = Mock(return_value=unserialized_args)
+        args = broker.unserialize(cap_args)
+        self.assertEqual(args, unserialized_args)
+
+        cap_kw = ['dictionary']
+        broker.unserialize = Mock(return_value={})
+        kw = broker.unserialize(cap_kw)
+        broker.unserialize.assert_called_with(cap_kw)
+        self.assertEqual(kw, {})
+
+        pickledArgs = pickle.dumps(
+            (args, kw), pickle.HIGHEST_PROTOCOL
+        )
+
+        self.assertEqual(
+            pickledArgs,
+            '\x80\x02]q\x01}q\x02(U\x07monitorq\x03U\tlocalhostq\x04U\tcomponentq\x05U\tzenstatusq\x06U\x05agentq\x07h\x06U\x07managerq\x08U\x0c550b82acdec1q\tU\x07timeoutq\nM\x84\x03U\x06deviceq\x0bh\x04U\neventClassq\x0cU\n/Heartbeatq\rua\x85q\x0e}q\x0f\x86.'
+        )
+
+        chunkedArgs = []
+        chunkSize = 102400
+        while pickledArgs:
+            chunk = pickledArgs[:chunkSize]
+            chunkedArgs.append(chunk)
+            pickledArgs = pickledArgs[chunkSize:]
+
+        self.assertEqual(
+            chunkedArgs,
+            [pickle.dumps((args, kw), pickle.HIGHEST_PROTOCOL)]
+        )
+
+        out = wi.remoteMessageReceived(
+            broker=broker,  # '<twisted.spread.pb.Broker instance at 0xb1a72d8>',
+            message='sendEvents',
+            args=[],
+            kw=['dictionary'],
+        )
+
+        self.assertEqual(out, broker.serialize.return_value)
+        broker.serialize.assert_called_with(
+            zenhub.deferToWorker.return_value, wi.perspective
+        )

--- a/Products/ZenHub/tests/test_interceptors.py
+++ b/Products/ZenHub/tests/test_interceptors.py
@@ -1,46 +1,30 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
 from unittest import TestCase
-from mock import Mock
+from mock import Mock, MagicMock, patch
 
 from Products.ZenHub.interceptors import (
     WorkerInterceptor,
     pb,
     pickle,
+    defer,
 )
+
+
+PATH = {'interceptors': 'Products.ZenHub.interceptors'}
 
 
 class WorkerInterceptorTest(TestCase):
 
-    cap_broker = '<twisted.spread.pb.Broker instance at 0xa198680>'
-    cap_message = 'sendEvents'
-    cap_args = [
-        'tuple',
-        ['list',
-            ['dictionary',
-                ['monitor', 'localhost'],
-                ['component', 'zenstatus'],
-                ['agent', 'zenstatus'],
-                ['manager', '550b82acdec1'],
-                ['timeout', 900],
-                ['device', 'localhost'],
-                ['eventClass', '/Heartbeat']
-    ]]]
-    cap_kw = ['dictionary']
-
-    def test_remoteMessageReceived(self):
-        service = Mock(name='service')
-        service.__class__ = 'Products.ZenHub.services.EventService.EventService'
-
-        zenhub = Mock(name='zenhub instance')
-        wi = WorkerInterceptor(zenhub=zenhub, service=service)
-        wi.perspective = Mock(spec=pb.IPerspective)
-
-        broker = Mock(spec=pb.Broker)
-
-        svc = str(service.__class__).rpartition('.')[0]
-        self.assertEqual(svc, 'Products.ZenHub.services.EventService')
-
-        # unserialize args
-        cap_args = [
+    def setUp(self):
+        self.cap_args = [
             'tuple',
             ['list',
                 ['dictionary',
@@ -50,57 +34,105 @@ class WorkerInterceptorTest(TestCase):
                     ['manager', '550b82acdec1'],
                     ['timeout', 900],
                     ['device', 'localhost'],
-                    ['eventClass', '/Heartbeat']
-        ]]]
-        unserialized_args = ([{
-            'monitor': 'localhost',
-            'component': 'zenstatus',
-            'agent': 'zenstatus',
-            'manager': '550b82acdec1',
-            'timeout': 900,
-            'device': 'localhost',
-            'eventClass': '/Heartbeat'
-        }],)
+                    ['eventClass', '/Heartbeat']]]]
 
-        broker.unserialize = Mock(return_value=unserialized_args)
-        args = broker.unserialize(cap_args)
-        self.assertEqual(args, unserialized_args)
+        self.cap_kw = ['dictionary']
 
-        cap_kw = ['dictionary']
-        broker.unserialize = Mock(return_value={})
-        kw = broker.unserialize(cap_kw)
-        broker.unserialize.assert_called_with(cap_kw)
-        self.assertEqual(kw, {})
-
-        pickledArgs = pickle.dumps(
-            (args, kw), pickle.HIGHEST_PROTOCOL
+        self.service = MagicMock(name='service')
+        self.service.__class__ = (
+            'Products.ZenHub.services.EventService.EventService'
         )
+        self.service.__str__.return_value = 'service.__str__'
+        self.zenhub = Mock(name='zenhub instance')
+        self.wi = WorkerInterceptor(zenhub=self.zenhub, service=self.service)
 
-        self.assertEqual(
-            pickledArgs,
-            '\x80\x02]q\x01}q\x02(U\x07monitorq\x03U\tlocalhostq\x04U\tcomponentq\x05U\tzenstatusq\x06U\x05agentq\x07h\x06U\x07managerq\x08U\x0c550b82acdec1q\tU\x07timeoutq\nM\x84\x03U\x06deviceq\x0bh\x04U\neventClassq\x0cU\n/Heartbeatq\rua\x85q\x0e}q\x0f\x86.'
-        )
+    def test_remoteMessageRecieved(self):
+        service = MagicMock(name='service')
+        service.__class__ = 'Products.ZenHub.services.EventService.EventService'
+        service.__str__.return_value = 'attribute: service.__str__'
+        zenhub = Mock(name='zen_hub')
+        zenhub.deferToWorker.return_value = 'deferred'
+        wi = WorkerInterceptor(zenhub=zenhub, service=service)
+        broker = Mock(name='pb.Broker', spec=pb.Broker)
 
-        chunkedArgs = []
-        chunkSize = 102400
-        while pickledArgs:
-            chunk = pickledArgs[:chunkSize]
-            chunkedArgs.append(chunk)
-            pickledArgs = pickledArgs[chunkSize:]
-
-        self.assertEqual(
-            chunkedArgs,
-            [pickle.dumps((args, kw), pickle.HIGHEST_PROTOCOL)]
-        )
-
-        out = wi.remoteMessageReceived(
-            broker=broker,  # '<twisted.spread.pb.Broker instance at 0xb1a72d8>',
+        out = wi.remoteMessageRecieved(
+            broker=broker,  # twisted.spread.pb.Broke
             message='sendEvents',
-            args=[],
-            kw=['dictionary'],
+            args=self.cap_args,
+            kw=self.cap_kw,
         )
 
-        self.assertEqual(out, broker.serialize.return_value)
+        # the event has been sent the ZenHub Workers
+        svc_name = self.wi.service_name
+        chunked_args = self.wi.chunk_args(self.cap_args, self.cap_kw)
+        zenhub.deferToWorker.assert_called_with(
+            svc_name,
+            service.instance,
+            'sendEvents',
+            chunked_args
+        )
+        # remoteMessageRecieved returns a Deferred
+        self.assertIsInstance(out, defer.Deferred)
+        # the result of out is pb.Broker.serialize()
+        self.assertEqual(out.result, broker.serialize.return_value)
+        # pb.Broker.serialize was called with expected args
         broker.serialize.assert_called_with(
-            zenhub.deferToWorker.return_value, wi.perspective
+            zenhub.deferToWorker.return_value,
+            wi.perspective
+        )
+
+    def test_service_name(self):
+        self.assertEqual(
+            self.wi.service_name, 'Products.ZenHub.services.EventService'
+        )
+
+    def test_chunk_args(self):
+        chunked_args = self.wi.chunk_args(self.cap_args, self.cap_kw)
+        self.assertEqual(
+            pickle.loads(''.join(chunked_args)),
+            (self.cap_args, self.cap_kw)
+        )
+        self.assertEqual(
+            chunked_args,
+            [pickle.dumps(
+                (self.cap_args, self.cap_kw),
+                pickle.HIGHEST_PROTOCOL
+            )]
+        )
+
+    def test_chunk_args_long(self):
+        # build args that will be more than the 102400 char limit once pickled
+        args = ['10 chr str' for _ in range(100000)]
+        kwargs = {'kw': 'args', }
+        chunked_args = self.wi.chunk_args(args, kwargs)
+
+        # join the chunked args back to a sting, and unpickle them.
+        self.assertEqual(
+            pickle.loads(''.join(chunked_args)),
+            (args, kwargs)
+        )
+
+    def test_mark_send_event_timer(self):
+        self.wi._eventsSent = Mock(
+            name='_eventsSent', spec=self.wi._eventsSent
+        )
+        self.wi.mark_send_event_timer(None, None)
+        self.wi._eventsSent.mark.assert_called_with()
+
+    def test_mark_send_events_timer(self):
+        self.wi._eventsSent = Mock(
+            name='_eventsSent', spec=self.wi._eventsSent
+        )
+        events = ['a', 'b']
+        self.wi.mark_send_events_timer(events, None)
+        self.wi._eventsSent.mark.assert_called_with(len(events))
+
+    @patch('{interceptors}.time'.format(**PATH), name='time', autospec=True)
+    def test_mark_apply_datamaps_timer(self, mtime):
+        self.wi._admTimer = Mock(name='_eventsSent', spec=self.wi._admTimer)
+        mtime.return_value = 300
+        start = 100
+        self.wi.mark_apply_datamaps_timer(None, start)
+        self.wi._admTimer.update.assert_called_with(
+            (mtime() - start) * 1000
         )

--- a/Products/ZenHub/tests/test_interceptors.py
+++ b/Products/ZenHub/tests/test_interceptors.py
@@ -158,3 +158,10 @@ class WorkerInterceptorTest(TestCase):
         self.wi._admTimer.update.assert_called_with(
             (mtime() - start) * 1000
         )
+
+    def test_callTime_property(self):
+        '''Required by ZenHub.heartbeat
+        WorkerInterceptor Service is expected to have a callTime initialized
+        to int(0)
+        '''
+        self.assertEqual(self.wi.callTime, 0)

--- a/Products/ZenHub/tests/test_interceptors.py
+++ b/Products/ZenHub/tests/test_interceptors.py
@@ -58,7 +58,7 @@ class WorkerInterceptorTest(TestCase):
 
         # the event has been sent the ZenHub Workers
         svc_name = self.wi.service_name
-        chunked_args = self.wi.chunk_args(self.cap_args, self.cap_kw)
+        chunked_args = self.wi.serialize_args(self.cap_args, self.cap_kw)
         self.zenhub.deferToWorker.assert_called_with(
             svc_name,
             self.service.instance,
@@ -108,8 +108,8 @@ class WorkerInterceptorTest(TestCase):
             self.wi.service_name, 'Products.ZenHub.services.EventService'
         )
 
-    def test_chunk_args(self):
-        chunked_args = self.wi.chunk_args(self.cap_args, self.cap_kw)
+    def test_serialize_args(self):
+        chunked_args = self.wi.serialize_args(self.cap_args, self.cap_kw)
         self.assertEqual(
             pickle.loads(''.join(chunked_args)),
             (self.cap_args, self.cap_kw)
@@ -122,11 +122,11 @@ class WorkerInterceptorTest(TestCase):
             )]
         )
 
-    def test_chunk_args_long(self):
+    def test_serialize_args_long(self):
         # build args that will be more than the 102400 char limit once pickled
         args = ['10 chr str' for _ in range(100000)]
         kwargs = {'kw': 'args', }
-        chunked_args = self.wi.chunk_args(args, kwargs)
+        chunked_args = self.wi.serialize_args(args, kwargs)
 
         # join the chunked args back to a sting, and unpickle them.
         self.assertEqual(


### PR DESCRIPTION
Fixes: ZEN-30227

- skip the extra steps of pickling sendEvent(s) messages and forwarding them to the zenhub workers, they just get unpickled and forwarded to the rawEvents queue.
- additional fine-tuning to speed up the remoteMessageRecieved method
- break WorkerInterceptor into testable components
- convert remoteMessageRecieved to an inlineCallback
- improve performance
- Create Unittests for WorkerInterceptor