### PR TITLE
ZEN-29654 Reopened- zenmail fails to parse hostname from an email address (the patch for this broke zenmail)

### DIFF
--- a/Products/ZenEvents/MailProcessor.py
+++ b/Products/ZenEvents/MailProcessor.py
@@ -34,7 +34,7 @@ class MailEvent(Event):
     Defaults for events created by the processor
     """
     agent = "zenmail"
-    eventGroup = "mail" 
+    eventGroup = "mail"
 
 
 # The following is copied from the Python standard library
@@ -68,7 +68,7 @@ class MessageProcessor(object):
     received via SMTP.
     """
 
-    def __init__(self, zem, defaultSeverity = 2): 
+    def __init__(self, zem, defaultSeverity = 2):
         """
         Initializer
 
@@ -79,6 +79,16 @@ class MessageProcessor(object):
         """
         self.zem = zem
         self.eventSeverity = defaultSeverity
+        self.one_part_email = re.compile(r'''^[<"']?(.*?)[">']?$''')
+        self.two_part_email = re.compile(r'(.*) <(.*?)>$')
+
+    def parse_email_address(self, address):
+        match = self.two_part_email.match(address)
+        if match:
+            return self.parse_email_address(match.group(2))
+        match = self.one_part_email.match(address)
+        if match:
+            return match.group(1)
 
     def process(self, messageStr):
         """
@@ -89,30 +99,32 @@ class MessageProcessor(object):
         """
         message = email.message_from_string(messageStr)
         self.message = message
-        
+
         fromAddr = message.get('From')
         origFromAddr = fromAddr
         log.debug("Found a 'from' address of %s" % fromAddr)
         if not fromAddr or fromAddr.find('@') == -1:
-            log.warning("Unable to process the 'from' address %s -- ignoring mail" \
-                        % fromAddr)
+            log.warning("Unable to process the 'from' address %s -- ignoring mail", fromAddr)
             return
-        
-        pattern = re.compile(r'(.*) <(.*?)>$')
-        match = pattern.match(fromAddr)
-        fromAddr = match.group(2).split('@')[-1]
+
+        fromAddr = self.parse_email_address(fromAddr)
+        if not fromAddr:
+            log.warning("Could not parse email address in the 'from' address %s -- ignoring mail",
+                        origFromAddr)
+            return
         log.debug("The from address after processing is '%s'" % fromAddr)
+        fromHost = fromAddr.split('@')[-1]
         try:
-            fromIp = socket.gethostbyname(fromAddr)
+            fromIp = socket.gethostbyname(fromHost)
         except socket.gaierror:
             fromIp = None
-            log.info('Hostname lookup failed for host: %s' % fromAddr)
+            log.info('Hostname lookup failed for host: %s' % fromHost)
 
         subject = message.get('Subject').replace("\r","").replace("\n", "")
 
         secs = self.getReceiveTime(message)
 
-        event = MailEvent(device=fromAddr, rcvtime=secs,
+        event = MailEvent(device=fromHost, rcvtime=secs,
                           fromEmailAddress=origFromAddr)
         if fromIp:
             event.ipAddress = fromIp
@@ -196,7 +208,7 @@ class MessageProcessor(object):
                      timestamp)
             tz = None
 
-        # Construct dt using the date and time as well as the timezone 
+        # Construct dt using the date and time as well as the timezone
         dt = datetime(t[0], t[1], t[2], t[3], t[4], t[5], 0, tz)
         secs = calendar.timegm(dt.utctimetuple())
         log.debug('Timestamp of the event (should be in UTC): %s -> %f',
@@ -211,7 +223,7 @@ class POPProcessor(MessageProcessor):
     implementing it here.
     """
 
-    def __init__(self, zem, defaultSeverity = 2): 
+    def __init__(self, zem, defaultSeverity = 2):
         """
         Initializer
 
@@ -229,7 +241,7 @@ class MailProcessor(MessageProcessor):
     implementing it here.
     """
 
-    def __init__(self, zem, defaultSeverity = 2): 
+    def __init__(self, zem, defaultSeverity = 2):
         """
         Initializer
 
@@ -242,15 +254,15 @@ class MailProcessor(MessageProcessor):
 
 class ZenMailTest(ZenScriptBase):
     """
-    Usage:  
-            
+    Usage:
+
     python MailProcessor.py file1 [...]
 
     Read text files that are saved emails and send events into Zenoss
     """
     def __init__(self):
         ZenScriptBase.__init__(self, connect=True)
-    
+
     def run(self):
         if len(self.args) == 0:
             log.critical("Need at least one input filename!")

--- a/Products/ZenEvents/tests/testMailProcessor.py
+++ b/Products/ZenEvents/tests/testMailProcessor.py
@@ -83,6 +83,20 @@ class TestMailProcessor(BaseTestCase):
         # I *think* it got fixed in Python
         self.checkMsgToEvent( "utc" )
 
+    def testParseEmail(self):
+        mp = MessageProcessor(self.zem, 2)
+        cases = [
+            'more.info@test.example.com',
+            '<more.info@test.example.com>',
+            '"more.info@test.example.com"',
+            '"more.info@test.example.com"',
+            "'more.info@test.example.com'",
+            '"More Information" <more.info@test.example.com>',
+        ]
+        expected = 'more.info@test.example.com'
+        for email in cases:
+            parsed = mp.parse_email_address(email)
+            self.assertEquals(parsed, expected)
 
 
 def test_suite():


### PR DESCRIPTION
Change From address parsing in MailProcessor