### PR TITLE
ZEN-29469: move ip to new realm on device collector change

### DIFF
--- a/Products/Zuul/routers/device.py
+++ b/Products/Zuul/routers/device.py
@@ -14,7 +14,6 @@ Operations for Device Organizers and Devices.
 Available at:  /zport/dmd/device_router
 """
 import logging
-import traceback
 from cgi import escape
 from collections import OrderedDict
 from itertools import islice
@@ -949,8 +948,10 @@ class DeviceRouter(TreeRouter):
                 return DirectResponse.succeed('Changed collector to %s for %s devices.' %
                                       (collector, len(uids)))
         except Exception, e:
-            log.debug(traceback.format_exc())
-            log.error(e)
+            if log.isEnabledFor(logging.DEBUG):
+                log.exception(e)
+            else:
+                log.error(e)
             return DirectResponse.exception(e, 'Failed to change the collector.')
 
     def setComponentsMonitored(self, uids, hashcheck, monitor=False, uid=None,

--- a/Products/Zuul/routers/device.py
+++ b/Products/Zuul/routers/device.py
@@ -14,6 +14,7 @@ Operations for Device Organizers and Devices.
 Available at:  /zport/dmd/device_router
 """
 import logging
+import traceback
 from cgi import escape
 from collections import OrderedDict
 from itertools import islice
@@ -938,7 +939,7 @@ class DeviceRouter(TreeRouter):
         uids = filterUidsByPermission(self.context.dmd, ZEN_ADMIN_DEVICE, uids)
         try:
             # iterate through uids so that logging works as expected
-            result = facade.setCollector(uids, collector, asynchronous)
+            result = facade.setCollector(uids, collector, asynchronous=asynchronous)
             for devUid in uids:
                 audit('UI.Device.ChangeCollector', devUid, collector=collector)
             if asynchronous and result:
@@ -948,7 +949,8 @@ class DeviceRouter(TreeRouter):
                 return DirectResponse.succeed('Changed collector to %s for %s devices.' %
                                       (collector, len(uids)))
         except Exception, e:
-            log.exception(e)
+            log.debug(traceback.format_exc())
+            log.error(e)
             return DirectResponse.exception(e, 'Failed to change the collector.')
 
     def setComponentsMonitored(self, uids, hashcheck, monitor=False, uid=None,


### PR DESCRIPTION
Do not log the trace when handling exception but log the
exception message and log a traceback only in debug mode.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-29469?focusedCommentId=132013&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-132013)