### PR TITLE
ZEN-31725 Add Memcached model views

### DIFF
--- a/Products/ZenUI3/browser/modelapi/configure.zcml
+++ b/Products/ZenUI3/browser/modelapi/configure.zcml
@@ -106,4 +106,11 @@
         permission="zenoss.Common"
         />
 
+    <browser:view
+        class=".modelapi.Memcached"
+        name="Memcached"
+        for="Products.ZenModel.interfaces.IDataRoot"
+        permission="zenoss.Common"
+        />
+
 </configure>

--- a/Products/ZenUI3/browser/modelapi/modelapi.py
+++ b/Products/ZenUI3/browser/modelapi/modelapi.py
@@ -338,3 +338,33 @@ class ZingConnector(BaseApiView):
         return (
             ('zingConnectors', 'zing-connector'),
         )
+
+class Memcached(BaseApiView):
+
+    @property
+    def _services(self):
+        return (
+            ('memcacheds', 'memcacheds'),
+        )
+
+    def _getServiceInstances(self, name):
+        idFormat = '{}'
+        titleFormat = '{}'
+        services = self._appfacade.query(name)
+        if not services:
+            return []
+        svc = services[0]
+        data = [dict(id=idFormat.format(name),
+                     title=titleFormat.format(name),
+                     controlplaneServiceId=svc.id,
+                     instanceCount=svc.instances,
+                     RAMCommitment=getattr(svc, 'RAMCommitment', None),
+                     lastModeledState=str(svc.state).lower()
+                     )
+                for i in range(svc.instances)]
+        return data
+
+    def _getServices(self, svcName):
+        memcacheds = self._getServiceInstances('memcached')
+        memcacheds += self._getServiceInstances('memcached-session')
+        return memcacheds


### PR DESCRIPTION
ZEN-31725 Add Memcached model views

https://zenoss.example/zport/dmd/Memcached

Example output:

```
{"memcacheds": [{"lastModeledState": "running", "RAMCommitment": 3221225472, "instanceCount": 1, "controlplaneServiceId": "f3h13yisx3opawmmsk68a4rsh", "title": "memcached", "id": "memcached"}, {"lastModeledState": "running", "RAMCommitment": 1073741824, "instanceCount": 1, "controlplaneServiceId": "3wat2pb8pb92yltanfjdhg4zr", "title": "memcached-session", "id": "memcached-session"}]}
```