### PR TITLE
Fixes ZEN-31081

### DIFF
--- a/Products/Zuul/facades/eventclassesfacade.py
+++ b/Products/Zuul/facades/eventclassesfacade.py
@@ -125,7 +125,7 @@ class EventClassesFacade(TreeFacade):
         resequences a list of sequenced instances
         """
         for i, uid in enumerate(uids):
-            obj = self._getObject(uid)
+            obj = self._getObject(uid.replace("%20", " "))
             obj.sequence = i
 
     def setTransform(self, uid, transform):


### PR DESCRIPTION
Event Class Mappings cannot be re-sequenced if they contain spaces because the UID returned from the request contains the encoded %20 value.