### PR TITLE
ZEN-30240: model service RAM Commitment and add it as a threshold

### DIFF
--- a/Products/ZenUtils/controlplane/application.py
+++ b/Products/ZenUtils/controlplane/application.py
@@ -13,6 +13,7 @@ IApplication* control-plane implementations.
 
 import logging
 import os
+import re
 import time
 from fnmatch import fnmatch
 from functools import wraps
@@ -30,6 +31,14 @@ from .runstates import RunStates
 
 LOG = logging.getLogger("zen.controlplane")
 _TENANT_ID_ENV = "CONTROLPLANE_TENANT_ID"
+
+
+MEM_MULTIPLIER = {
+    'k':1024,
+    'm':1024*1024,
+    'g':1024*1024*1024,
+    't':1024*1024*1024*1024
+}
 
 
 def getTenantId():
@@ -407,6 +416,17 @@ class DeployedApp(object):
         """
         """
         self._client.updateService(self._service)
+
+    @property
+    def RAMCommitment(self):
+        """
+        Get the RAM Commitment of the service and trasform it in the byte value.
+        RAMCommitment: string in form <number{0-9}><unit{K,M,G,T}>
+        """
+        match = re.search("(?P<value>[0-9]*\.?[0-9]*)(?P<unit>[k,m,g,t]+)", self._service.RAMCommitment, re.IGNORECASE)
+        if not match : return
+        RAMCommitment_bytes = int(match.group('value')) * MEM_MULTIPLIER.get(match.group('unit').lower())
+        return RAMCommitment_bytes
 
 
 class _DeployedAppConfigList(Sequence):

--- a/Products/ZenUtils/controlplane/data.py
+++ b/Products/ZenUtils/controlplane/data.py
@@ -444,6 +444,10 @@ class ServiceDefinition(object):
     def description(self):
         return self._data.get("Description")
 
+    @property
+    def RAMCommitment(self):
+        return self._data.get("RAMCommitment")
+
     @description.setter
     def description(self, desc):
         self._data["Description"] = desc


### PR DESCRIPTION
Get  RAMCommitment of the CC service for RM zp to model and use it.

Related PR to RM ZP: https://github.com/zenoss/ZenPacks.zenoss.RMMonitor/pull/144

[JIRA&DEMO](https://jira.zenoss.com/browse/ZEN-30240?focusedCommentId=143046&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-143046)