### PR TITLE
ZEN-30907: Fix node selecting after reload in the tree

### DIFF
--- a/Products/Zuul/infos/report.py
+++ b/Products/Zuul/infos/report.py
@@ -8,7 +8,7 @@
 ##############################################################################
 
 
-from zope.component import adapts, getUtility
+from zope.component import adapts
 from zope.interface import implements
 from Products.Zuul.tree import TreeNode
 from Products.Zuul.interfaces import IReportClassNode, IReportNode
@@ -17,7 +17,6 @@ from Products.ZenModel.ZenModelRM import ZenModelRM
 from Products.Zuul.routers.report import essentialReportOrganizers
 from Products.ZenModel.GraphReport import GraphReport
 from Products.ZenModel.MultiGraphReport import MultiGraphReport
-from Products.ZenUtils.virtual_root import IVirtualRoot
 
 class ReportClassNode(TreeNode):
     implements(IReportClassNode)
@@ -73,7 +72,7 @@ class ReportNode(TreeNode):
 
     @property
     def uid(self):
-        return getUtility(IVirtualRoot).ensure_virtual_root(self._object.uid)
+        return self._object.uid
 
     @property
     def leaf(self):


### PR DESCRIPTION
The addition of cz prefix on the backend side caused some side effects in [`getNodePathById` method](https://github.com/zenoss/zenoss-prodbin/blob/24072cf22f2f09635dd70e9d5392baa24c68ad04/Products/ZenUI3/browser/resources/js/zenoss/HierarchyTreePanel.js#L577) of `HierarchyTreePanel` component. The node path that function began to return is not a valid node path so after reloading application is not able to select a node that was selected before reloading.

By [PR #3152](https://github.com/zenoss/zenoss-prodbin/pull/3152) was added [JS code that ensures](https://github.com/zenoss/zenoss-prodbin/blob/develop/Products/ZenUI3/browser/resources/js/zenoss/Reports.js#L278) that `uid` that will be used on the report page is with cz prefix and this fixes the problem.