### PR TITLE
Allow Twisted to unserialize unregistered classes.

### DIFF
--- a/Products/ZenHub/broker.py
+++ b/Products/ZenHub/broker.py
@@ -1,0 +1,58 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, 2018 all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+from twisted.spread import pb
+from twisted.spread.interfaces import IUnjellyable
+
+
+class ZenSecurityOptions(object):
+    """Override SecurityOptions with more permissive security."""
+
+    def isModuleAllowed(self, moduleName):
+        """Return True always because all modules are allowed."""
+        return True
+
+    def isClassAllowed(self, klass):
+        """Return True if the given class is allowed, False otherwise.
+
+        Assumes the module has already been allowed.
+
+        A class is allowed if it implements the IUnjellyable interface.
+        """
+        return IUnjellyable.implementedBy(klass)
+
+    def isTypeAllowed(self, typeName):
+        """Return True always because all all typenames are allowed."""
+        return True
+
+
+zenSecurityOptions = ZenSecurityOptions()
+
+
+class ZenBroker(pb.Broker):
+    """Extend pb.Broker to pass the ZenSecurityOptions object to pb.Broker."""
+
+    def __init__(self, **kw):
+        """Initialize an instance of ZenBroker."""
+        kw["security"] = zenSecurityOptions
+        pb.Broker.__init__(self, **kw)
+
+
+class ZenPBClientFactory(pb.PBClientFactory):
+    """Extend pb.PBClientFactory to specify ZenBroker as the protocol."""
+
+    protocol = ZenBroker
+
+
+class ZenPBServerFactory(pb.PBServerFactory):
+    """Extend pb.PBServerFactory to specify ZenBroker as the protocol."""
+
+    protocol = ZenBroker

--- a/Products/ZenHub/servicemanager.py
+++ b/Products/ZenHub/servicemanager.py
@@ -44,9 +44,7 @@ pb.setUnjellyableForClass(RemoteBadMonitor, RemoteBadMonitor)
 
 
 class HubServiceManager(object):
