### PR TITLE
Handle PBConnectionLost exceptions

### DIFF
--- a/Products/ZenHub/dispatchers/workerpool.py
+++ b/Products/ZenHub/dispatchers/workerpool.py
@@ -21,8 +21,9 @@ class ServiceCallError(Exception):
     This is an internal use only exception and not part of the public API.
     """
 
-    def __init__(self, mesg):
+    def __init__(self, mesg, source):
         super(ServiceCallError, self).__init__(mesg)
+        self.source = source
 
 
 class WorkerPool(
@@ -187,7 +188,7 @@ class WorkerRef(object):
             _, _, tb = sys.exc_info()
             error = ServiceCallError(
                 "Failed to retrieve service '%s': (%s) %s"
-                % (job.service, type(ex).__name__, ex)
+                % (job.service, type(ex).__name__, ex), ex
             )
             raise ServiceCallError, error, tb
 
@@ -200,6 +201,6 @@ class WorkerRef(object):
             _, _, tb = sys.exc_info()
             error = ServiceCallError(
                 "Failed to execute %s.%s: (%s) %s"
-                % (job.service, job.method, type(ex).__name__, ex)
+                % (job.service, job.method, type(ex).__name__, ex), ex
             )
             raise ServiceCallError, error, tb

--- a/Products/ZenHub/dispatchers/workers.py
+++ b/Products/ZenHub/dispatchers/workers.py
@@ -66,8 +66,8 @@ class WorkerPoolDispatcher(object):
             dfr.addErrback(
                 lambda ex: self.__log.error(
                     "Failed to report status (%s): %s",
-                    worker.workerId, ex
-                )
+                    worker.workerId, ex,
+                ),
             )
             deferreds.append(dfr)
         return defer.DeferredList(deferreds)
@@ -82,7 +82,7 @@ class WorkerPoolDispatcher(object):
         # Schedule a call to _execute to process this newly submitted job.
         self.__reactor.callLater(0, self._execute)
         self.__log.info(
-            "Job submitted: (%s) %s.%s", job.monitor, job.service, job.method
+            "Job submitted: (%s) %s.%s", job.monitor, job.service, job.method,
         )
         return ajob.deferred
 
@@ -104,7 +104,7 @@ class WorkerPoolDispatcher(object):
                 defer.returnValue(None)
 
             self.__log.info(
-                "There are %s workers available", self.__workers.available
+                "There are %s workers available", self.__workers.available,
             )
             self.__log.info("Worklist has %s jobs", len(self.__worklist))
             asyncjob = self.__worklist.pop()
@@ -136,8 +136,8 @@ class WorkerPoolDispatcher(object):
         dfr = defer.maybeDeferred(listener, job)
         dfr.addErrback(
             lambda x: self.__log.error(
-                "Error in listener %r: %s", listener, x
-            )
+                "Error in listener %r: %s", listener, x,
+            ),
         )
         return dfr
 
@@ -153,22 +153,22 @@ class WorkerPoolDispatcher(object):
             except ServiceCallError as ex:
                 if worker in self.__workers:
                     self.__log.error(
-                        "(worker %s) %s: %s", worker.workerId, ex, ex.source
+                        "(worker %s) %s: %s", worker.workerId, ex, ex.source,
                     )
                     self.__reactor.callLater(
                         0, asyncjob.failure,
-                        pb.Error("Internal ZenHub error: %s" % (ex,))
+                        pb.Error("Internal ZenHub error: %s" % (ex,)),
                     )
                 else:
                     self.__log.warn(
-                        "(worker %s) Bad worker ref: %s", worker.workerId, ex
+                        "(worker %s) Bad worker ref: %s", worker.workerId, ex,
                     )
                     # Bad worker reference, so retry the call
                     self.__worklist.pushfront(asyncjob)
             except pb.PBConnectionLost as ex:
                 self.__log.warn(
                     "(worker %s) Worker no longer accepting work: %s",
-                    worker.workerId, ex
+                    worker.workerId, ex,
                 )
                 # Worker went away, so retry the call
                 self.__worklist.pushfront(asyncjob)
@@ -237,12 +237,12 @@ class StatsMonitor(object):
 
         self.__log.info(
             "(worker %s) Finished work job=%s elapsed=%0.3f",
-            wid, jobDesc, elapsed
+            wid, jobDesc, elapsed,
         )
         lifetime = finish - asyncjob.recvtime
         self.__log.info(
             "Job %s.%s (%s) lifetime was %0.3f seconds",
-            job.service, job.method, job.monitor, lifetime
+            job.service, job.method, job.monitor, lifetime,
         )
 
 
@@ -269,7 +269,7 @@ class JobStats(object):
 
 
 ServiceCallJob = collections.namedtuple(
-    "ServiceCallJob", "service monitor method args kwargs"
+    "ServiceCallJob", "service monitor method args kwargs",
 )
 
 

--- a/Products/ZenHub/interfaces.py
+++ b/Products/ZenHub/interfaces.py
@@ -99,7 +99,7 @@ class IInvalidationFilter(Interface):
     Filters invalidations before they're pushed to workers.
     """
     weight = Attribute(
-        "Where this filter should be in the process. Lower is earlier."
+        "Where this filter should be in the process. Lower is earlier.",
     )
 
     def initialize(context):
