### PR TITLE
[ZEN-31617] Add Model Views for Impact to facilitate modeling by RM Monitor

### DIFF
--- a/Products/ZenUI3/browser/modelapi/configure.zcml
+++ b/Products/ZenUI3/browser/modelapi/configure.zcml
@@ -91,6 +91,14 @@
         />
 
     <browser:view
+        zcml:condition="installed ZenPacks.zenoss.Impact"
+        class=".modelapi.ImpactDaemons"
+        name="ImpactDaemons"
+        for="Products.ZenModel.interfaces.IDataRoot"
+        permission="zenoss.Common"
+        />
+
+    <browser:view
         zcml:condition="have zingConnector"
         class=".modelapi.ZingConnector"
         name="ZingConnector"

--- a/Products/ZenUI3/browser/modelapi/modelapi.py
+++ b/Products/ZenUI3/browser/modelapi/modelapi.py
@@ -318,6 +318,16 @@ class Writer(BaseApiView):
         writers += super(Writer, self)._getServices('writer-bigtable')
         return writers
 
+class ImpactDaemons(BaseApiView):
+    """
+    This view emits the Impact daemon services
+    """
+    @property
+    def _services(self):
+        return (
+            ('impacts', 'Impact'),
+            ('zenimpactstates', 'zenimpactstate'),
+        )
 
 class ZingConnector(BaseApiView):
     """


### PR DESCRIPTION
Add model views for Impact to facilitate modeling by RM Monitor. This adds a model view under /zport/dmd/ImpactDaemons that returns Impact (server) and zenimpactstate Control Center information.

The ZCML doesn't load the view if Impact isn't installed.

https://jira.zenoss.com/browse/ZEN-31617