-    """Responsible for initializing and starting the ZenHub services and
-    XMLRPC servers.
-    """
+    """Initializes and starts the ZenHub services and XMLRPC servers."""
 
     def __init__(
             self, modeling_pause_timeout=None, passwordfile=None,
@@ -125,15 +123,16 @@ class HubServiceManager(object):
 
     @property
     def services(self):
+        """Return the ZenHub services."""
         return self.__services
 
     @property
     def worklist(self):
+        """Return the job worklist."""
         return self.__worklist
 
     def onExecute(self, listener):
-        """Register a listener that will be called prior the execution of
-        a job on a worker.
+        """Register a callable to be invoked before a job is executed.
 
         @param listener {callable}
         """
@@ -141,9 +140,11 @@ class HubServiceManager(object):
 
     @defer.inlineCallbacks
     def reportWorkerStatus(self):
+        """Return the status of workers."""
         yield self.__workerdispatcher.reportWorkerStatus()
 
     def getStatusReport(self):
+        """Return a report on the services."""
         now = time.time()
 
         gauges = get_worklist_metrics(self.__worklist)
@@ -223,23 +224,29 @@ class HubServiceManager(object):
 
 @implementer(portal.IRealm)
 class HubRealm(object):
-    """
-    Following the Twisted authentication framework.
-    See http://twistedmatrix.com/projects/core/documentation/howto/cred.html
-    """
+    """Defines realm from which avatars are retrieved."""
 
     def __init__(self, avatar):
+        """Initialize an instance of HubRealm.
+
+        All avatar requests are given the same avatar.  That avatar is
+        passed into the realm upon initialization.
+        """
         self.__avatar = avatar
 
     def requestAvatar(self, name, mind, *interfaces):
+        """Return an avatar.
+
+        Raises NotImplementedError if interfaces does not include
+        pb.IPerspective.
+        """
         if pb.IPerspective not in interfaces:
             raise NotImplementedError
         return pb.IPerspective, self.__avatar, lambda: None
 
 
 class HubAvatar(pb.Avatar):
-    """Manages the connection between clients and ZenHub.
-    """
+    """Manages the connection between clients and ZenHub."""
 
     def __init__(self, services, workers):
         """Initialize an instance of HubAvatar.
@@ -252,16 +259,18 @@ class HubAvatar(pb.Avatar):
         self.__log = getLogger("zenhub", self)
 
     def perspective_ping(self):
+        """Return 'pong'."""
         return 'pong'
 
     def perspective_getHubInstanceId(self):
+        """Return the Control Center instance ID the running service."""
         return os.environ.get('CONTROLPLANE_INSTANCE_ID', 'Unknown')
 
     def perspective_getService(
             self, name, monitor=None, listener=None, options=None):
-        """
-        Allow a collector to find a Hub service by name.  It also
-        associates the service with a collector so that changes can be
+        """Return a reference to a Hub service.
+
+        It also associates the service with a collector so that changes can be
         pushed back out to collectors.
 
         @param name {string} The name of the service, e.g. "EventService"
@@ -287,8 +296,7 @@ class HubAvatar(pb.Avatar):
             return service
 
     def perspective_reportingForWork(self, worker, workerId):
-        """
-        Allow a worker register for work.
+        """Allow a worker register for work.
 
         @param worker {RemoteReference} Reference to zenhubworker
         @return None
@@ -340,7 +348,7 @@ class HubServiceRegistry(Mapping):
         return self.__services[key]
 
     def getService(self, name, monitor):
-        """Returns (a Referenceable to) the named service.
+        """Return (a Referenceable to) the named service.
 
         The name of the service should be the fully qualified module path
         containing the class implementing the service.  For example,
@@ -402,6 +410,7 @@ class HubServiceRegistry(Mapping):
 
 @implementer(IServiceAddedEvent)
 class ServiceAddedEvent(object):
+    """An event class dispatched when a service is first loaded."""
 
     def __init__(self, name, instance):
         """Initialize a ServiceAddedEvent instance.
@@ -414,17 +423,15 @@ class ServiceAddedEvent(object):
 
 
 class UnknownServiceError(pb.Error):
-    """Raised if the requested service doesn't exist.
-    """
+    """Raised if the requested service doesn't exist."""
 
 
 @implementer(IServiceReferenceFactory)
 class WorkerInterceptorFactory(object):
-    """This is a factory that builds WorkerInterceptor objects.
-    """
+    """This is a factory that builds WorkerInterceptor objects."""
 
     def __init__(self, dispatcher):
-        """Initializes an instance of WorkerInterceptorFactory.
+        """Initialize an instance of WorkerInterceptorFactory.
 
         @param dispatcher {IAsyncDispatch} Executes service calls
         """
@@ -442,12 +449,10 @@ class WorkerInterceptorFactory(object):
 # Note: The name 'WorkerInterceptor' is required to remain compatible with
 # the EnterpriseCollector zenpack.
 class WorkerInterceptor(pb.Referenceable):
-    """The WorkerInterceptor extends a Referenceable to delegate message
-    handling to an executor.
-    """
+    """Delegates message handling to an executor."""
 
     def __init__(self, service, name, monitor, executor):
-        """Initializes an instance of WorkerInterceptor.
+        """Initialize an instance of WorkerInterceptor.
 
         @param service {HubService subclass} The service object.
         @param name {str} Name of the service.
@@ -463,10 +468,12 @@ class WorkerInterceptor(pb.Referenceable):
 
     @property
     def service(self):
+        """Return the service handled by this interceptor."""
         return self.__service
 
     @defer.inlineCallbacks
     def remoteMessageReceived(self, broker, message, args, kw):
+        """Defer execution of the message to an executor."""
         begin = time.time()
         try:
             args = broker.unserialize(args)
@@ -497,22 +504,21 @@ class WorkerInterceptor(pb.Referenceable):
             )
 
     def __getattr__(self, attr):
-        """Forward calls to the service object.
-        """
+        """Forward calls to the service object."""
         return getattr(self.__service, attr)
 
 
 class AuthXmlRpcService(XmlRpcService):
-    """Extends XmlRpcService to provide authentication.
-    """
+    """Extends XmlRpcService to provide authentication."""
 
     @classmethod
     def makeSite(cls, dmd, checker):
+        """Create and return Site object."""
         service = cls(dmd, checker)
         return server.Site(service)
 
     def __init__(self, dmd, checker):
-        """Initializes an AuthXmlRpcService instance.
+        """Initialize an AuthXmlRpcService instance.
 
         @param dmd {DMD} A /zport/dmd reference
         @param checker {ICredentialsChecker} Used to authenticate clients.
@@ -521,15 +527,12 @@ class AuthXmlRpcService(XmlRpcService):
         self.checker = checker
 
     def doRender(self, unused, request):
-        """
-        Call the inherited render engine after authentication succeeds.
-        See @L{XmlRpcService.XmlRpcService.Render}.
-        """
+        """Call the inherited render engine after authentication succeeds."""
         return XmlRpcService.render(self, request)
 
     def unauthorized(self, request):
-        """
-        Render an XMLRPC error indicating an authentication failure.
+        """Render an XMLRPC error indicating an authentication failure.
+
         @type request: HTTPRequest
         @param request: the request for this xmlrpc call.
         @return: None
@@ -537,8 +540,8 @@ class AuthXmlRpcService(XmlRpcService):
         self._cbRender(xmlrpc.Fault(self.FAILURE, "Unauthorized"), request)
 
     def render(self, request):
-        """
-        Unpack the authorization header and check the credentials.
+        """Unpack the authorization header and check the credentials.
+
         @type request: HTTPRequest
         @param request: the request for this xmlrpc call.
         @return: NOT_DONE_YET
@@ -567,8 +570,7 @@ class AuthXmlRpcService(XmlRpcService):
 
 
 def getCredentialCheckers(pwdfile):
-    """
-    Load the password file
+    """Load the password file.
 
     @return: an object satisfying the ICredentialsChecker
     interface using a password file or an empty list if the file

--- a/Products/ZenHub/servicemanager.py
+++ b/Products/ZenHub/servicemanager.py
@@ -7,6 +7,8 @@
 #
 ##############################################################################
 
+from __future__ import absolute_import
+
 import os
 import socket
 import sys
@@ -28,6 +30,7 @@ from Products.ZenUtils.Utils import importClass, ipv6_available
 
 from .PBDaemon import RemoteBadMonitor, RemoteException
 from .XmlRpcService import XmlRpcService
+from .broker import ZenPBServerFactory
 from .dispatchers import (
     DispatchingExecutor, EventDispatcher, WorkerPoolDispatcher,
     WorkerPool, ServiceCallJob, StatsMonitor,
@@ -107,7 +110,7 @@ class HubServiceManager(object):
         realm = HubRealm(avatar)
         checkers = getCredentialCheckers(self.__passwdfile)
         hubportal = portal.Portal(realm, checkers)
-        hubserver_factory = pb.PBServerFactory(hubportal)
+        hubserver_factory = ZenPBServerFactory(hubportal)
         tcp_version = "tcp6" if ipv6_available() else "tcp"
         pb_descriptor = "%s:port=%s" % (tcp_version, self.__pbport)
         pb_server = serverFromString(reactor, pb_descriptor)

--- a/Products/ZenHub/tests/test_broker.py
+++ b/Products/ZenHub/tests/test_broker.py
@@ -1,0 +1,96 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+import types
+from unittest import TestCase
+from zope.interface import implementer
+
+from Products.ZenHub.broker import (
+    IUnjellyable,
+    ZenBroker,
+    ZenPBClientFactory,
+    ZenPBServerFactory,
+    zenSecurityOptions,
+    ZenSecurityOptions,
+)
+
+
+class ZenSecurityOptionsTest(TestCase):
+    """Test the ZenSecurityOptions class."""
+
+    def setUp(t):
+        t.options = ZenSecurityOptions()
+
+    def test_global_object(t):
+        t.assertIsInstance(zenSecurityOptions, ZenSecurityOptions)
+
+    def test_allow_all_types(t):
+        # Just a sample of type names.
+        typenames = (
+            "__builtin__.dict",
+            "remote",
+            "Products.ZenHub.services.ProcessConfig.ProcessProxy",
+        )
+        for typename in typenames:
+            t.assertTrue(t.options.isTypeAllowed(typename))
+
+    def test_allow_all_modules(t):
+        # Just a sample of module names
+        modnames = (
+            "__main__",
+            "zope",
+            "Products.ZenHub",
+            "ZenPacks.zenoss.PythonCollector.services.PythonConfig",
+        )
+        for modname in modnames:
+            t.assertTrue(t.options.isTypeAllowed(modname))
+
+    def test_disallow_arbitrary_class(t):
+        classes = (
+            types.ClassType("foo", (), {}),
+            types.TypeType("bar", (), {}),
+        )
+        for cls in classes:
+            t.assertFalse(IUnjellyable.implementedBy(cls))
+            t.assertFalse(t.options.isClassAllowed(cls))
+
+    def test_allow_unjellyable_class(t):
+        classes = (
+            implementer(IUnjellyable)(types.ClassType("foo", (), {})),
+            implementer(IUnjellyable)(types.TypeType("bar", (), {})),
+        )
+        for cls in classes:
+            t.assertTrue(t.options.isClassAllowed(cls))
+
+
+class ZenBrokerTest(TestCase):
+    """Test the ZenBroker class."""
+
+    def setUp(t):
+        t.broker = ZenBroker()
+
+    def test_has_security(t):
+        t.assertIsInstance(t.broker.security, ZenSecurityOptions)
+        t.assertEqual(t.broker.security, zenSecurityOptions)
+
+
+class ZenPBClientFactoryTest(TestCase):
+    """Test the ZenPBClientFactory class."""
+
+    def test_has_zenbroker(t):
+        t.assertIs(ZenPBClientFactory.protocol, ZenBroker)
+
+
+class ZenPBServerFactoryTest(TestCase):
+    """Test the ZenPBServerFactory class."""
+
+    def test_has_zenbroker(t):
+        t.assertIs(ZenPBServerFactory.protocol, ZenBroker)

--- a/Products/ZenHub/tests/test_servicemanager.py
+++ b/Products/ZenHub/tests/test_servicemanager.py
@@ -16,7 +16,7 @@ from zope.interface.verify import verifyObject
 
 from Products.ZenHub.dispatchers.workers import JobStats, WorkerStats
 from Products.ZenHub.servicemanager import (
-    AuthXmlRpcService, XmlRpcService,
+    AuthXmlRpcService,
     DispatchingExecutor,
     getCredentialCheckers,
     HubAvatar,
@@ -28,7 +28,7 @@ from Products.ZenHub.servicemanager import (
     RemoteBadMonitor, UnknownServiceError, RemoteException,
     ServiceAddedEvent, IServiceAddedEvent,
     ZenHubPriority,
-    pb, defer
+    pb, defer,
 )
 
 PATH = {'src': 'Products.ZenHub.servicemanager'}
@@ -50,13 +50,16 @@ class Callback(object):
     """
 
     def __init__(self):
+        """Initialize a Callback instance."""
         self.result = None
 
     def __call__(self, r):
+        """Save the result."""
         self.result = r
 
 
 class HubServiceManagerTest(TestCase):
+    """Test the HubServiceManager class."""
 
     def setUp(self):
         self.modeling_pause_timeout = 1.0
@@ -70,7 +73,7 @@ class HubServiceManagerTest(TestCase):
             modeling_pause_timeout=self.modeling_pause_timeout,
             passwordfile=self.passwordfile,
             pbport=self.pbport,
-            xmlrpcport=self.xmlrpcport
+            xmlrpcport=self.xmlrpcport,
         )
 
     def test_init_missing_modeling_pause_timeout(self):
