### PR TITLE
ZEN-30779: Prevent hanging of events console

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
@@ -1553,14 +1553,16 @@
             if (decoded.state) {
                 try {
                     state = Ext.decode(Zenoss.util.base64.decode(decodeURIComponent(decoded.state)));
+                    Ext.state.Manager.set(this.stateId, state);
+                    this.fireEvent('recreateGrid', this);
                 } catch(e) { }
             //in case parameters are not encoded
             } else {
-                state = {"filters": decoded};
+                var filters = { filters: decoded };
+                this.clearFilters();
+                this.applyState(filters);
+                this.filterRow.storeSearch();
             }
-
-            Ext.state.Manager.set(this.stateId, state);
-            this.fireEvent('recreateGrid', this);
         },
         clearURLState: function() {
             var qs = Ext.urlDecode(window.location.search.replace(/^\?/, ''));


### PR DESCRIPTION
Prevent error that appears when we try to update `Ext.state.Manager` when there is no reason to do it since from url we got filters params for events, not a state.

[Jira & Demo](https://jira.zenoss.com/browse/ZEN-30779?focusedCommentId=136576&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-136576)