### PR TITLE
ZEN-29895: add debug option to 'Model Device' UI with 'download'

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -1803,7 +1803,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
 
     security.declareProtected(ZEN_MANAGE_DEVICE, 'collectDevice')
     def collectDevice(self, setlog=True, REQUEST=None, generateEvents=False,
-                      background=False, write=None):
+                      background=False, write=None, debug=False):
         """
         Collect the configuration of this device AKA Model Device
 
@@ -1823,7 +1823,8 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
             return
 
         perfConf.collectDevice(self, setlog, REQUEST, generateEvents,
-                               background, write)
+                               background, write, collectPlugins='',
+                               debug=debug)
 
         if REQUEST:
             audit('UI.Device.Remodel', self)

--- a/Products/ZenModel/PerformanceConf.py
+++ b/Products/ZenModel/PerformanceConf.py
@@ -514,7 +514,7 @@ class PerformanceConf(Monitor, StatusColor):
     def collectDevice(
             self, device=None, setlog=True, REQUEST=None,
             generateEvents=False, background=False, write=None,
-            collectPlugins=''):
+            collectPlugins='', debug=False):
         """
         Collect the configuration of this device AKA Model Device
 
@@ -534,7 +534,7 @@ class PerformanceConf(Monitor, StatusColor):
         xmlrpc = isXmlRpc(REQUEST)
         result = self._executeZenModelerCommand(device.id, self.id, background,
                                                 REQUEST, write,
-                                                collectPlugins=collectPlugins)
+                                                collectPlugins=collectPlugins, debug=debug)
         if result and xmlrpc:
             return result
         log.info('configuration collected')
