### PR TITLE
ZEN-30743: allow dot in the datasource and datapoint name

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/monitoringTemplates/datasource.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/monitoringTemplates/datasource.js
@@ -333,8 +333,8 @@ Ext.define("Zenoss.DataSourceTreeGrid", {
                     ref: 'metricName',
                     fieldLabel: _t('Name'),
                     allowBlank: false,
-                    regex: Zenoss.env.textMasks.allowedNameTextDash,
-                    regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDash,
+                    regex: Zenoss.env.textMasks.allowedNameTextDashDot,
+                    regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDashDot,
                     blankText: _t('Name is a required field')
                 }],
                 buttons: [{
@@ -409,8 +409,8 @@ Ext.define("Zenoss.DataSourceTreeGrid", {
                     ref: 'dataSourceName',
                     fieldLabel: _t('Name'),
                     allowBlank: false,
-                    regex: Zenoss.env.textMasks.allowedNameTextDash,
-                    regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDash,
+                    regex: Zenoss.env.textMasks.allowedNameTextDashDot,
+                    regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDashDot,
                     blankText: _t('Name is a required field')
                 }, {
                     xtype: 'combo',
@@ -579,8 +579,8 @@ Ext.define("Zenoss.DataSourceTreeGrid", {
             newId = findSubObject({name:"newId"}, config)
             if (newId) {
                 newId.inputAttrTpl = null;
-                newId.regex = Zenoss.env.textMasks.allowedNameTextDash;
-                newId.regexText = Zenoss.env.textMasks.allowedNameTextFeedbackDash;
+                newId.regex = Zenoss.env.textMasks.allowedNameTextDashDot;
+                newId.regexText = Zenoss.env.textMasks.allowedNameTextFeedbackDashDot;
             }
 
             if (isDataPoint) {


### PR DESCRIPTION
A while ago rules for datasource name was added, that rule
was disabling a form if we have any special character in the
name except underscores and dashes since datasource name is
part of the metric name in OpenTSDB that was breaking graphs.
According to OpenTSDB documentation, dots are also acceptable in
metric names.

Since datasource name is used as a part for metric name in OpenTSDB I added periods to one of the allowed characters in datasource name according to OpenTSDB docs.
http://opentsdb.net/docs/build/html/user_guide/writing.html

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30743?focusedCommentId=138653&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-138653)