@@ -166,7 +166,7 @@ class ICollectorEventFingerprintGenerator(Interface):
 
     weight = Attribute(
         "The priority of the fingerprint generator. Generators are executed "
-        "in ascending order until the first non-None fingerprint is returned"
+        "in ascending order until the first non-None fingerprint is returned",
     )
 
     def generate(event):
@@ -201,7 +201,7 @@ class ICollectorEventTransformer(Interface):
 
     weight = Attribute(
         "The priority of the event transformer (the transformers are "
-        "executed in ascending order using the weight of each filter)"
+        "executed in ascending order using the weight of each filter)",
     )
 
     def transform(event):

--- a/Products/ZenHub/interfaces.py
+++ b/Products/ZenHub/interfaces.py
@@ -98,7 +98,9 @@ class IInvalidationFilter(Interface):
     """
     Filters invalidations before they're pushed to workers.
     """
-    weight = Attribute("Where this filter should be in the process. Lower is earlier.")
+    weight = Attribute(
+        "Where this filter should be in the process. Lower is earlier."
+    )
 
     def initialize(context):
         """
@@ -111,13 +113,15 @@ class IInvalidationFilter(Interface):
         L{FILTER_CONTINUE}).
         """
 
+
 class IInvalidationOid(Interface):
     """
     Allows an invalidation OID to be changed to a different OID or dropped
     """
     def transformOid(oid):
         """
-        Given an OID, return the same oid, a different one, a list of other oids or None.
+        Given an OID, return the same oid, a different one,
+        a list of other oids or None.
         """
 
 
@@ -128,6 +132,7 @@ class IHubConfProvider(Interface):
     def getHubConf():
         """
         """
+
 
 class IHubHeartBeatCheck(Interface):
     """
@@ -140,39 +145,41 @@ class IHubHeartBeatCheck(Interface):
 
 class ICollectorEventFingerprintGenerator(Interface):
     """
-    Interface used to generate a fingerprint for an event on the collector. Event
-    fingerprints are used on the collector to perform de-duplication of events. Events
-    are de-duplicated to prevent event floods of similar/identical events from
-    overwhelming the system.
+    Interface used to generate a fingerprint for an event on the collector.
+    Event fingerprints are used on the collector to perform de-duplication
+    of events. Events are de-duplicated to prevent event floods of
+    similar/identical events from overwhelming the system.
 
-    The default fingerprint generator (if no additional ones are implemented) is a
-    pipe-delimited string consisting of the following:
+    The default fingerprint generator (if no additional ones are implemented)
+    is a pipe-delimited string consisting of the following:
 
      - eventKey specified: device, component, eventClass, eventKey, severity
      - no eventKey: device, component, eventClass, severity, summary
 
-    This matches the default algorithm used in zeneventd to de-duplicate events.
+    This matches the default algorithm used in zeneventd to
+    de-duplicate events.
 
-    NOTE: This fingerprint is not persisted in any way on the event - it is only used
-    to perform de-duplication at the collector before events are flushed to ZenHub.
+    NOTE: This fingerprint is not persisted in any way on the event - it is
+    only used to perform de-duplication at the collector before events are
+    flushed to ZenHub.
     """
 
     weight = Attribute(
-        """The priority of the fingerprint generator. Generators are executed
-        in ascending order until the first non-None fingerprint is returned."""
+        "The priority of the fingerprint generator. Generators are executed "
+        "in ascending order until the first non-None fingerprint is returned"
     )
 
     def generate(event):
         """
-        Generates a fingerprint for the event, or returns None if this generator should
-        not be used to generate a fingerprint for this event (the next generator, if
-        found, will be run).
+        Generates a fingerprint for the event, or returns None if this
+        generator should not be used to generate a fingerprint for this event
+        (the next generator, if found, will be run).
 
         @param event: The event to generate a fingerprint for.
         @type event: dict
