### PR TITLE
ZEN-31734: Validate objectMaps in RelationshipMaps

### DIFF
--- a/Products/DataCollector/ApplyDataMap/applydatamap.py
+++ b/Products/DataCollector/ApplyDataMap/applydatamap.py
@@ -258,7 +258,9 @@ class ApplyDataMap(object):
 # Preproce, diff and set directives
 ##############################################################################
 
-def _validate_datamap(device, datamap, relname, compname, modname, parentId):
+def _validate_datamap(
+    device, datamap, relname=None, compname=None, modname=None, parentId=None
+):
     if isinstance(datamap, RelationshipMap):
         log.debug('_validate_datamap: got valid RelationshipMap')
     elif relname:
@@ -386,7 +388,7 @@ def _process_relationshipmap(relmap, base_device):
         object_map.relname = relmap.relname
 
     new_maps = [
-        IncrementalDataMap(parent, object_map)
+        _validate_datamap(parent, object_map)
         for object_map in relmap.maps
     ]
     relmap.maps = new_maps

--- a/Products/DataCollector/ApplyDataMap/tests/test_applydatamap.py
+++ b/Products/DataCollector/ApplyDataMap/tests/test_applydatamap.py
@@ -186,6 +186,22 @@ class ApplyDataMapTests(TestCase):
         t.adm._report_changes.assert_called_with(relmap, device)
         t.assertEqual(ret, t.adm._report_changes.return_value)
 
+    def test_applyDataMap_RelationshipMap_contains_IncrementalDataMap(t):
+        '''A relationshipMap may contain IncrementalDataMaps
+        in addition to ObjectMaps
+        '''
+        base = Device(id='owner')
+        device = Device(id='related_device')
+        device.dmd = Mock(name='dmd')
+        relmap = RelationshipMap()
+        relmap.append(
+            IncrementalDataMap(device, ObjectMap({'comments': 'ok'}))
+        )
+
+        t.adm.applyDataMap(base, relmap)
+
+        t.assertEqual(device.comments, 'ok')
+
     @patch('{src}._validate_datamap'.format(**PATH), autospec=True)
     @patch('{src}.transact'.format(**PATH), autospec=True)
     def test_applyDataMap_ObjectMap(t, transact, _validate_datamap):


### PR DESCRIPTION
fixes ZEN-31734