@@ -78,7 +81,7 @@ class HubServiceManagerTest(TestCase):
             HubServiceManager(
                 passwordfile=self.passwordfile,
                 pbport=self.pbport,
-                xmlrpcport=self.xmlrpcport
+                xmlrpcport=self.xmlrpcport,
             )
 
     def test_init_missing_passwordfile(self):
@@ -86,7 +89,7 @@ class HubServiceManagerTest(TestCase):
             HubServiceManager(
                 modeling_pause_timeout=self.modeling_pause_timeout,
                 pbport=self.pbport,
-                xmlrpcport=self.xmlrpcport
+                xmlrpcport=self.xmlrpcport,
             )
 
     def test_init_missing_pbport(self):
@@ -94,7 +97,7 @@ class HubServiceManagerTest(TestCase):
             HubServiceManager(
                 modeling_pause_timeout=self.modeling_pause_timeout,
                 passwordfile=self.passwordfile,
-                xmlrpcport=self.xmlrpcport
+                xmlrpcport=self.xmlrpcport,
             )
 
     def test_init_missing_xmlrpcport(self):
@@ -128,7 +131,7 @@ class HubServiceManagerTest(TestCase):
         authXmlRpcService,
         serverFromString,
         ipv6_available,
-        pBServerFactory,
+        pbServerFactory,
         portal,
         getCredentialCheckers,
         hubRealm,
