### PR TITLE
ZEN-30552: If a page is rendered inside iframe then use Zenoss variable from parent

### DIFF
--- a/Products/ZenModel/skins/zenmodel/templates.pt
+++ b/Products/ZenModel/skins/zenmodel/templates.pt
@@ -113,6 +113,10 @@
             });
 
         }
+
+        if (window.frameElement) {
+            window.Zenoss = window.parent.Zenoss;
+        }
         </script>
     </head>
     <body class="yui-skin-sam">


### PR DESCRIPTION
We had a such problem since when we were trying to delete a user command the [submit_form](https://github.com/zenoss/zenoss-prodbin/blob/cb746c707e5e59bf510d656339011cb55ba2efda/Products/ZenWidgets/skins/zenui/javascript/zenoss-utils.js#L1050) method that has in his body reference to `Zenoss.render.link` was called. Because of the fact, that iframe did not have Zenoss variable an error appeared.