### PR TITLE
Adding zcml features

### DIFF
--- a/Products/ZenossStartup/configure.zcml
+++ b/Products/ZenossStartup/configure.zcml
@@ -1,0 +1,9 @@
+<configure 
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:zenoss="http://namespaces.zope.org/zenoss">
+
+    <include file="meta.zcml"/>
+    <zenoss:addGlobalFeatures configuration="/opt/zenoss/etc/global.conf" />
+
+</configure>

--- a/Products/ZenossStartup/meta.zcml
+++ b/Products/ZenossStartup/meta.zcml
@@ -1,0 +1,9 @@
+<configure xmlns="http://namespaces.zope.org/meta">
+  <directives namespace="http://namespaces.zope.org/zenoss">
+    <directive
+        name="addGlobalFeatures"
+        schema=".metaglobal.IAddGlobalFeatures"
+        handler=".metaglobal.addGlobalFeatures"
+        />
+  </directives>
+</configure>

--- a/Products/ZenossStartup/metaglobal.py
+++ b/Products/ZenossStartup/metaglobal.py
@@ -1,6 +1,6 @@
 ##############################################################################
 # 
-# Copyright (C) Zenoss, Inc. 2009, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
 # 
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.

--- a/Products/ZenossStartup/metaglobal.py
+++ b/Products/ZenossStartup/metaglobal.py
@@ -30,7 +30,6 @@ def addGlobalFeatures(_context, configuration='/opt/zenoss/etc/global.conf'):
         include the file parameter if a string 'zcml-' is defined in /opt/zenoss/etc/global.conf
     """
     # inject into zcml context the global features specified in global.conf
-    import pdb; pdb.set_trace()
     conf = globalConfToDict()
     for key, value in conf.iteritems():
         if key[:_flen] == _FEATURE_PREFIX:

--- a/Products/ZenossStartup/metaglobal.py
+++ b/Products/ZenossStartup/metaglobal.py
@@ -1,0 +1,41 @@
+##############################################################################
+# 
+# Copyright (C) Zenoss, Inc. 2009, all rights reserved.
+# 
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+# 
+##############################################################################
+
+
+from zope.interface import Interface
+from zope.configuration.fields import GlobalObject
+from zope.schema import TextLine
+
+from Products.ZenUtils.GlobalConfig import globalConfToDict
+_FEATURE_PREFIX = "zcml-"
+_flen = len(_FEATURE_PREFIX)
+
+class IAddGlobalFeatures(Interface):
+    """ The 'if-global-include'' directive
+    """
+    configuration = TextLine(
+        title=u"Configuration",
+        description=u"Global configuration file",
+        required=True
+    )
+
+def addGlobalFeatures(_context, configuration='/opt/zenoss/etc/global.conf'):
+    """ The 'if-global-include'' directive
+        include the file parameter if a string 'zcml-' is defined in /opt/zenoss/etc/global.conf
+    """
+    # inject into zcml context the global features specified in global.conf
+    import pdb; pdb.set_trace()
+    conf = globalConfToDict()
+    for key, value in conf.iteritems():
+        if key[:_flen] == _FEATURE_PREFIX:
+            feature = key[_flen:]
+            if not feature or not isinstance(value, basestring) or value.lower() != "true":
+                continue
+            # add the feature to the existing global zcml context
+            _context.provideFeature(unicode(feature))

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-VERSION  ?= 7.0.0
+VERSION  ?= 7.0.1
 BUILD_NUMBER ?= DEV
 BRANCH   ?= develop
 ARTIFACT_TAG ?= $(shell echo $(BRANCH) | sed 's/\//-/g')
@@ -10,7 +10,7 @@ ARTIFACT := prodbin-$(VERSION)-$(ARTIFACT_TAG).tar.gz
 # See zenoss-version.mk for more information about make targets that use these values.
 SCHEMA_MAJOR ?= 300
 SCHEMA_MINOR ?= 0 
-SCHEMA_REVISION ?= 0
+SCHEMA_REVISION ?= 1
 
 DIST_ROOT := dist
 


### PR DESCRIPTION
This is to enable injection of zcml meta:provides feature strings directly from variables defined in global.conf file..