-        @return: A fingerprint for the event (string) used for de-duplication of events
-                 at the collector. If this generator cannot generate a fingerprint for
-                 the event, then it should return None.
+        @return: A fingerprint for the event (string) used for de-duplication
+            of events at the collector. If this generator cannot generate a
+            fingerprint for the event, then it should return None.
         @rtype: str
         """
 
@@ -184,16 +191,17 @@ TRANSFORM_DROP = 2
 
 class ICollectorEventTransformer(Interface):
     """
-    Interface used to perform filtering of events at the collector. This could be
-    used to drop events, transform event content, etc.
+    Interface used to perform filtering of events at the collector.
+    This could be used to drop events, transform event content, etc.
 
-    These transformers are run sequentially before a fingerprint is generated for
-    the event, so they can set fields which are used by an ICollectorEventFingerprintGenerator.
+    These transformers are run sequentially before a fingerprint is generated
+    for the event, so they can set fields which are used by an
+    ICollectorEventFingerprintGenerator.
     """
 
     weight = Attribute(
-        """The priority of the event transformer (the transformers are executed in
-        ascending order using the weight of each filter)."""
+        "The priority of the event transformer (the transformers are "
+        "executed in ascending order using the weight of each filter)"
     )
 
     def transform(event):
@@ -202,9 +210,24 @@ class ICollectorEventTransformer(Interface):
 
         @param event: The event to transform.
         @type event: dict
-        @return: Returns TRANSFORM_CONTINUE if this event should be forwarded on
-                 to the next transformer in the sequence, TRANSFORM_STOP if no
-                 further transformers should be performed on this event, and
-                 TRANSFORM_DROP if the event should be dropped.
+        @return: Returns TRANSFORM_CONTINUE if this event should be forwarded
+            on to the next transformer in the sequence, TRANSFORM_STOP if no
+            further transformers should be performed on this event, and
+            TRANSFORM_DROP if the event should be dropped.
         @rtype: int
+        """
+
+
+class IServiceReferenceFactory(Interface):
+    """The IServiceReferenceFactory interface describes objects used to
+    build twisted.spread.pb.Referenceable objects.
+    """
+
+    def build(service, name, monitor):
+        """Build and return a ServiceReference object.
+
+        @param service {HubService} Service object
+        @param name {string} Name of the service
+        @param monitor {string} Name of the performance monitor (collector)
+        @returns {twisted.spread.pb.Referenceable}
         """

--- a/Products/ZenHub/servicemanager.py
+++ b/Products/ZenHub/servicemanager.py
@@ -32,7 +32,7 @@ from .dispatchers import (
     DispatchingExecutor, EventDispatcher, WorkerPoolDispatcher,
     WorkerPool, ServiceCallJob, StatsMonitor
 )