@@ -142,7 +145,7 @@ class HubServiceManagerTest(TestCase):
         workerPoolDispatcher,
         register_metrics_on_worklist,
         zenHubWorklist,
-        modelingPaused
+        modelingPaused,
     ):
         dmd = Mock("dmd", spec_set=["ZenEventManager"])
         reactor = Mock()
@@ -160,7 +163,7 @@ class HubServiceManagerTest(TestCase):
         realm = hubRealm.return_value
         checkers = getCredentialCheckers.return_value
         portalObj = portal.return_value
-        pb_factory = pBServerFactory.return_value
+        pb_factory = pbServerFactory.return_value
         xmlrpc_site = authXmlRpcService.makeSite.return_value
 
         ipv6_available.side_effect = lambda: True
@@ -184,17 +187,17 @@ class HubServiceManagerTest(TestCase):
             modeling_pause_timeout=self.modeling_pause_timeout,
             passwordfile=self.passwordfile,
             pbport=self.pbport,
-            xmlrpcport=self.xmlrpcport
+            xmlrpcport=self.xmlrpcport,
         )
         manager.start(dmd, reactor)
 
         modelingPaused.assert_called_once_with(
-            dmd, self.modeling_pause_timeout
+            dmd, self.modeling_pause_timeout,
         )
         zenHubWorklist.assert_called_once_with(modeling_paused=paused)
         register_metrics_on_worklist.assert_called_once_with(worklist)
         workerPoolDispatcher.assert_called_once_with(
-            reactor, worklist, pool, stats
+            reactor, worklist, pool, stats,
         )
         eventDispatcher.assert_called_once_with(dmd.ZenEventManager)
         dispatchingExecutor.assert_called_once_with([events], default=workers)
@@ -204,16 +207,16 @@ class HubServiceManagerTest(TestCase):
         hubRealm.assert_called_once_with(avatar)
         getCredentialCheckers.assert_called_once_with(self.passwordfile)
         portal.assert_called_once_with(realm, checkers)
-        pBServerFactory.assert_called_once_with(portalObj)
+        pbServerFactory.assert_called_once_with(portalObj)
 
         serverFromString.assert_has_calls([
             call(reactor, pb_descriptor),
-            call(reactor, xmlrpc_descriptor)
+            call(reactor, xmlrpc_descriptor),
         ])
 
         pb_server.listen.assert_called_once_with(pb_factory)
         dfr.addCallback.assert_called_once_with(
-            manager._HubServiceManager__setKeepAlive
+            manager._HubServiceManager__setKeepAlive,
         )
         authXmlRpcService.makeSite.assert_called_once_with(dmd, checkers)
         xmlrpc_server.listen.assert_called_once_with(xmlrpc_site)
