### PR TITLE
ZEN-31177: send to UI asterisks instead of valid password

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -132,7 +132,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         {'id':'smtpPort', 'type': 'int', 'mode':'w'},
         {'id':'pageCommand', 'type': 'string', 'mode':'w'},
         {'id':'smtpUser', 'type': 'string', 'mode':'w'},
-        {'id':'smtpPass', 'type': 'string', 'mode':'w'},
+        {'id':'smtpPass', 'type': 'password', 'mode':'w'},
         {'id':'smtpUseTLS', 'type': 'int', 'mode':'w'},
         {'id':'emailFrom', 'type': 'string', 'mode':'w'},
         {'id':'geomapapikey', 'type': 'string', 'mode':'w'},

--- a/Products/ZenModel/skins/zenmodel/editSettings.pt
+++ b/Products/ZenModel/skins/zenmodel/editSettings.pt
@@ -106,7 +106,7 @@ loader.insert();
       <td class="noselect tableheader" i18n:attributes="title" title="Use this only if authentication is required" i18n:translate='' align="left">SMTP Password (blank for none)</td>
       <td class="tablevalues">
         <input class="tablevalues" id="smtpPass" autocomplete="off" i18n:attributes="title" title="Use this only if authentication is required" type="password" name="smtpPass"
-            tal:attributes="value here/smtpPass|string:" />
+            onfocus="this.value=''" tal:define="password_val here/smtpPass; plen python:len(password_val); secured_pass python:'*'*plen"  tal:attributes="value secured_pass" />
       </td>
     </tr>
     <tr class="odd">

--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -356,6 +356,7 @@ class ZenPropertyManager(object, PropertyManager):
             setprops(id=id, type=type, visible=visible)
             self._setPropValue(id, value)
 
+    _onlystars = re.compile("^\*+$").search
     def _updateProperty(self, id, value):
         """This method sets a property on a zope object. It overrides the
         method in PropertyManager. If Zope is upgraded you will need to check
@@ -364,6 +365,10 @@ class ZenPropertyManager(object, PropertyManager):
         Converters.py
         """
         try:
+            # Do not update property if its a password
+            # and value is secured(equals to all asterisk)
+            if self.zenPropIsPassword(id) and self._onlystars(value):
+                return
             super(ZenPropertyManager, self)._updateProperty(id, value)
         except ValueError:
             proptype = self.getPropertyType(id)
@@ -372,7 +377,6 @@ class ZenPropertyManager(object, PropertyManager):
                 "type. It should be type '%s'.", id, value, proptype
             )
 
-    _onlystars = re.compile("^\*+$").search
     security.declareProtected(ZEN_ZPROPERTIES_EDIT, 'manage_editProperties')
     def manage_editProperties(self, REQUEST):
         """Edit object properties via the web.


### PR DESCRIPTION
User password for SMTP server is accessible in browser dev tool
by just selecting an input field, the input field value attribute
will show the password as clear text.
Set the value attribute of the input field to masked password under
asterisks. When the form on the UI is submited save the password
only if its new. When SMTP password field is in focus clear it
to prevent updating old password since it can cause wrong password
situation(****  will be saved like ****56)

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-31177?focusedCommentId=142300&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-142300)