-from .interfaces import IServiceAddedEvent
+from .interfaces import IServiceAddedEvent, IServiceReferenceFactory
 from .worklist import (
     ZenHubWorklist, ZenHubPriority, ModelingPaused,
     register_metrics_on_worklist, get_worklist_metrics
@@ -323,8 +323,8 @@ class HubServiceRegistry(Mapping):
         """Initialize a HubServiceRegistry instance.
 
         @param dmd {dmd} The ZODB dmd object.
-        @param factory {WorkerInterceptorFactory}
-            Builds WorkerInterceptor objects.
+        @param factory {IServiceReferenceFactory}
+            Builds IServiceReference objects.
         """
         self.__dmd = dmd
         self.__factory = factory
@@ -418,6 +418,7 @@ class UnknownServiceError(pb.Error):
     """
 
 
+@implementer(IServiceReferenceFactory)
 class WorkerInterceptorFactory(object):
     """This is a factory that builds WorkerInterceptor objects.
     """

--- a/Products/ZenHub/servicemanager.py
+++ b/Products/ZenHub/servicemanager.py
@@ -30,12 +30,12 @@ from .PBDaemon import RemoteBadMonitor, RemoteException
 from .XmlRpcService import XmlRpcService
 from .dispatchers import (
     DispatchingExecutor, EventDispatcher, WorkerPoolDispatcher,
-    WorkerPool, ServiceCallJob, StatsMonitor
+    WorkerPool, ServiceCallJob, StatsMonitor,
 )
 from .interfaces import IServiceAddedEvent, IServiceReferenceFactory
 from .worklist import (
     ZenHubWorklist, ZenHubPriority, ModelingPaused,
-    register_metrics_on_worklist, get_worklist_metrics
+    register_metrics_on_worklist, get_worklist_metrics,
 )
 
 banana.SIZE_LIMIT = 1024 * 1024 * 10
@@ -95,11 +95,11 @@ class HubServiceManager(object):
         self.__workers = WorkerPool()
         self.__stats = StatsMonitor()
         self.__workerdispatcher = WorkerPoolDispatcher(
-            reactor, self.__worklist, self.__workers, self.__stats
+            reactor, self.__worklist, self.__workers, self.__stats,
         )
         events = EventDispatcher(dmd.ZenEventManager)
         executor = DispatchingExecutor(
-            [events], default=self.__workerdispatcher
+            [events], default=self.__workerdispatcher,
         )
         service_factory = WorkerInterceptorFactory(executor)
         self.__services = HubServiceRegistry(dmd, service_factory)
@@ -166,27 +166,27 @@ class HubServiceManager(object):
             "Hub Execution Timings:",
             "   {:<32} {:>8} {:>12} {:>13}  {} ".format(
                 "method", "count", "idle_total",
-                "running_total", "last_called_time"
-            )
+                "running_total", "last_called_time",
+            ),
         ])
 
         statline = " - {:<32} {:>8} {:>12} {:>13}  {:%Y-%m-%d %H:%M:%S}"
         sorted_by_running_total = sorted(
-            execTimer.iteritems(), key=lambda e: -(e[1].running_total)
+            execTimer.iteritems(), key=lambda e: -(e[1].running_total),
         )
         lines.extend(
             statline.format(
                 method, stats.count,
                 timedelta(seconds=round(stats.idle_total)),
                 timedelta(seconds=round(stats.running_total)),
-                datetime.fromtimestamp(stats.last_called_time)
+                datetime.fromtimestamp(stats.last_called_time),
             )
             for method, stats in sorted_by_running_total
         )
 
         lines.extend([
             "",
-            "Worker Stats:"
+            "Worker Stats:",
         ])
         nostatsFmt = "    {:>2}:Idle [] No jobs run"
         statsFmt = "    {:>2}:{} [{}  Idle: {}] {}"
@@ -194,7 +194,7 @@ class HubServiceManager(object):
             statsFmt.format(
                 workerId, stats.status, stats.description,
                 timedelta(seconds=round(stats.previdle)),
-                timedelta(seconds=round(now - stats.lastupdate))
+                timedelta(seconds=round(now - stats.lastupdate)),
             )
             if stats else nostatsFmt.format(workerId)
             for workerId, stats in sorted(workTracker.iteritems())
@@ -210,14 +210,14 @@ class HubServiceManager(object):
         sock.setsockopt(socket.SOL_TCP, socket.TCP_KEEPCNT, 2)
         self.__log.debug(
             "set socket%s  CONNECT_TIMEOUT:%d  TCP_KEEPINTVL:%d",
-            sock.getsockname(), CONNECT_TIMEOUT, interval
+            sock.getsockname(), CONNECT_TIMEOUT, interval,
         )
 
     def __raiseMissingKeywordError(self, name):
         raise TypeError(
             "%s.__init__ missing expected keyword argument: %s" % (
-                type(self).__name__, name
-            )
+                type(self).__name__, name,
+            ),
         )
 
 
@@ -301,7 +301,7 @@ class HubAvatar(pb.Avatar):
         except Exception as ex:
             self.__log.exception("Failed to add worker %s", workerId)
             raise pb.Error(
-                "Internal ZenHub error: %s: %s" % (ex.__class__, ex)
+                "Internal ZenHub error: %s: %s" % (ex.__class__, ex),
             )
 
         def removeWorker(worker):
@@ -369,7 +369,7 @@ class HubServiceRegistry(Mapping):
         # Sanity check the names given to us
         if not self.__dmd.Monitors.Performance._getOb(monitor, False):
             raise RemoteBadMonitor(
-                "Unknown performance monitor: '%s'" % (monitor,), None
+                "Unknown performance monitor: '%s'" % (monitor,), None,
             )
 
         svc = self.__services.get((name, monitor))
@@ -472,10 +472,10 @@ class WorkerInterceptor(pb.Referenceable):
             args = broker.unserialize(args)
             kw = broker.unserialize(kw)
             job = ServiceCallJob(
-                self.__name, self.__monitor, message, args, kw
+                self.__name, self.__monitor, message, args, kw,
             )
             self.__log.info(
-                "Calling %s.%s from %s", self.__name, message, self.__monitor
+                "Calling %s.%s from %s", self.__name, message, self.__monitor,
             )
             state = yield self.__executor.submit(job)
             response = broker.serialize(state, self.perspective)
@@ -483,7 +483,7 @@ class WorkerInterceptor(pb.Referenceable):
         except (pb.Error, pb.RemoteError, RemoteException):
             self.__log.info(
                 "Called  %s.%s from %s [failure]",
-                self.__name, message, self.__monitor
+                self.__name, message, self.__monitor,
             )
             raise  # propagate these exceptions
         except Exception as ex:
@@ -493,7 +493,7 @@ class WorkerInterceptor(pb.Referenceable):
             end = time.time()
             self.callTime += (end - begin)
             self.__log.info(
-                "Called  %s.%s from %s", self.__name, message, self.__monitor
+                "Called  %s.%s from %s", self.__name, message, self.__monitor,
             )
 
     def __getattr__(self, attr):
@@ -548,8 +548,8 @@ class AuthXmlRpcService(XmlRpcService):
             self.unauthorized(request)
         else:
             try:
-                type, encoded = auth.split()
-                if type not in ('Basic',):
+                authtype, encoded = auth.split()
+                if authtype not in ('Basic',):
                     self.unauthorized(request)
                 else:
                     user, passwd = encoded.decode('base64').split(':')

--- a/Products/ZenHub/tests/test_zenhubworker.py
+++ b/Products/ZenHub/tests/test_zenhubworker.py
@@ -36,7 +36,7 @@ class ZenHubWorkerTest(TestCase):
     def setUp(t):
         # Patch out the ZCmdBase __init__ method
         t.ZCmdBase_patcher = patch.object(
-            ZCmdBase, '__init__', autospec=True, return_value=None
+            ZCmdBase, '__init__', autospec=True, return_value=None,
         )
         t.ZCmdBase__init__ = t.ZCmdBase_patcher.start()
         t.addCleanup(t.ZCmdBase_patcher.stop)
@@ -76,7 +76,7 @@ class ZenHubWorkerTest(TestCase):
         t.patchers = {}
         for target in needs_patching:
             patched = patch(
-                '{src}.{target}'.format(target=target, **PATH), autospec=True
+                '{src}.{target}'.format(target=target, **PATH), autospec=True,
             )
             t.patchers[target] = patched
             setattr(t, target, patched.start())
@@ -92,7 +92,7 @@ class ZenHubWorkerTest(TestCase):
         t.assertEqual(t.zhw.profiler, t.ContinuousProfiler.return_value)
         t.zhw.profiler.start.assert_called_with()
         t.reactor.addSystemEventTrigger.assert_called_once_with(
-            "before", "shutdown", t.zhw.profiler.stop
+            "before", "shutdown", t.zhw.profiler.stop,
         )
 
         t.assertEqual(t.zhw.current, IDLE)
@@ -105,22 +105,22 @@ class ZenHubWorkerTest(TestCase):
 
         t.ServiceReferenceFactory.assert_called_once_with(t.zhw)
         t.HubServiceRegistry.assert_called_once_with(
-            t.dmd, t.ServiceReferenceFactory.return_value
+            t.dmd, t.ServiceReferenceFactory.return_value,
         )
         t.assertEqual(
-            t.HubServiceRegistry.return_value, t.zhw._ZenHubWorker__registry
+            t.HubServiceRegistry.return_value, t.zhw._ZenHubWorker__registry,
         )
 
         t.UsernamePassword.assert_called_once_with(
-            t.zhw.options.hubusername, t.zhw.options.hubpassword
+            t.zhw.options.hubusername, t.zhw.options.hubpassword,
         )
         t.clientFromString.assert_called_once_with(
             t.reactor,
-            "tcp:%s:%s" % (t.zhw.options.hubhost, t.zhw.options.hubport)
+            "tcp:%s:%s" % (t.zhw.options.hubhost, t.zhw.options.hubport),
         )
         t.ZenHubClient.assert_called_once_with(
             t.reactor, t.clientFromString.return_value,
-            t.UsernamePassword.return_value, t.zhw, 10.0
+            t.UsernamePassword.return_value, t.zhw, 10.0,
         )
         t.assertEqual(t.ZenHubClient.return_value, t.zhw._ZenHubWorker__client)
 
@@ -128,8 +128,8 @@ class ZenHubWorkerTest(TestCase):
             daemon_tags={
                 'zenoss_daemon': 'zenhub_worker_%s' % t.zhw.options.workerid,
                 'zenoss_monitor': t.zhw.options.monitor,
-                'internal': True
-            }
+                'internal': True,
+            },
         )
         t.assertEqual(t.zhw._metric_manager, t.MetricManager.return_value)
 
@@ -160,7 +160,7 @@ class ZenHubWorkerTest(TestCase):
         t.zhw.audit(action)
 
     @patch('{src}.super'.format(**PATH))
-    def test_sighandler_USR1(t, super):
+    def test_sighandler_USR1(t, _super):
         t.zhw.options.profiling = True
         t.zhw.profiler = Mock(ContinuousProfiler, name='profiler')
         signum, frame = sentinel.signum, sentinel.frame
@@ -168,8 +168,8 @@ class ZenHubWorkerTest(TestCase):
         t.zhw.sighandler_USR1(signum, frame)
 
         t.zhw.profiler.dump_stats.assert_called_with()
-        super.assert_called_with(ZenHubWorker, t.zhw)
-        super.return_value.sighandler_USR1.assert_called_with(signum, frame)
+        _super.assert_called_with(ZenHubWorker, t.zhw)
+        _super.return_value.sighandler_USR1.assert_called_with(signum, frame)
 
     def test_sighandler_USR2(t):
         args = sentinel.args
@@ -179,35 +179,35 @@ class ZenHubWorkerTest(TestCase):
 
         t.zhw.reportStats.assert_called_with()
 
-    def test_work_started(t):
+    def test__work_started(t):
         startTime = sentinel.startTime
 
-        t.zhw.work_started(startTime)
+        t.zhw._work_started(startTime)
 
         t.assertEqual(t.zhw.currentStart, startTime)
         t.zhw.numCalls.mark.assert_called_once_with()
 
     @patch("{src}.IDLE".format(**PATH))
-    def test_work_finished_no_shutdown(t, idle):
+    def test__work_finished_no_shutdown(t, idle):
         duration = sentinel.duration
         method = sentinel.method
         t.zhw.numCalls.count = 1
         t.zhw.options.call_limit = 5
 
-        t.zhw.work_finished(duration, method)
+        t.zhw._work_finished(duration, method)
 
         t.assertEqual(idle, t.zhw.current)
         t.assertEqual(0, t.zhw.currentStart)
         t.reactor.callLater.assert_not_called()
 
     @patch("{src}.IDLE".format(**PATH))
-    def test_work_finished_with_shutdown(t, idle):
+    def test__work_finished_with_shutdown(t, idle):
         duration = sentinel.duration
         method = sentinel.method
         t.zhw.numCalls.count = 5
         t.zhw.options.call_limit = 5
 
-        t.zhw.work_finished(duration, method)
+        t.zhw._work_finished(duration, method)
 
         t.assertEqual(idle, t.zhw.current)
         t.assertEqual(0, t.zhw.currentStart)
@@ -234,7 +234,7 @@ class ZenHubWorkerTest(TestCase):
         stats.lasttime = 555
         service.callStats = {method: stats}
         t.zhw._ZenHubWorker__registry = {
-            (name, instance): service
+            (name, instance): service,
         }
         isodate = isoDateTime.return_value
 
@@ -248,7 +248,7 @@ class ZenHubWorkerTest(TestCase):
             'Running statistics:\n'
             ' - {parsed_service_id: <49}{method: <32}'
             '{stats.numoccurrences: 9}{stats.totaltime: 13.2f}'
-            '{average_time: 9.2f} {isodate}'.format(**locals())
+            '{average_time: 9.2f} {isodate}'.format(**locals()),
         )
 
     def test_remote_reportStatus(t):
@@ -339,7 +339,7 @@ class ZenHubWorkerTest(TestCase):
         t.assertEqual(t.zhw.options.hubusername, 'admin')
         t.assertEqual(t.zhw.options.hubpassword, 'zenoss')
         t.assertEqual(t.zhw.options.call_limit, 200)
-        t.assertEqual(t.zhw.options.profiling, False)
+        t.assertFalse(t.zhw.options.profiling)
         t.assertEqual(t.zhw.options.monitor, 'localhost')
         t.assertEqual(t.zhw.options.workerid, 0)
 
@@ -368,7 +368,7 @@ class ZenHubClientTest(TestCase):
         t.patchers = {}
         for target in needs_patching:
             patched = patch(
-                '{src}.{target}'.format(target=target, **PATH), autospec=True
+                '{src}.{target}'.format(target=target, **PATH), autospec=True,
             )
             t.patchers[target] = patched
             name = target.rpartition('.')[-1]
@@ -376,7 +376,7 @@ class ZenHubClientTest(TestCase):
             t.addCleanup(patched.stop)
 
         t.zhc = ZenHubClient(
-            t.reactor, t.endpoint, t.credentials, t.worker, t.timeout
+            t.reactor, t.endpoint, t.credentials, t.worker, t.timeout,
         )
 
     def test___init__(t):
@@ -386,13 +386,13 @@ class ZenHubClientTest(TestCase):
         t.assertEqual(t.zhc._ZenHubClient__worker, t.worker)
         t.assertEqual(t.zhc._ZenHubClient__timeout, t.timeout)
 
-        t.assertEqual(t.zhc._ZenHubClient__stopping, False)
-        t.assertEqual(t.zhc._ZenHubClient__pinger, None)
-        t.assertEqual(t.zhc._ZenHubClient__service, None)
+        t.assertFalse(t.zhc._ZenHubClient__stopping)
+        t.assertIsNone(t.zhc._ZenHubClient__pinger)
+        t.assertIsNone(t.zhc._ZenHubClient__service)
         t.assertEqual(t.zhc._ZenHubClient__log, t.getLogger.return_value)
         t.assertEqual(
             t.zhc._ZenHubClient__signalFile,
-            t.ConnectedToZenHubSignalFile.return_value
+            t.ConnectedToZenHubSignalFile.return_value,
         )
 
     @patch.object(ZenHubClient, "_ZenHubClient__prepForConnection")
@@ -401,11 +401,11 @@ class ZenHubClientTest(TestCase):
 
         t.zhc.start()
 
-        t.assertEqual(t.zhc._ZenHubClient__stopping, False)
+        t.assertFalse(t.zhc._ZenHubClient__stopping)
         t.backoffPolicy.assert_called_once_with(initialDelay=0.5, factor=3.0)
         t.ClientService.assert_called_once_with(
             t.endpoint, t.PBClientFactory.return_value,
-            retryPolicy=t.backoffPolicy.return_value
+            retryPolicy=t.backoffPolicy.return_value,
         )
         service = t.ClientService.return_value
         service.startService.assert_called_once_with()
@@ -414,7 +414,7 @@ class ZenHubClientTest(TestCase):
     @patch.object(ZenHubClient, "_ZenHubClient__reset")
     def test_stop(t, reset):
         t.zhc.stop()
-        t.assertEqual(t.zhc._ZenHubClient__stopping, True)
+        t.assertTrue(t.zhc._ZenHubClient__stopping)
         reset.assert_called_once_with()
 
     @patch.object(ZenHubClient, "_ZenHubClient__reset")
@@ -520,17 +520,17 @@ class ZenHubClientTest(TestCase):
         zenhub.callRemote.assert_called_once_with(
             "reportingForWork",
             t.zhc._ZenHubClient__worker,
-            workerId=t.zhc._ZenHubClient__worker.instanceId
+            workerId=t.zhc._ZenHubClient__worker.instanceId,
         )
         t.LoopingCall.assert_called_once_with(t.PingZenHub.return_value)
         t.assertEqual(t.zhc._ZenHubClient__pinger, pinger)
         pinger.start.assert_called_once_with(
-            t.zhc._ZenHubClient__timeout, now=False
+            t.zhc._ZenHubClient__timeout, now=False,
         )
         pinger_deferred.addErrback.assert_called_once_with(pingFail)
         t.zhc._ZenHubClient__signalFile.touch.assert_called_once_with()
         broker.notifyOnDisconnect.assert_called_once_with(
-            t.zhc._ZenHubClient__disconnected
+            t.zhc._ZenHubClient__disconnected,
         )
 
         t.zhc._ZenHubClient__signalFile.remove.assert_not_called()
@@ -548,7 +548,7 @@ class ZenHubClientTest(TestCase):
 
         login.assert_called_once_with(broker)
         t.zhc._ZenHubClient__log.error.assert_called_once_with(
-            ANY, type(ex), ex
+            ANY, type(ex), ex,
         )
         t.zhc._ZenHubClient__signalFile.remove.assert_called_once_with()
         t.reactor.stop.assert_called_once_with()
@@ -586,10 +586,10 @@ class ZenHubClientTest(TestCase):
         zenhub.callRemote.assert_called_once_with(
             "reportingForWork",
             t.zhc._ZenHubClient__worker,
-            workerId=t.zhc._ZenHubClient__worker.instanceId
+            workerId=t.zhc._ZenHubClient__worker.instanceId,
         )
         t.zhc._ZenHubClient__log.error.assert_called_once_with(
-            ANY, type(ex), ex
+            ANY, type(ex), ex,
         )
         t.zhc._ZenHubClient__signalFile.remove.assert_called_once_with()
         t.reactor.stop.assert_called_once_with()
@@ -607,10 +607,10 @@ class ZenHubClientTest(TestCase):
 
         t.assertEqual(expected, actual)
         broker.factory.login.assert_called_once_with(
-            t.zhc._ZenHubClient__credentials, t.zhc._ZenHubClient__worker
+            t.zhc._ZenHubClient__credentials, t.zhc._ZenHubClient__worker,
         )
         t.reactor.callLater.assert_called_once_with(
-            t.zhc._ZenHubClient__timeout, actual.cancel
+            t.zhc._ZenHubClient__timeout, actual.cancel,
         )
         timeout.active.assert_called_once_with()
         timeout.cancel.assert_called_once_with()
@@ -629,10 +629,10 @@ class ZenHubClientTest(TestCase):
 
         t.assertEqual(expected, actual)
         broker.factory.login.assert_called_once_with(
-            t.zhc._ZenHubClient__credentials, t.zhc._ZenHubClient__worker
+            t.zhc._ZenHubClient__credentials, t.zhc._ZenHubClient__worker,
         )
         t.reactor.callLater.assert_called_once_with(
-            t.zhc._ZenHubClient__timeout, actual.cancel
+            t.zhc._ZenHubClient__timeout, actual.cancel,
         )
         timeout.active.assert_called_once_with()
         timeout.cancel.assert_not_called()
@@ -650,7 +650,7 @@ class PingZenHubTest(TestCase):
         t.patchers = {}
         for target in needs_patching:
             patched = patch(
-                '{src}.{target}'.format(target=target, **PATH), autospec=True
+                '{src}.{target}'.format(target=target, **PATH), autospec=True,
             )
             t.patchers[target] = patched
             name = target.rpartition('.')[-1]
@@ -696,7 +696,7 @@ class ServiceReferenceFactoryTest(TestCase):
         result = factory.build(service, name, monitor)
 
         ServiceReference.assert_called_once_with(
-            service, name, monitor, worker
+            service, name, monitor, worker,
         )
         t.assertEqual(ServiceReference.return_value, result)
 
@@ -705,7 +705,7 @@ class ServiceReferenceTest(TestCase):
 
     def setUp(t):
         t._CumulativeWorkerStats_patcher = patch(
-            "{src}._CumulativeWorkerStats".format(**PATH), autospec=True
+            "{src}._CumulativeWorkerStats".format(**PATH), autospec=True,
         )
         t._CumulativeWorkerStats = t._CumulativeWorkerStats_patcher.start()
         t.addCleanup(t._CumulativeWorkerStats_patcher.stop)
@@ -743,7 +743,7 @@ class ServiceReferenceTest(TestCase):
             p.assert_called_once_with(message)
             t.worker.async_syncdb.assert_called_once_with()
             t.service.remoteMessageReceived.assert_called_once_with(
-                broker, message, args, kwargs
+                broker, message, args, kwargs,
             )
 
     def test_remoteMessageReceived_raises_exception(t):
@@ -771,7 +771,7 @@ class ServiceReferenceTest(TestCase):
             p.assert_called_once_with(method)
             t.worker.async_syncdb.assert_called_once_with()
             t.service.remoteMessageReceived.assert_called_once_with(
-                broker, method, args, kwargs
+                broker, method, args, kwargs,
             )
             t.assertEqual(ValueError, handler.result)
 
@@ -789,11 +789,11 @@ class ServiceReferenceTest(TestCase):
             with t.ref._ServiceReference__update_stats(method) as p:
                 t.assertEqual(t.service, p)
                 t.assertEqual(expected_current, t.worker.current)
-                t.worker.work_started.assert_called_once_with(start)
+                t.worker._work_started.assert_called_once_with(start)
 
             stats.addOccurrence.assert_called_once_with(5, finish)
             t.assertEqual(5, t.service.callTime)
-            t.worker.work_finished.assert_called_once_with(5, method)
+            t.worker._work_finished.assert_called_once_with(5, method)
 
 
 class _CumulativeWorkerStatsTest(TestCase):


### PR DESCRIPTION
A PBConnectionLost exception occurs when a zenhubworker quits before zenhub notices its absence.
Handle PBConnectionLost exceptions explicitly and improve log messages regarding worker availability.

Fixes ZEN-31513.