### PR TITLE
ZEN-30592: remove buildTextLabel functionality

### DIFF
--- a/Products/ZenWidgets/ZenTableState.py
+++ b/Products/ZenWidgets/ZenTableState.py
@@ -182,34 +182,11 @@ class ZenTableState:
         pageLabel = ""
         # do not show the page label if there is only one page
         if self.totalobjs > self.batchSize:
-            if self.sortedHeader:
-                pageLabel = self._buildTextLabel(objects[index])
-            elif self.batchSize:
+            if self.batchSize:
                 pageLabel = str(1+index/self.batchSize)
             else:
                 pageLabel = '1'
         return pageLabel
-
-
-    def _buildTextLabel(self, item):
-        startAbbr = ""
-        endAbbr = ""
-        attr = getattr(item, self.sortedHeader, self.defaultValue)
-        if callable(attr): attr = attr()
-        if isinstance(attr, DateTime) and not attr.millis():
-            label = self.defaultValue
-        elif isinstance(attr, basestring):
-            label = attr
-        else:
-            label = str(attr)
-        if isinstance(item, dict):
-            label = item.get(self.sortedHeader, "")
-        if len(label) > self.abbrThresh:
-            startAbbr = label[:self.abbrStartLabel]
-            if self.abbrEndLabel > 0:
-                endAbbr = label[-self.abbrEndLabel:]
-            label = "".join((startAbbr, self.abbrSeparator, endAbbr))
-        return label
 
 
     def setTableState(self, attname, value, default=None, reset=False, request=None):

--- a/Products/ZenWidgets/ZenTableState.py
+++ b/Products/ZenWidgets/ZenTableState.py
@@ -182,11 +182,34 @@ class ZenTableState:
         pageLabel = ""
         # do not show the page label if there is only one page
         if self.totalobjs > self.batchSize:
-            if self.batchSize:
+            if self.sortedHeader:
+                pageLabel = self._buildTextLabel(objects[index])
+            elif self.batchSize:
                 pageLabel = str(1+index/self.batchSize)
             else:
                 pageLabel = '1'
         return pageLabel
+
+
+    def _buildTextLabel(self, item):
+        startAbbr = ""
+        endAbbr = ""
+        attr = getattr(item, self.sortedHeader, self.defaultValue)
+        if callable(attr): attr = attr()
+        if isinstance(attr, DateTime) and not attr.millis():
+            label = self.defaultValue
+        else:
+            label = attr
+        if isinstance(item, dict):
+            label = item.get(self.sortedHeader, "")
+        # ensuring that we are always working with a string
+        label = str(label)
+        if len(label) > self.abbrThresh:
+            startAbbr = label[:self.abbrStartLabel]
+            if self.abbrEndLabel > 0:
+                endAbbr = label[-self.abbrEndLabel:]
+            label = "".join((startAbbr, self.abbrSeparator, endAbbr))
+        return label
 
 
     def setTableState(self, attname, value, default=None, reset=False, request=None):


### PR DESCRIPTION
When a user uses page size filter on the table view and sorts
the column that has int value in it will fall with a traceback.
Also, values from the sorted column are used as a page name on
pagination select element, which is not logically right, there
should be only the page numbers 1,2,3 ....
Remove that functionality since it is confusing and not logical.

We are using `_buildTextLabel`  only in this module.

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30592?focusedCommentId=140258&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-140258) 
