### PR TITLE
ZEN-30498: Prevent overriding of custom graphs colors

### DIFF
--- a/Products/ZenUI3/browser/resources/css/zen-cse.css
+++ b/Products/ZenUI3/browser/resources/css/zen-cse.css
@@ -408,7 +408,7 @@ BYE BYE BORDERS
     }
 
     /*ZEN-30098*/
-    .z-cse .x-surface path {
+    .z-cse .x-surface path[stroke="#444"] {
         stroke: #4b4b4c;
     }
     .z-cse .x-surface text {
@@ -2461,7 +2461,7 @@ BYE BYE BORDERS
     .z-cse.z-cse-dark .x-surface text {
         fill: #ccc;
     }
-    .z-cse.z-cse-dark .x-surface path {
+    .z-cse.z-cse-dark .x-surface path[stroke="#444"] {
         stroke: #ccc;
     }
 


### PR DESCRIPTION
The default `stroke` for axes in `Ext.chart.theme.Base` is `#444`, so we have to apply overriding only in this case to let other `path`s have custom colors.

[Jira & Demo](https://jira.zenoss.com/browse/ZEN-30498?focusedCommentId=136504&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-136504)