@@ -231,10 +234,10 @@ class HubServiceManagerTest(TestCase):
         now = time.time() - (1350)
         workTracker = {
             0: WorkerStats(
-                "Busy", "localhost:EventServer:sendEvent", now, 34.8
+                "Busy", "localhost:EventServer:sendEvent", now, 34.8,
             ),
             1: WorkerStats(
-                "Idle", "localhost:SomeService:someMethod", now, 4054.3
+                "Idle", "localhost:SomeService:someMethod", now, 4054.3,
             ),
             2: None,
         }
@@ -242,28 +245,28 @@ class HubServiceManagerTest(TestCase):
             "sendEvent": Mock(
                 JobStats,
                 count=2953, idle_total=3422.3, running_total=35.12,
-                last_called_time=now
+                last_called_time=now,
             ),
             "sendEvents": Mock(
                 JobStats,
                 count=451, idle_total=3632.5, running_total=20.5,
-                last_called_time=now
+                last_called_time=now,
             ),
             "applyDataMaps": Mock(
                 JobStats,
                 count=169, idle_total=620.83, running_total=3297.248,
-                last_called_time=now
+                last_called_time=now,
             ),
             "singleApplyDataMaps": Mock(
                 JobStats,
                 count=23, idle_total=1237.345, running_total=936.85,
-                last_called_time=now
+                last_called_time=now,
             ),
             "someMethod": Mock(
                 JobStats,
                 count=276, idle_total=7384.3, running_total=83.3,
-                last_called_time=now
-            )
+                last_called_time=now,
+            ),
         }
         getWorklistMetrics.return_value = gauges
         stats = statsMonitor.return_value
@@ -273,12 +276,13 @@ class HubServiceManagerTest(TestCase):
             modeling_pause_timeout=self.modeling_pause_timeout,
             passwordfile=self.passwordfile,
             pbport=self.pbport,
-            xmlrpcport=self.xmlrpcport
+            xmlrpcport=self.xmlrpcport,
         )
         print manager.getStatusReport()
 
 
 class HubRealmTest(TestCase):
+    """Test the HubRealm class."""
 
     def setUp(self):
         self.avatar = Mock(HubAvatar)
@@ -299,8 +303,13 @@ class HubRealmTest(TestCase):
 
 
 class MockWorker(object):
+    """Mock zenhubworker reference.
+
+    Used to implement the notifyOnDisconnect event handler.
+    """
 
     def __init__(self):
+        """Initialize a MockWorker instance."""
         self.__cb = None
 
     def notifyOnDisconnect(self, cb):
@@ -311,15 +320,16 @@ class MockWorker(object):
 
 
 class HubAvatarTest(TestCase):
+    """Test the HubAvatar class."""
 
     def setUp(self):
         self.getLogger_patcher = patch(
-            "{src}.getLogger".format(**PATH), autospec=True
+            "{src}.getLogger".format(**PATH), autospec=True,
         )
         self.getLogger = self.getLogger_patcher.start()
         self.addCleanup(self.getLogger_patcher.stop)
         self.services = create_autospec(HubServiceRegistry)
-        self.workers = set([])  # only __contains__, add, and remove needed
+        self.workers = set()  # only __contains__, add, and remove needed
         self.avatar = HubAvatar(self.services, self.workers)
 
     def test_perspective_ping(self):
@@ -367,7 +377,7 @@ class HubAvatarTest(TestCase):
 
         expected = self.services.getService.return_value
         actual = self.avatar.perspective_getService(
-            service_name, monitor, listener=listener, options=options
+            service_name, monitor, listener=listener, options=options,
         )
 
         self.services.getService.assert_called_with(service_name, monitor)
@@ -389,7 +399,7 @@ class HubAvatarTest(TestCase):
         with self.assertRaises(pb.Error):
             self.avatar.perspective_getService(service_name)
             logger.exception.assert_called_once_with(
-                "Failed to get service '%s'", service_name
+                "Failed to get service '%s'", service_name,
             )
 
     def test_perspective_reportingForWork(self):
@@ -411,10 +421,11 @@ class HubAvatarTest(TestCase):
 
 
 class HubServiceRegistryTest(TestCase):
+    """Test the HubServiceRegistry class."""
 
     def setUp(self):
         self.getLogger_patcher = patch(
-            "{src}.getLogger".format(**PATH), autospec=True
+            "{src}.getLogger".format(**PATH), autospec=True,
         )
         self.getLogger = self.getLogger_patcher.start()
         self.addCleanup(self.getLogger_patcher.stop)
@@ -467,7 +478,7 @@ class HubServiceRegistryTest(TestCase):
 
         importClass.assert_has_calls([
             call(name),
-            call("Products.ZenHub.services.%s" % name, name)
+            call("Products.ZenHub.services.%s" % name, name),
         ])
         self.factory.build.assert_not_called()
 
