### PR TITLE
ZEN-30823: Fix issue with copying large modeling output

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
@@ -152,16 +152,25 @@ Ext.define("Zenoss.CommandWindow", {
         var tempText = document.createElement("textarea");
         tempText.value = body;
         document.body.appendChild(tempText);
-        tempText.focus();
-        tempText.select();
-        try {
-            if (document.execCommand('copy')) {
-               Zenoss.flares.Manager.success('Copied command output to clipboard');
+
+        function afterTextareaAppending() {
+            tempText.focus();
+            tempText.select();
+            try {
+                if (document.execCommand('copy')) {
+                    Zenoss.flares.Manager.success('Copied command output to clipboard');
+                }
+            } catch (err) {
+                console.error("Failed to copy command output to clipboard", err);
+            } finally {
+                document.body.removeChild(tempText);
             }
-        } catch(err) {
-            console.error("Failed to copy command output to clipboard", err);
-        } finally {
-            document.body.removeChild(tempText);
+        }
+
+        if (Ext.isChrome) {
+            setTimeout(afterTextareaAppending);
+        } else {
+            afterTextareaAppending();
         }
     },
     closeAndRedirect: function() {

--- a/Products/ZenUI3/browser/resources/js/zenoss/ExtOverrides.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/ExtOverrides.js
@@ -1115,4 +1115,12 @@ Ext.override(Ext.util.Sorter, {
         }
     });
 
+    Ext.isEdge = (function () {
+        return /edge/.test(Ext.userAgent);
+    })();
+
+    Ext.isChrome = !Ext.isEdge && (function () {
+        return /\bchrome\b/.test(Ext.userAgent);
+    })();
+
 }());


### PR DESCRIPTION
The approach with `setTimeout` is the workaround that fixes the issue on Chrome.