### PR TITLE
ZEN-29433: global name 'log' is not defined

### DIFF
--- a/Products/Jobber/facade.py
+++ b/Products/Jobber/facade.py
@@ -77,5 +77,5 @@ class FacadeMethodJob(Job):
             except FacadeMethodJobFailed:
                 raise
             except (TypeError, KeyError):
-                log.error('The output from job {} is not in the right format.'
+                self.log.error('The output from job {} is not in the right format.'
                         .format(self.request.id))

--- a/Products/ZenModel/DeviceClass.py
+++ b/Products/ZenModel/DeviceClass.py
@@ -220,7 +220,6 @@ class DeviceClass(DeviceOrganizer, ZenPackable, TemplateContainer):
 
         notify(DeviceClassMovedEvent(dev, dev.deviceClass().primaryAq(), target))
 
-        exported = False
 
         if dev.__class__ != targetClass:
             from Products.ZenRelations.ImportRM import NoLoginImportRM
@@ -324,19 +323,19 @@ class DeviceClass(DeviceOrganizer, ZenPackable, TemplateContainer):
             source.devices._delObject(devname)
             log.debug('Importing device %s to %s', devname, target)
             devImport(xmlfile)
-            exported = True
         else:
             dev._operation = 1
             source.devices._delObject(devname)
             target.devices._setObject(devname, dev)
         dev = target.devices._getOb(devname)
 
+        is_dev_moved = True
         IGlobalIdentifier(dev).guid = guid
         dev.setLastChange()
         dev.setAdminLocalRoles()
         notify(IndexingEvent(dev))
 
-        return exported
+        return is_dev_moved
 
     def moveDevices(self, moveTarget, deviceNames=None, REQUEST=None):
         """
@@ -355,12 +354,12 @@ class DeviceClass(DeviceOrganizer, ZenPackable, TemplateContainer):
         target = self.getDmdRoot(self.dmdRootName).getOrganizer(moveTarget)
         if isinstance(deviceNames, basestring): deviceNames = (deviceNames,)
         targetClass = target.getPythonDeviceClass()
-        numExports = 0
+        moved_devices_count = 0
         for devname in deviceNames:
             devicewasExported = self._moveDevice(devname, target, targetClass)
             if devicewasExported:
-                numExports += 1
-        return numExports
+                moved_devices_count += 1
+        return moved_devices_count
 
     security.declareProtected(ZEN_DELETE_DEVICE, 'removeDevices')
     def removeDevices(self, deviceNames=None, deleteStatus=False,

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -557,7 +557,7 @@ class DeviceFacade(TreeFacade):
         assert isinstance(target, DeviceOrganizer)
         devs = (self._getObject(uid) for uid in uids)
         targetname = target.getOrganizerName()
-        exports = 0
+        moved_devices_count = 0
         if isinstance(target, DeviceGroup):
             for dev in devs:
                 paths = set(dev.getDeviceGroupNames())
@@ -577,8 +577,13 @@ class DeviceFacade(TreeFacade):
                 dev.setLocation(targetname)
                 notify(ObjectAddedToOrganizerEvent(dev, target))
         elif isinstance(target, DeviceClass):
-            exports = self._dmd.Devices.moveDevices(targetname,[dev.id for dev in devs])
-        return exports
+            moved_devices_count = self._dmd.Devices.moveDevices(targetname,[dev.id for dev in devs])
+
+        result = {
+            'success': bool(moved_devices_count),
+            'message': 'The %s devices have been moved' % moved_devices_count
+        }
+        return result
 
     def _setProductionState(self, uids, state):
         if isinstance(uids, basestring):


### PR DESCRIPTION
Backport PR for https://github.com/zenoss/zenoss-prodbin/pull/3228

Add the `is_dev_moved variable` in the `_moveDevice` method of `DeviceClass`.
Set the `is_dev_moved` as True at the end of the method because if there are no exceptions above this line of code the device change its class. So we return the success result regardless of the device was exported or only moved to another class.

Rename `exports` variable to the `moved_dev_amount` on the `devicefacade.py`

Fix undefined log variable in the `facade.py`

Add the appropriate result structure of the `_moveDevices` method of `DeviceFacade`.