@@ -544,7 +544,7 @@ class PerformanceConf(Monitor, StatusColor):
 
     def _executeZenModelerCommand(
             self, deviceName, performanceMonitor="localhost", background=False,
-            REQUEST=None, write=None, collectPlugins=''):
+            REQUEST=None, write=None, collectPlugins='', debug=False):
         """
         Execute zenmodeler and return result
         @param deviceName: The name of the device
@@ -571,6 +571,8 @@ class PerformanceConf(Monitor, StatusColor):
         else:
             args.append(REQUEST)
             zenmodelerCmd = self._getZenModelerCommand(*args)
+            if debug:
+                zenmodelerCmd.append('-v10')
             result = self._executeCommand(zenmodelerCmd, REQUEST, write)
         return result
 

--- a/Products/ZenUI3/browser/command.py
+++ b/Products/ZenUI3/browser/command.py
@@ -171,3 +171,15 @@ class ModelView(StreamingView):
         facade = getFacade('device', self.context)
         for device in imap(facade._getObject, uids):
             device.collectDevice(REQUEST=self.request, write=self.write)
+
+
+class ModelDebugView(StreamingView):
+    """
+    Accepts a list of uids to model.
+    """
+    def stream(self):
+        data = unjson(self.request.get('data'))
+        uids = data['uids']
+        facade = getFacade('device', self.context)
+        for device in imap(facade._getObject, uids):
+            device.collectDevice(REQUEST=self.request, write=self.write, debug=True)

--- a/Products/ZenUI3/browser/configure.zcml
+++ b/Products/ZenUI3/browser/configure.zcml
@@ -291,6 +291,13 @@
     />
 
 <browser:page
+    class=".command.ModelDebugView"
+    name="run_model_debug"
+    for="*"
+    permission="zenoss.ManageDevice"
+    />
+
+<browser:page
     class=".command.TestDataSourceView"
     name="test_datasource"
     for="Products.ZenModel.RRDDataSource.RRDDataSource"

--- a/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
@@ -79,7 +79,15 @@ Ext.define("Zenoss.CommandWindow", {
             fbar: {
                 buttonAlign: 'left',
                 id:'window_footer_toolbar',
-                items: {
+                items: [
+                    {
+                        xtype: 'button',
+                        text: _t('Copy to clipboard'),
+                        handler: Ext.bind(function(c){
+                            this.copyToClipboard();
+                            }, this)
+                    }, '-',
+                    {
                     xtype: 'checkbox',
                     checked: true,
                     boxLabel: _t('Autoscroll'),
@@ -88,9 +96,9 @@ Ext.define("Zenoss.CommandWindow", {
                             this.startScrolling();
                         } else {
                             this.stopScrolling();
-                        }
-                    }, this)
-                }
+                        }}, this)
+                    },
+                ]
             }
         });
         Zenoss.CommandWindow.superclass.constructor.call(this, config);
@@ -136,6 +144,21 @@ Ext.define("Zenoss.CommandWindow", {
         if (Ext.get('window_footer_toolbar')) {
             Ext.get('window_footer_toolbar').focus();
             this.task.delay(250);
+        }
+    },
+    copyToClipboard: function() {
+        var body = this.getCommandPanel().getBody().innerText;
+        var textArea = document.createElement("textarea");
+        textArea.value = body;
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        try {
+            document.execCommand('copy');
+        } catch(err) {
+            console.error("Failed to copy text to clipboard", err);
+        } finally {
+            document.body.removeChild(textArea);
         }
     },
     closeAndRedirect: function() {

--- a/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
@@ -148,17 +148,20 @@ Ext.define("Zenoss.CommandWindow", {
     },
     copyToClipboard: function() {
         var body = this.getCommandPanel().getBody().innerText;
-        var textArea = document.createElement("textarea");
-        textArea.value = body;
-        document.body.appendChild(textArea);
-        textArea.focus();
-        textArea.select();
+        // maybe a better Ext-y way to do this, but the below works well.
+        var tempText = document.createElement("textarea");
+        tempText.value = body;
+        document.body.appendChild(tempText);
+        tempText.focus();
+        tempText.select();
         try {
-            document.execCommand('copy');
+            if (document.execCommand('copy')) {
+               Zenoss.flares.Manager.success('Copied command output to clipboard');
+            }
         } catch(err) {
-            console.error("Failed to copy text to clipboard", err);
+            console.error("Failed to copy command output to clipboard", err);
         } finally {
-            document.body.removeChild(textArea);
+            document.body.removeChild(tempText);
         }
     },
     closeAndRedirect: function() {

--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -953,6 +953,23 @@ function modelDevice() {
     win.show();
 }
 
+function modelDeviceDebug() {
+        var win = new Zenoss.CommandWindow({
+            uids: [UID],
+            target: 'run_model_debug',
+            listeners: {
+                close: function(){
+                    Ext.defer(function() {
+                        window.top.location.reload();
+                    }, 1000);
+                }
+            },
+            title: _t('Model Debug')
+        });
+        win.show();
+}
+
+
 function resumeCollection() {
     Zenoss.remote.DeviceRouter.resumeCollection(UID, function(data) {
         Ext.defer(function() {
@@ -1212,13 +1229,28 @@ Ext.getCmp('footer_bar').add([{
     },
     menu: {}
 },'-', {
-
-    xtype: 'button',
-    text: _t('Model Device'),
-    hidden: Zenoss.Security.doesNotHavePermission('Manage Device'),
-    handler: modelDevice
-
-}]);
+        xtype: 'ContextConfigureMenu',
+        id: 'testing_configure_menu',
+        text: _t('Test'),
+        listeners: {
+        render: function(){
+            this.setContext(UID);
+        }
+    },
+    menuItems: [
+        {
+            xtype: 'menuitem',
+            text: _t('Model Device'),
+            hidden: Zenoss.Security.doesNotHavePermission('Manage Device'),
+            handler: modelDevice
+        }, {
+            xtype: 'menuitem',
+            text: _t('Model Debug'),
+            hidden: Zenoss.Security.doesNotHavePermission('Manage Device'),
+            handler: modelDeviceDebug
+        }
+    ]}
+]);
     if (Ext.isIE) {
         // work around a rendering bug in ExtJs see ticket ZEN-3054
         var viewport = Ext.getCmp('viewport');

--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -1231,7 +1231,8 @@ Ext.getCmp('footer_bar').add([{
 },'-', {
         xtype: 'ContextConfigureMenu',
         id: 'testing_configure_menu',
-        text: _t('Test'),
+        text: _t('Modeling'),
+        iconCls: '',
         listeners: {
         render: function(){
             this.setContext(UID);

--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -1238,7 +1238,7 @@ Ext.getCmp('footer_bar').add([{
             handler: modelDevice
         }, {
             xtype: 'menuitem',
-            text: _t('Model Debug'),
+            text: _t('Model Device (Debug)'),
             hidden: Zenoss.Security.doesNotHavePermission('Manage Device'),
             handler: modelDeviceDebug
         }

--- a/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/devdetail.js
@@ -937,10 +937,14 @@ function addComponentHandler(item) {
     });
 }
 
-function modelDevice() {
+function modelDevice(debugging) {
+    var target = 'run_model';
+    if (debugging == true) {
+        target = 'run_model_debug';
+    }
     var win = new Zenoss.CommandWindow({
         uids: [UID],
-        target: 'run_model',
+        target: target,
         listeners: {
             close: function(){
                 Ext.defer(function() {
@@ -954,19 +958,7 @@ function modelDevice() {
 }
 
 function modelDeviceDebug() {
-        var win = new Zenoss.CommandWindow({
-            uids: [UID],
-            target: 'run_model_debug',
-            listeners: {
-                close: function(){
-                    Ext.defer(function() {
-                        window.top.location.reload();
-                    }, 1000);
-                }
-            },
-            title: _t('Model Debug')
-        });
-        win.show();
+        modelDevice(true);
 }
 
 


### PR DESCRIPTION
This PR replaces the 'Model Device' button in the device overview UI with a menu with 2 option buttons. 
1. - Model the current device as before.
2. - Model the current device with debug logging enabled.

The command window widget has been enhanced to add a 'Copy to clipboard' button to allow end users to paste the output of the modeling run into the save location of their choice. This new button appears in all places where 'command windows' are used.

Tested locally in Chrome/FF.

 