@@ -492,6 +503,7 @@ class HubServiceRegistryTest(TestCase):
 
 
 class WorkerInterceptorFactoryTest(TestCase):
+    """Test the WorkerInterceptorFactory class."""
 
     def setUp(self):
         self.dispatcher = Mock()
@@ -511,10 +523,11 @@ class WorkerInterceptorFactoryTest(TestCase):
 
 
 class WorkerInterceptorTest(TestCase):
+    """Test the WorkerInterceptor class."""
 
     def setUp(self):
         self.getLogger_patcher = patch(
-            "{src}.getLogger".format(**PATH), autospec=True
+            "{src}.getLogger".format(**PATH), autospec=True,
         )
         self.getLogger = self.getLogger_patcher.start()
         self.addCleanup(self.getLogger_patcher.stop)
@@ -524,7 +537,7 @@ class WorkerInterceptorTest(TestCase):
         self.service = Mock()
         self.executor = MagicMock(DispatchingExecutor)
         self.reference = WorkerInterceptor(
-            self.service, self.name, self.monitor, self.executor
+            self.service, self.name, self.monitor, self.executor,
         )
         self.reference.perspective = sentinel.perspective
 
@@ -546,19 +559,19 @@ class WorkerInterceptorTest(TestCase):
         job = serviceJob.return_value
 
         dfr = self.reference.remoteMessageReceived(
-            self.broker, method, args, kwargs
+            self.broker, method, args, kwargs,
         )
 
         self.assertEqual(dfr.result, state)
         self.executor.submit.assert_called_once_with(job)
         serviceJob.assert_called_once_with(
-            self.name, self.monitor, method, args, kwargs
+            self.name, self.monitor, method, args, kwargs,
         )
         self.broker.unserialize.assert_has_calls([
-            call(args), call(kwargs)
+            call(args), call(kwargs),
         ])
         self.broker.serialize.assert_called_once_with(
-            state, self.reference.perspective
+            state, self.reference.perspective,
         )
 
     def test_remoteMessageReceived_raise_external_error(self):
@@ -568,7 +581,7 @@ class WorkerInterceptorTest(TestCase):
         exceptions = [
             pb.Error(ValueError("boom")),
             pb.RemoteError("ValueError", "boom", "[no traceback]"),
-            RemoteException("boom", "tb")
+            RemoteException("boom", "tb"),
         ]
         for expected_ex in exceptions:
             self.executor.submit.side_effect = \
@@ -576,13 +589,13 @@ class WorkerInterceptorTest(TestCase):
 
             cb = Callback()
             dfr = self.reference.remoteMessageReceived(
-                self.broker, "method", args, kwargs
+                self.broker, "method", args, kwargs,
             )
             dfr.addErrback(cb)
 
             try:
                 self.broker.unserialize.assert_has_calls([
-                    call(args), call(kwargs)
+                    call(args), call(kwargs),
                 ])
                 self.broker.serialize.assert_not_called()
                 self.assertEqual(cb.result.value, expected_ex)
@@ -597,13 +610,13 @@ class WorkerInterceptorTest(TestCase):
         self.executor.submit.side_effect = lambda j: defer.fail(ex)
 
         dfr = self.reference.remoteMessageReceived(
-            self.broker, "method", args, kwargs
+            self.broker, "method", args, kwargs,
         )
         dfr.addErrback(lambda f: (f.trap(pb.Error), f))
         exType, failure = dfr.result
 
         self.broker.unserialize.assert_has_calls([
-            call(args), call(kwargs)
+            call(args), call(kwargs),
         ])
         self.broker.serialize.assert_not_called()
         self.assertIs(exType, pb.Error)
@@ -611,6 +624,8 @@ class WorkerInterceptorTest(TestCase):
 
 
 class ServiceAddedEventTest(TestCase):
+    """Test the ServiceAddedEvent class."""
+
     def test___init__(t):
         name, instance = 'name', 'instance'
         service_added_event = ServiceAddedEvent(name, instance)
@@ -626,6 +641,7 @@ class ServiceAddedEventTest(TestCase):
 
 
 class AuthXmlRpcServiceTest(TestCase):
+    """Test the AuthXmlRpcService class."""
 
     def setUp(t):
         t.dmd = Mock(name='dmd', spec_set=['ZenEventManager'])
@@ -643,18 +659,14 @@ class AuthXmlRpcServiceTest(TestCase):
         XmlRpcService__init__.assert_called_with(axrs, dmd)
         t.assertEqual(axrs.checker, checker)
 
-    def test_doRender(t):
-        '''should be refactored to call self.render,
-        instead of the parrent class directly
-        '''
-        render = create_autospec(XmlRpcService.render, name='render')
-        XmlRpcService.render = render
+    @patch("{src}.XmlRpcService.render".format(**PATH), autospec=True)
+    def test_doRender(t, render):
         request = sentinel.request
 
