### PR TITLE
ZEN-30469: The test regex window is not fetching process list

### DIFF
--- a/Products/Zuul/facades/processfacade.py
+++ b/Products/Zuul/facades/processfacade.py
@@ -167,9 +167,7 @@ class ProcessFacade(TreeFacade):
                 zenmodelerPath = binPath(zenmodelerName)
                 monitorId = device.perfServer().id
                 if monitorId != 'localhost':
-                    zenmodelerPath = binPath(zenmodelerName)
-                    if len(zenmodelerPath) == 0:
-                        isPerfMonRemote = True
+                    isPerfMonRemote = True
                 if isPerfMonRemote:
                     cmd = 'zminion --minion-name zminion_%s run -- "%s %s"' % (device.getPerformanceServerName(), zenmodelerName, ' '.join(zenmodelerOpts))
                 else:


### PR DESCRIPTION
When we have the remote collector getProcessList should be
run on that collector, but it is not.
Logical operator that is used to set the modeler collector
is not right. We should use remote modeling in the case
when the collector is not equal to localhost and do not care
about the path to zenmodelerPath.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30469?focusedCommentId=138141&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138141)