### PR TITLE
ZEN-30880: make a request to server to get Browser state

### DIFF
--- a/Products/ZenUI3/browser/javascript.py
+++ b/Products/ZenUI3/browser/javascript.py
@@ -271,15 +271,16 @@ class BrowserState(JavaScriptSnippet):
     """
     Restores the browser state.
     """
+    # return the js snippet that will make a request for browser state
+    # and than set it
     def snippet(self):
-        try:
-            userSettings = self.context.ZenUsers.getUserSettings()
-        except AttributeError:
-            # We're on a backcompat page where we don't have browser state
-            # anyway. Move on.
-            return ''
-        state_container = getattr(userSettings, '_browser_state', {})
-        if isinstance(state_container, basestring):
-            state_container = {}
-        state = state_container.get('state', '{}')
-        return 'Ext.state.Manager.getProvider().setState(%r);' % state
+        snippet = """
+            Ext.onReady(function(){
+                Zenoss.remote.MessagingRouter.getBrowserState({},
+                    function(response){
+                            Ext.state.Manager.getProvider().setState(response)
+                    }
+                )
+            })
+        """
+        return snippet

--- a/Products/Zuul/routers/messaging.py
+++ b/Products/Zuul/routers/messaging.py
@@ -41,6 +41,22 @@ class MessagingRouter(DirectRouter):
         if state != state_container.get('state', ''):
             state_container['state'] = state
 
+    def getBrowserState(self):
+        """
+        Retur the browser state for the current user.
+        """
+        try:
+            userSettings = self.context.dmd.ZenUsers.getUserSettings()
+        except AttributeError:
+            # We're on a backcompat page where we don't have browser state
+            # anyway. Move on.
+            return ''
+        state_container = getattr(userSettings, '_browser_state', {})
+        if isinstance(state_container, basestring):
+            state_container = {}
+        state = state_container.get('state', '{}')
+        return state
+
 
     def clearBrowserState(self, user=None):
         """


### PR DESCRIPTION
There is nginx filtering rules that are adding /cz# prefix
to all the html that is passed to UI and this is breaking
things that do not require /cz# prefix.
To fetch the browser state we are now making an api call.

[JIRA&DEMO
](https://jira.zenoss.com/browse/ZEN-30880?focusedCommentId=138066&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138066)
