### PR TITLE
ZEN-30926: Add "Model Change Handler time" measurement to RM ZenPack

### DIFF
--- a/Products/ZenMessaging/queuemessaging/publisher.py
+++ b/Products/ZenMessaging/queuemessaging/publisher.py
@@ -300,6 +300,7 @@ class PublishSynchronizer(object):
             log.debug("ModelEventList batch size %s" % count)
         return msgs
 
+    @Metrology.utilization_timer('zen.queuepublisher.beforeCompletionHookTimer')
     def beforeCompletionHook(self, tx):
         try:
             log.debug("beforeCompletionHook on tx %s" % tx)
@@ -322,6 +323,7 @@ class PublishSynchronizer(object):
             if hasattr(tx, '_synchronizedPublisher'):
                 tx._synchronizedPublisher = None
 
+    @Metrology.utilization_timer('zen.queuepublisher.afterCompletionHookTimer')
     def afterCompletionHook(self, status, tx):
         try:
             log.debug("afterCompletionHook status:%s for tx %s" % (status, tx))


### PR DESCRIPTION
Added the Metrology timers to check the commit hook processing.

Backport from https://github.com/zenoss/zenoss-prodbin/pull/3471/commits/e9655c5b7d2df970d50563574621118988736385