### PR TITLE
Fixes ZEN-30966

### DIFF
--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -179,6 +179,10 @@ class TreeFacade(ZuulFacade):
             elif key == 'productionState':
                 qs.append(Or(*[Eq('productionState', str(state))
                              for state in value]))
+            # ZEN-30966 - stringify values from the 'priority' list if it's passed in for query criteria
+            elif key == 'priority':
+                qs.append(Or(*[Eq('priority', str(priority))
+                               for priority in value]))
             # ZEN-10057 - move filtering on indexed groups/systems/location from post-filter to query
             elif key in organizersToClass:
                 organizerQuery = self.findMatchingOrganizers(organizersToClass[key], organizersToPath[key], value)


### PR DESCRIPTION
Fixes ZEN-30966, backport of ZEN-30949: Fixes a condition where a 'priority' filter was not being converted from a list, resulting in an expected object type making it into the solr model index search.