-        ret = t.axrs.doRender('unused arg', request)
+        result = t.axrs.doRender('unused arg', request)
 
-        XmlRpcService.render.assert_called_with(t.axrs, request)
-        t.assertEqual(ret, render.return_value)
+        render.assert_called_with(t.axrs, request)
+        t.assertEqual(result, render.return_value)
 
     @patch('{src}.xmlrpc'.format(**PATH), name='xmlrpc', autospec=True)
     def test_unauthorized(t, xmlrpc):
@@ -668,7 +680,7 @@ class AuthXmlRpcServiceTest(TestCase):
 
     @patch('{src}.server'.format(**PATH), name='server', autospec=True)
     @patch(
-        '{src}.credentials'.format(**PATH), name='credentials', autospec=True
+        '{src}.credentials'.format(**PATH), name='credentials', autospec=True,
     )
     def test_render(t, credentials, server):
         request = Mock(name='request', spec_set=['getHeader'])
@@ -686,7 +698,7 @@ class AuthXmlRpcServiceTest(TestCase):
         encoded.decode.return_value.split.assert_called_with(':')
         credentials.UsernamePassword.assert_called_with('user', 'password')
         t.axrs.checker.requestAvatarId.assert_called_with(
-            credentials.UsernamePassword.return_value
+            credentials.UsernamePassword.return_value,
         )
         deferred = t.axrs.checker.requestAvatarId.return_value
         deferred.addCallback.assert_called_with(t.axrs.doRender, request)
@@ -695,6 +707,7 @@ class AuthXmlRpcServiceTest(TestCase):
 
 
 class LoadCheckersTest(TestCase):
+    """Test the LoadCheckers class."""
 
     @patch('{src}.checkers'.format(**PATH), spec=True)
     def test_getCredentialCheckers(self, checkers):

--- a/Products/ZenHub/tests/test_servicemanager.py
+++ b/Products/ZenHub/tests/test_servicemanager.py
@@ -7,6 +7,8 @@
 #
 ##############################################################################
 
+from __future__ import absolute_import
+
 import time
 
 from unittest import TestCase, skip
@@ -122,7 +124,7 @@ class HubServiceManagerTest(TestCase):
     @patch("{src}.HubRealm".format(**PATH), autospec=True)
     @patch("{src}.getCredentialCheckers".format(**PATH), autospec=True)
     @patch("{src}.portal.Portal".format(**PATH), autospec=True)
-    @patch("{src}.pb.PBServerFactory".format(**PATH), autospec=True)
+    @patch("{src}.ZenPBServerFactory".format(**PATH), autospec=True)
     @patch("{src}.ipv6_available".format(**PATH), autospec=True)
     @patch("{src}.serverFromString".format(**PATH), autospec=True)
     @patch("{src}.AuthXmlRpcService".format(**PATH))

--- a/Products/ZenHub/tests/test_zenhubworker.py
+++ b/Products/ZenHub/tests/test_zenhubworker.py
@@ -32,6 +32,7 @@ PATH = {'src': 'Products.ZenHub.zenhubworker'}
 
 
 class ZenHubWorkerTest(TestCase):
+    """Test the ZenHubWorker class."""
 
     def setUp(t):
         # Patch out the ZCmdBase __init__ method
@@ -51,7 +52,7 @@ class ZenHubWorkerTest(TestCase):
             setattr(t, name, patcher.start())
             t.addCleanup(patcher.stop)
 
-        # ZenHubWorker.options = sentinel.options
+        # Set ZenHubWorker's options to some real and mock values
         t.options.profiling = True
         t.options.hubhost = "localhost"
         t.options.hubport = 8765
@@ -154,8 +155,7 @@ class ZenHubWorkerTest(TestCase):
         ])
 
     def test_audit(t):
-        '''does nothing
-        '''
+        # Verifies the API exists, although it does nothing.
         action = sentinel.action
         t.zhw.audit(action)
 
@@ -216,10 +216,12 @@ class ZenHubWorkerTest(TestCase):
     @patch('{src}.isoDateTime'.format(**PATH), autospec=True)
     @patch('{src}.time'.format(**PATH), autospec=True)
     def test_reportStats(t, time, isoDateTime):
-        '''Metric Reporting Function. Log various statistics on services
-        as a general rule, do not test individual log messages, just log format
-        this function is difficult to read and should be refactored
-        '''
+        """Test the metric reporting function.
+
+        Log various statistics on services as a general rule, do not test
+        individual log messages, just log format this function is difficult
+        to read and should be refactored.
+        """
         t.zhw.current = sentinel.current_job
         t.zhw.options.workerid = 1
         t.zhw.currentStart = 0
@@ -320,10 +322,12 @@ class ZenHubWorkerTest(TestCase):
 
     @patch('{src}.ZCmdBase'.format(**PATH))
     def test_buildOptions(t, ZCmdBase):
