### PR TITLE
ZPS-3987: remove cse prefix from object id

### DIFF
--- a/Products/ZenModel/ZenPacker.py
+++ b/Products/ZenModel/ZenPacker.py
@@ -9,8 +9,10 @@
 
 
 import Globals
+from zope.component import getUtility
 from AccessControl import ClassSecurityInfo
 from Products.ZenWidgets import messaging
+from Products.ZenUtils.virtual_root import IVirtualRoot
 
 class ZenPacker(object):
     security = ClassSecurityInfo()
@@ -49,6 +51,8 @@ class ZenPacker(object):
 
     def findObject(self, id):
         "Ugly hack for inconsistent object structure accross Organizers"
+        # remove cz# prefix if there is one in the object id
+        id = getUtility(IVirtualRoot).strip_virtual_root(id)
         result = []
         try:
             result.append(self._getOb(id))


### PR DESCRIPTION
Id of the object may come with cz# prefix and we would not
be able to get the object itself.
Remove cz# prefix from the object id

[JIRA&DEMO](https://jira.zenoss.com/browse/ZPS-3987?focusedCommentId=132733&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-132733)