### PR TITLE
Don't homogenize service call exceptions.

### DIFF
--- a/Products/ZenHub/dispatchers/tests/test_workers.py
+++ b/Products/ZenHub/dispatchers/tests/test_workers.py
@@ -23,9 +23,9 @@ from ..workers import (
     WorkerPoolDispatcher,
     ServiceCallJob, AsyncServiceCallJob,
     StatsMonitor, WorkerStats, JobStats,
-    RemoteException
+    RemoteException, banana, jelly,
 )
-from ..workerpool import WorkerPool, WorkerRef, ServiceCallError
+from ..workerpool import WorkerPool, WorkerRef
 
 PATH = {'src': 'Products.ZenHub.dispatchers.workers'}
 
@@ -199,88 +199,95 @@ class WorkerPoolDispatcherTest(TestCase):
         self.worklist.pushfront.assert_not_called()
         self.worklist.push.assert_not_called()
 
-    def test__call_service_pbRemoteError(self):
+    def test__call_service_remote_errors(self):
         job = ServiceCallJob("service", "localhost", "method", [], {})
         ajob = AsyncServiceCallJob(job)
         worker = Mock(spec=WorkerRef)
-        error = pb.RemoteError("type", "boom", "tb")
-        worker.run.side_effect = error
         cm = MagicMock(spec=("__exit__", "__enter__"))
         cm.__enter__.return_value = worker
         self.workers.borrow.return_value = cm
 
-        self.dispatcher._call_service(ajob)
+        exc = ValueError("boom")
+        errors = (
+            RemoteException("ExceptionalRemoteBoom", None),
+            pb.RemoteError(ValueError, exc, None),
+        )
+        for error in errors:
+            worker.run.side_effect = error
 
-        worker.run.assert_called_once_with(job)
-        self.reactor.callLater.assert_called_once_with(0, ajob.failure, error)
-        self.worklist.pushfront.assert_not_called()
-        self.worklist.push.assert_not_called()
+            self.dispatcher._call_service(ajob)
 
-    def test__call_service_RemoteException(self):
-        job = ServiceCallJob("service", "localhost", "method", [], {})
-        ajob = AsyncServiceCallJob(job)
-        worker = Mock(spec=WorkerRef)
-        error = RemoteException("boom", sentinel.traceback)
-        worker.run.side_effect = error
-        cm = MagicMock(spec=("__exit__", "__enter__"))
-        cm.__enter__.return_value = worker
-        self.workers.borrow.return_value = cm
+            self.reactor.callLater.assert_called_once_with(
+                0, ajob.failure, error,
+            )
+            self.logger.info.assert_not_called()
+            self.logger.warn.assert_not_called()
+            self.logger.error.assert_not_called()
+            self.logger.exception.assert_not_called()
 
-        self.dispatcher._call_service(ajob)
+            # reset the mocks for the next iteration
+            self.reactor.reset_mock()
 
-        worker.run.assert_called_once_with(job)
-        self.reactor.callLater.assert_called_once_with(0, ajob.failure, error)
-        self.worklist.pushfront.assert_not_called()
-        self.worklist.push.assert_not_called()
-
-    def test__call_service_internal_error(self):
+    @patch("{src}.pb.Error".format(**PATH))
+    def test__call_service_internal_error(self, _pberror):
         job = ServiceCallJob("service", "localhost", "method", [], {})
         ajob = AsyncServiceCallJob(job)
         worker = Mock(spec=WorkerRef, workerId=1)
-        error = ServiceCallError("boom", TypeError("original boom"))
+        error = TypeError("original boom")
         worker.run.side_effect = error
         cm = MagicMock(spec=("__exit__", "__enter__"))
         cm.__enter__.return_value = worker
         self.workers.borrow.return_value = cm
         self.workers.__contains__.return_value = True
 
-        self.dispatcher._call_service(ajob)
+        errors = (
+            pb.ProtocolError("protocol boom"),
+            banana.BananaError("banana boom"),
+            jelly.InsecureJelly("jelly boom"),
+        )
+        for error in errors:
+            worker.run.side_effect = error
 
-        worker.run.assert_called_once_with(job)
-        self.logger.exception.assert_not_called()
-        self.assertTrue(self.logger.error.called)
-        self.assertEqual(self.logger.error.call_count, 1)
+            self.dispatcher._call_service(ajob)
 
