### PR TITLE
AuthXmlRpcService accepts just one cred checker.

### DIFF
--- a/Products/ZenHub/servicemanager.py
+++ b/Products/ZenHub/servicemanager.py
@@ -118,7 +118,7 @@ class HubServiceManager(object):
         dfr.addCallback(self.__setKeepAlive)
 
         # Initialize and start the XMLRPC server
-        self.__xmlrpc_site = AuthXmlRpcService.makeSite(dmd, checkers)
+        self.__xmlrpc_site = AuthXmlRpcService.makeSite(dmd, checkers[0])
         xmlrpc_descriptor = "%s:port=%s" % (tcp_version, self.__xmlrpcport)
         xmlrpc_server = serverFromString(reactor, xmlrpc_descriptor)
         xmlrpc_server.listen(self.__xmlrpc_site)
@@ -519,6 +519,7 @@ class AuthXmlRpcService(XmlRpcService):
         """
         XmlRpcService.__init__(self, dmd)
         self.checker = checker
+        self.__log = getLogger("zenhub", self)
 
     def doRender(self, unused, request):
         """
@@ -562,6 +563,9 @@ class AuthXmlRpcService(XmlRpcService):
 
                     d.addErrback(error, request)
             except Exception:
+                self.__log.exception(
+                    "[render] Exception caught; assuming unauthorized",
+                )
                 self.unauthorized(request)
         return server.NOT_DONE_YET
 

--- a/Products/ZenHub/tests/test_servicemanager.py
+++ b/Products/ZenHub/tests/test_servicemanager.py
@@ -158,7 +158,9 @@ class HubServiceManagerTest(TestCase):
         services = hubServiceRegistry.return_value
         avatar = hubAvatar.return_value
         realm = hubRealm.return_value
-        checkers = getCredentialCheckers.return_value
+        checker = Mock()
+        checkers = [checker]
+        getCredentialCheckers.return_value = checkers
         portalObj = portal.return_value
         pb_factory = pBServerFactory.return_value
         xmlrpc_site = authXmlRpcService.makeSite.return_value
@@ -215,7 +217,7 @@ class HubServiceManagerTest(TestCase):
         dfr.addCallback.assert_called_once_with(
             manager._HubServiceManager__setKeepAlive
         )
-        authXmlRpcService.makeSite.assert_called_once_with(dmd, checkers)
+        authXmlRpcService.makeSite.assert_called_once_with(dmd, checker)
         xmlrpc_server.listen.assert_called_once_with(xmlrpc_site)
 
     @skip("Not testing string formatting")


### PR DESCRIPTION
Fixes ZEN-31603.