-        '''After initialization, the ZenHubWorker instance should have
-        options parsed from its buildOptions method
-        assertions based on default options
-        '''
+        """Test the result of the buildOptions method.
+
+        In this isolated test, after argument parsing, the ZenHubWorker
+        instance options object should have values matching the default
+        values specified for the options.
+        """
         # this should call buildOptions on parent classes, up the tree
         # currently calls an ancestor class directly
         # parser expected to be added by CmdBase.buildParser
@@ -345,6 +349,7 @@ class ZenHubWorkerTest(TestCase):
 
 
 class ZenHubClientTest(TestCase):
+    """Test the ZenHubClient class."""
 
     def setUp(t):
         # t.reactor = Mock()
@@ -639,6 +644,7 @@ class ZenHubClientTest(TestCase):
 
 
 class PingZenHubTest(TestCase):
+    """Test the PingZenHub class."""
 
     def setUp(t):
         t.zenhub = Mock()
@@ -684,6 +690,7 @@ class PingZenHubTest(TestCase):
 
 
 class ServiceReferenceFactoryTest(TestCase):
+    """Test the ServiceReferenceFactory class."""
 
     @patch("{src}.ServiceReference".format(**PATH), autospec=True)
     def test_build(t, ServiceReference):
@@ -702,6 +709,7 @@ class ServiceReferenceFactoryTest(TestCase):
 
 
 class ServiceReferenceTest(TestCase):
+    """Test the ServiceReference class."""
 
     def setUp(t):
         t._CumulativeWorkerStats_patcher = patch(
@@ -797,6 +805,7 @@ class ServiceReferenceTest(TestCase):
 
 
 class _CumulativeWorkerStatsTest(TestCase):
+    """Test the _CumulativeWorkerStats class."""
 
     def test___init__(t):
         cws = _CumulativeWorkerStats()

--- a/Products/ZenHub/tests/test_zenhubworker.py
+++ b/Products/ZenHub/tests/test_zenhubworker.py
@@ -7,6 +7,8 @@
 #
 ##############################################################################
 
+from __future__ import absolute_import
+
 from unittest import TestCase
 from mock import patch, sentinel, call, Mock, create_autospec, ANY, MagicMock
 
@@ -360,7 +362,7 @@ class ZenHubClientTest(TestCase):
 
         # Patch external dependencies
         needs_patching = [
-            'pb.PBClientFactory',
+            'ZenPBClientFactory',
             'clientFromString',
             'ClientService',
             'ConnectedToZenHubSignalFile',
@@ -409,7 +411,7 @@ class ZenHubClientTest(TestCase):
         t.assertFalse(t.zhc._ZenHubClient__stopping)
         t.backoffPolicy.assert_called_once_with(initialDelay=0.5, factor=3.0)
         t.ClientService.assert_called_once_with(
-            t.endpoint, t.PBClientFactory.return_value,
+            t.endpoint, t.ZenPBClientFactory.return_value,
             retryPolicy=t.backoffPolicy.return_value,
         )
         service = t.ClientService.return_value

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -198,7 +198,7 @@ class ZenHubWorker(ZCmdBase, pb.Referenceable):
         if self.current != IDLE:
             self.log.info(
                 "Currently performing %s, elapsed %.2f s",
-                self.current, now-self.currentStart,
+                self.current, now - self.currentStart,
             )
         else:
             self.log.info("Currently IDLE")
@@ -216,7 +216,7 @@ class ZenHubWorker(ZCmdBase, pb.Referenceable):
                             svc, method,
                             stats.numoccurrences,
                             stats.totaltime,
-                            stats.totaltime/stats.numoccurrences
+                            stats.totaltime / stats.numoccurrences
                             if stats.numoccurrences else 0.0,
                             isoDateTime(stats.lasttime),
                         ),

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -32,6 +32,7 @@ import Globals  # noqa: F401
 
 from Products.DataCollector.Plugins import loadPlugins
 from Products.ZenHub import PB_PORT, OPTION_STATE, CONNECT_TIMEOUT
+from Products.ZenHub.broker import ZenPBClientFactory
 from Products.ZenHub.interfaces import IServiceReferenceFactory
 from Products.ZenHub.metricmanager import MetricManager
 from Products.ZenHub.servicemanager import (
@@ -332,7 +333,7 @@ class ZenHubClient(object):
     def start(self):
         """Start connecting to ZenHub."""
         self.__stopping = False
-        factory = pb.PBClientFactory()
+        factory = ZenPBClientFactory()
         self.__service = ClientService(
             self.__endpoint, factory,
             retryPolicy=backoffPolicy(initialDelay=0.5, factor=3.0),


### PR DESCRIPTION
Versions of zenhub prior to the recent refactor used double serialization (jelly and pickle) to communicate with the zenhubworkers.  This had the side effect of bypassing Twisted's check to ensure only registered classes could have their objects unserialized.  The refactor removed the use of pickle and so the check for registration was enforced, breaking some ZenPacks. This change removes the registration requirement.

Fixes ZEN-31571.