-        self.assertTrue(self.reactor.callLater.called)
-        self.assertEqual(self.reactor.callLater.call_count, 1)
-        args = self.reactor.callLater.call_args[0]
-        self.assertEqual(len(args), 3)
-        self.assertEqual(args[0], 0)
-        self.assertEqual(args[1], ajob.failure)
-        self.assertIsInstance(args[2], pb.Error)
+            self.reactor.callLater.assert_called_once_with(
+                0, ajob.failure, _pberror.return_value,
+            )
+            self.logger.info.assert_not_called()
+            self.logger.warn.assert_not_called()
+            self.logger.error.assert_called_once_with(
+                ANY, worker.workerId, type(error).__name__, error,
+            )
+            self.logger.exception.assert_not_called()
+            self.worklist.pushfront.assert_not_called()
+            self.worklist.push.assert_not_called()
 
-        self.worklist.pushfront.assert_not_called()
-        self.worklist.push.assert_not_called()
+            # reset the mocks for the next iteration
+            self.logger.error.reset_mock()
+            self.reactor.reset_mock()
 
-    def test__call_service_bad_worker(self):
+    def test__call_service_unhandled_error(self):
         job = ServiceCallJob("service", "localhost", "method", [], {})
         ajob = AsyncServiceCallJob(job)
         worker = Mock(spec=WorkerRef, workerId=1)
-        error = ServiceCallError("boom", ValueError("original boom"))
+        error = ValueError("original boom")
         worker.run.side_effect = error
         cm = MagicMock(spec=("__exit__", "__enter__"))
         cm.__enter__.return_value = worker
         self.workers.borrow.return_value = cm
         self.workers.__contains__.return_value = False
 
-        self.dispatcher._call_service(ajob)
+        handler = Mock()
+        dfr = self.dispatcher._call_service(ajob)
+        dfr.addErrback(handler)
 
+        self.assertEqual(1, handler.call_count)
         worker.run.assert_called_once_with(job)
-        self.logger.warn.assert_called_once_with(ANY, worker.workerId, error)
+        self.logger.warn.assert_not_called()
         self.logger.error.assert_not_called()
         self.logger.exception.assert_not_called()
         self.reactor.callLater.assert_not_called()
-        self.worklist.pushfront.assert_called_once_with(ajob)
+        self.worklist.pushfront.assert_not_called()
         self.worklist.push.assert_not_called()
 
     def test__call_service_PBConnectionLost(self):

--- a/Products/ZenHub/dispatchers/workerpool.py
+++ b/Products/ZenHub/dispatchers/workerpool.py
@@ -8,22 +8,11 @@
 ##############################################################################
 
 import collections
-import sys
 
 from contextlib import contextmanager
 from twisted.internet import defer
 
-
-class ServiceCallError(Exception):
-    """This exception is raised when there's an issue while attempting
-    to execute a remote call on a worker.
-
-    This is an internal use only exception and not part of the public API.
-    """
-
-    def __init__(self, mesg, source):
-        super(ServiceCallError, self).__init__(mesg)
-        self.source = source
+from Products.ZenUtils.Logger import getLogger
 
 
 class WorkerPool(
@@ -160,6 +149,7 @@ class WorkerRef(object):
         """
         self.__worker = worker
         self.__services = services
+        self.__log = getLogger("zenhub", self)
 
     @property
     def ref(self):
@@ -177,7 +167,7 @@ class WorkerRef(object):
         """Execute the job.
 
         @param job {ServiceCallJob} Details on the RPC method to invoke.
-        @raises ServiceCallError if an error occurs while attempting to
+        @raises Exception if an error occurs while attempting to
             execute a remote procedure call.  An RPC error may occur while
             retrieving the remote service reference or when invoking the
             job specified method on the remote service reference.
@@ -185,12 +175,11 @@ class WorkerRef(object):
         try:
             service = yield self.__services.lookup(job.service, job.monitor)
         except Exception as ex:
-            _, _, tb = sys.exc_info()
-            error = ServiceCallError(
-                "Failed to retrieve service '%s': (%s) %s"
-                % (job.service, type(ex).__name__, ex), ex
+            self.__log.error(
+                "(worker %s) Failed to retrieve service '%s': %s",
+                self.__worker.workerId, job.service, ex,
             )
-            raise ServiceCallError, error, tb
+            raise
 
         try:
             result = yield service.callRemote(
@@ -198,9 +187,8 @@ class WorkerRef(object):
             )
             defer.returnValue(result)
         except Exception as ex:
-            _, _, tb = sys.exc_info()
-            error = ServiceCallError(
-                "Failed to execute %s.%s: (%s) %s"
-                % (job.service, job.method, type(ex).__name__, ex), ex
+            self.__log.error(
+                "(worker %s) Failed to execute %s.%s: %s",
+                self.__worker.workerId, job.service, job.method, ex,
             )
-            raise ServiceCallError, error, tb
+            raise


### PR DESCRIPTION
Exceptions raised from remote calls are no longer converted into a single exception type.  Removed testing for whether a zenhubworker reference is 'current'.

Fixes ZEN-31694.