### PR TITLE
ZEN-30326 - !important invalid image for fields in form

### DIFF
--- a/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
+++ b/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
@@ -3389,7 +3389,7 @@ textarea.x-form-field {
 
 .x-form-invalid-field, textarea.x-form-invalid-field {
   background-color: white;
-  background-image: url('../img/xtheme-zenoss/grid/invalid_line.gif');
+  background-image: url('../img/xtheme-zenoss/grid/invalid_line.gif') !important;
   background-repeat: repeat-x;
   background-position: bottom;
   border-color: #cc3300; }


### PR DESCRIPTION
set background image for fields in ExtJs forms "!important" attribute to support cse style sheets.