### PR TITLE
Update SCHEMA versions for zenmigrate prior to release

### DIFF
--- a/Products/ZenModel/migrate/addAuth0.py
+++ b/Products/ZenModel/migrate/addAuth0.py
@@ -13,7 +13,6 @@ This migration script adds Auth0 plugin to PAS.
 '''
 
 import logging
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 log = logging.getLogger("zen.migrate")
 
@@ -23,7 +22,7 @@ from Products.ZenUtils.Auth0.Auth0 import setup
 
 class AddAuth0(Migrate.Step):
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         setup(dmd)

--- a/Products/ZenModel/migrate/addDeviceIpAddrRelation.py
+++ b/Products/ZenModel/migrate/addDeviceIpAddrRelation.py
@@ -19,11 +19,10 @@ from Products.ZenModel.IpAddress import IpAddress
 from Products.Zuul.catalog.events import IndexingEvent
 from Products.ZenUtils.IpUtil import ipAndMaskFromIpMask
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 class addDeviceIpAddrRelation(Migrate.Step):
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/addIndexesForDevice.py
+++ b/Products/ZenModel/migrate/addIndexesForDevice.py
@@ -12,7 +12,6 @@ import logging
 from Products.Zuul.catalog.model_catalog_init import reindex_model_catalog
 from Products.Zuul.catalog.indexable import DeviceIndexable
 from Products.Zuul.catalog.interfaces import IModelCatalogTool
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 log = logging.getLogger("zen.migrate")
@@ -23,7 +22,7 @@ class AddIndexesForDevice(Migrate.Step):
     to pull data directly from SOLR without touching ZODB.
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/addLagAndZEPEventClasses.py
+++ b/Products/ZenModel/migrate/addLagAndZEPEventClasses.py
@@ -10,11 +10,10 @@
 import Migrate
 from Products.ZenEvents.EventClass import manage_addEventClass
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 class AddLagAndZEPEventClasses(Migrate.Step):
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         if 'Lag' not in [i.id for i in dmd.Events.Status.Ping.getSubEventClasses()]:

--- a/Products/ZenModel/migrate/addMemcachedForSessions.py
+++ b/Products/ZenModel/migrate/addMemcachedForSessions.py
@@ -13,7 +13,6 @@ import logging
 import os
 log = logging.getLogger("zen.migrate")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 import Migrate
 import servicemigration as sm
 from servicemigration.endpoint import Endpoint
@@ -52,7 +51,7 @@ class AddMemcachedForSessions(Migrate.Step):
     Update memcache healthcheck, and add the service to Core
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
     changed = False
 
     def cutover(self, dmd):

--- a/Products/ZenModel/migrate/addOpentsdbHbaseConnectionHealthCheck.py
+++ b/Products/ZenModel/migrate/addOpentsdbHbaseConnectionHealthCheck.py
@@ -11,7 +11,6 @@ import logging
 log = logging.getLogger("zen.migrate")
 
 import Migrate
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 import servicemigration as sm
 from servicemigration import HealthCheck
 sm.require("1.1.11")
@@ -21,7 +20,7 @@ class AddOpentsdbHbaseConnectionHealthCheck (Migrate.Step):
     """add new healthchecks to Opentsdb reader and writer for hbase connectivity
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addZenossPublicEndpoint.py
+++ b/Products/ZenModel/migrate/addZenossPublicEndpoint.py
@@ -15,7 +15,6 @@ import servicemigration as sm
 from servicemigration.vhost import VHost
 sm.require("1.1.9")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 class AddZenossPublicEndpoint(Migrate.Step):
@@ -23,7 +22,7 @@ class AddZenossPublicEndpoint(Migrate.Step):
     Add public endpoint ("zenoss") to zproxy.
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/addZproxyNginxImpactConfig.py
+++ b/Products/ZenModel/migrate/addZproxyNginxImpactConfig.py
@@ -15,7 +15,6 @@ import logging
 import re
 log = logging.getLogger("zen.migrate")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 import Migrate
 import servicemigration as sm
 sm.require("1.1.5")
@@ -24,7 +23,7 @@ org_statement='pagespeed Disallow \"*/static/*\";\n\n'
 new_statement='pagespeed  Disallow \"*/static/*\";\n        pagespeed  Disallow \"*/impact_graph*\";\n        pagespeed  Allow    \"*/impact_graph*.js\";\n\n'
 
 class AddZproxyNginxImpactConfig(Migrate.Step):
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     config_file = "/opt/zenoss/zproxy/conf/zproxy-nginx.conf"
     save_file = "/opt/zenoss/var/ext/zproxy-nginx.conf.orig"

--- a/Products/ZenModel/migrate/addzCommandCollectionInterval.py
+++ b/Products/ZenModel/migrate/addzCommandCollectionInterval.py
@@ -10,7 +10,6 @@
 
 import Migrate
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 """
 Add global cycle time zProp for 'COMMAND' type datasources,
@@ -19,7 +18,7 @@ migrate existing datasources which we have in core to use it.
 
 
 class AddzCommandCollectionInterval(Migrate.Step):
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     
     def cutover(self, dmd):

--- a/Products/ZenModel/migrate/deleteRateOptionsForServices.py
+++ b/Products/ZenModel/migrate/deleteRateOptionsForServices.py
@@ -11,7 +11,6 @@ import logging
 
 log = logging.getLogger("zen.migrate")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 import Migrate
 import servicemigration as sm
 
@@ -24,7 +23,7 @@ class DeleteRateOptionsForServices(Migrate.Step):
     Remove reset values.
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
 

--- a/Products/ZenModel/migrate/fixRabbitmqHealthCheck.py
+++ b/Products/ZenModel/migrate/fixRabbitmqHealthCheck.py
@@ -11,7 +11,6 @@ import logging
 log = logging.getLogger("zen.migrate")
 
 import Migrate
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 import servicemigration as sm
 sm.require("1.1.11")
@@ -21,7 +20,7 @@ class FixRabbitmqHealthCheck(Migrate.Step):
     """fix broken rabbitmq endpoints
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/limitRabbitMQInstances.py
+++ b/Products/ZenModel/migrate/limitRabbitMQInstances.py
@@ -14,7 +14,6 @@ import Migrate
 import servicemigration as sm
 sm.require("1.1.9")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 class LimitRabbitMQInstances(Migrate.Step):
@@ -22,7 +21,7 @@ class LimitRabbitMQInstances(Migrate.Step):
     Limit number of RabbitMQ's instances to 1.
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/rate_cutoff.py
+++ b/Products/ZenModel/migrate/rate_cutoff.py
@@ -12,7 +12,6 @@ import time
 log = logging.getLogger("zen.migrate")
 
 import Migrate
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 import servicemigration as sm
 
 sm.require("1.1.11")
@@ -20,7 +19,7 @@ sm.require("1.1.11")
 class RateCutoff(Migrate.Step):
     """Fix the credentials for consumer and query services"""
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
         try:

--- a/Products/ZenModel/migrate/updateRateOptionsForMetricShipper.py
+++ b/Products/ZenModel/migrate/updateRateOptionsForMetricShipper.py
@@ -14,7 +14,6 @@ import Migrate
 import servicemigration as sm
 sm.require("1.1.10")
 
-from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
 
 
 class UpdateRateOptionsForMetricShipper(Migrate.Step):
@@ -22,7 +21,7 @@ class UpdateRateOptionsForMetricShipper(Migrate.Step):
     Update/Add rateOptions for counters.
     """
 
-    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+    version = Migrate.Version(300, 0, 1)
 
     def cutover(self, dmd):
 


### PR DESCRIPTION
This PR is the result of running `make replace-zmigrateversion` per the instructions in  Products/ZenModel/migrate/README.md.

The intent is to immediately follow-up this PR by releasing `develop` to `master` as the 7.0.1 release