### PR TITLE
ZEN-30135 - style changes for codeminor field for light/dark themes

### DIFF
--- a/Products/ZenUI3/browser/resources/css/zen-cse.css
+++ b/Products/ZenUI3/browser/resources/css/zen-cse.css
@@ -126,10 +126,10 @@ darker input fields:           #505050
 .z-cse .x-panel-dd-spacer  /* dashboard portlet drop target */
 { background-image: none !important; background-color: rgba(255,255,255,0.4) !important; }
 
-/* CodeMirror.css */
-.z-cse .CodeMirror,
-.z-cse .CodeMirror-gutters
-{ background-image: none; background-color: transparent; }
+/* CodeMirror edited panel header text color */
+.z-cse .edited_feedback .x-panel-header-text {
+    color: orange !important;
+}
 .z-cse #configs-body > .x-panel
 { background-image: none !important; background-color: transparent !important; }
 
@@ -2929,4 +2929,9 @@ BYE BYE BORDERS
     .z-cse.z-cse-dark .inspector span.status-up,
     .z-cse.z-cse-dark .inspector .inspector-body .inspector-property .inspector-property-value div {
         color: #5a5a5a;
+    }
+
+    /* CodeMirror edited panel header text color */
+    .z-cse.z-cse-dark .edited_feedback .x-panel-header-text {
+        color: yellow !important;
     }


### PR DESCRIPTION
Set orange color to edited codeminor header for light theme.
Remove transparent background from codeminor lines and gutter to hide overlapping text on scroll.