### PR TITLE
ZEN-30701: Disable internal metrics for non-cycle (manual run) daemon operations

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -205,52 +205,52 @@ class CollectorDaemon(RRDDaemon):
                                       self.preferences.collectorName)
 
         super(CollectorDaemon, self).__init__(name=self.preferences.collectorName)
-
-        # setup daemon statistics (deprecated names)
         self._statService = StatisticsService()
-        self._statService.addStatistic("devices", "GAUGE")
-        self._statService.addStatistic("dataPoints", "DERIVE")
-        self._statService.addStatistic("runningTasks", "GAUGE")
-        self._statService.addStatistic("taskCount", "GAUGE")
-        self._statService.addStatistic("queuedTasks", "GAUGE")
-        self._statService.addStatistic("missedRuns", "GAUGE")
-
-        # namespace these a bit so they can be used in ZP monitoring.
-        # prefer these stat names and metrology in future refs
-        self._dataPointsMetric = Metrology.meter("collectordaemon.dataPoints")
-        daemon = self
-        class DeviceGauge(Gauge):
-            @property
-            def value(self):
-                return len(daemon._devices)
-        Metrology.gauge('collectordaemon.devices', DeviceGauge())
-
-        # Scheduler statistics
-        class RunningTasks(Gauge):
-            @property
-            def value(self):
-                return daemon._scheduler._executor.running
-        Metrology.gauge('collectordaemon.runningTasks', RunningTasks())
-
-        class TaskCount(Gauge):
-            @property
-            def value(self):
-                return daemon._scheduler.taskCount
-        Metrology.gauge('collectordaemon.taskCount', TaskCount())
-
-        class QueuedTasks(Gauge):
-            @property
-            def value(self):
-                return daemon._scheduler._executor.queued
-        Metrology.gauge('collectordaemon.queuedTasks', QueuedTasks())
-
-        class MissedRuns(Gauge):
-            @property
-            def value(self):
-                return daemon._scheduler.missedRuns
-        Metrology.gauge('collectordaemon.missedRuns', MissedRuns())
-
         zope.component.provideUtility(self._statService, IStatisticsService)
+
+        if self.options.cycle:
+            # setup daemon statistics (deprecated names)
+            self._statService.addStatistic("devices", "GAUGE")
+            self._statService.addStatistic("dataPoints", "DERIVE")
+            self._statService.addStatistic("runningTasks", "GAUGE")
+            self._statService.addStatistic("taskCount", "GAUGE")
+            self._statService.addStatistic("queuedTasks", "GAUGE")
+            self._statService.addStatistic("missedRuns", "GAUGE")
+
+            # namespace these a bit so they can be used in ZP monitoring.
+            # prefer these stat names and metrology in future refs
+            self._dataPointsMetric = Metrology.meter("collectordaemon.dataPoints")
+            daemon = self
+            class DeviceGauge(Gauge):
+                @property
+                def value(self):
+                    return len(daemon._devices)
+            Metrology.gauge('collectordaemon.devices', DeviceGauge())
+
+            # Scheduler statistics
+            class RunningTasks(Gauge):
+                @property
+                def value(self):
+                    return daemon._scheduler._executor.running
+            Metrology.gauge('collectordaemon.runningTasks', RunningTasks())
+
+            class TaskCount(Gauge):
+                @property
+                def value(self):
+                    return daemon._scheduler.taskCount
+            Metrology.gauge('collectordaemon.taskCount', TaskCount())
+
+            class QueuedTasks(Gauge):
+                @property
+                def value(self):
+                    return daemon._scheduler._executor.queued
+            Metrology.gauge('collectordaemon.queuedTasks', QueuedTasks())
+
+            class MissedRuns(Gauge):
+                @property
+                def value(self):
+                    return daemon._scheduler.missedRuns
+            Metrology.gauge('collectordaemon.missedRuns', MissedRuns())
 
         self._deviceGuids = {}
         self._devices = set()

--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -853,8 +853,8 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
             self._metrologyReporter = TwistedMetricReporter(self.options.writeStatistics, self.metricWriter(), daemonTags)
             self._metrologyReporter.start()
 
-
-        reactor.callWhenRunning(startStatsLoop)
+        if self.options.cycle:
+            reactor.callWhenRunning(startStatsLoop)
         d.addCallback(callback)
         d.addErrback(twisted.python.log.err)
         reactor.run()


### PR DESCRIPTION
Reduces noise in daemon logs when doing a 'zenpython/zencommand run' while testing. Fixes ZEN-30701.