### PR TITLE
ZEN-30809 - Link for Resource is broken in event details

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
@@ -351,14 +351,14 @@ Ext.onReady(function() {
         init: function() {
             var default_renderers = {
                 device: function(value, sourceData) {
-                    var val = sourceData.device_title;
+                    var val = Ext.htmlEncode(sourceData.device_title);
                     if (sourceData.device_url) {
                         val = Zenoss.render.default_uid_renderer(
                             sourceData.device_url,
                             sourceData.device_title);
                     }
 
-                    return Ext.htmlEncode(val);
+                    return val;
                 },
                 component: function(value, sourceData) {
                     var val = Ext.htmlEncode(sourceData.component_title);


### PR DESCRIPTION
encode only title, we need html from default_uid_renderer.