### PR TITLE
ZEN-30783 Zope Self-Monitoring Collection Needs a Timeout

### DIFF
--- a/bin/metrics/zenossStatsView.py
+++ b/bin/metrics/zenossStatsView.py
@@ -126,7 +126,7 @@ class ZProxyMetricGatherer(MetricGatherer):
         for id_, zope in zopes.iteritems():
             try:
                 s = requests.Session()
-                result = s.get(self.ZPROXY_STATS_URL % zope)
+                result = s.get(self.ZPROXY_STATS_URL % zope, timeout=10)
                 if result.status_code == 200:
                     data = result.json()
                     now = time.time()


### PR DESCRIPTION
This was fixed in 6.x, but never made it into CZ.