### PR TITLE
add ZenMessaging.queuemessaging for tests

### DIFF
--- a/Products/ZenTestCase/testing-noevent.zcml
+++ b/Products/ZenTestCase/testing-noevent.zcml
@@ -13,6 +13,7 @@
   <include package="Products.ZenWidgets" file="scriptmessaging.zcml"/>
   <include package="Products.Jobber"/>
   <include package="Products.Zuul"/>
+  <include package="Products.ZenMessaging.queuemessaging"/>
   <include package="Products.ZenUtils"/>
   <include package="Products.Zing"/>
 


### PR DESCRIPTION
Something in the ApplyDataMap refactor has resulted in test using it to
require that the ZCML for Products.ZenMessaging.queuemessaging to be
loaded.

Without it we get unit test errors such as the following in ZenPackLib's
unit tests.

    Running ZenPacks.zenoss.ZenPackLib.tests.test_layered_unit_tests.SharedLayer2 tests:
      Set up ZenPacks.zenoss.ZenPackLib.tests.ZPLTestCaseLayerBase Traceback (most recent call last):
      File "/opt/zenoss/lib/python2.7/site-packages/zope/testrunner/runner.py", line 380, in run_layer
	setup_layer(options, layer, setup_layers)
      File "/opt/zenoss/lib/python2.7/site-packages/zope/testrunner/runner.py", line 667, in setup_layer
	setup_layer(options, base, setup_layers)
      File "/opt/zenoss/lib/python2.7/site-packages/zope/testrunner/runner.py", line 667, in setup_layer
	setup_layer(options, base, setup_layers)
      File "/opt/zenoss/lib/python2.7/site-packages/zope/testrunner/runner.py", line 672, in setup_layer
	layer.setUp()
      File "/mnt/src/ZenPacks.zenoss.ZenPackLib/ZenPacks/zenoss/ZenPackLib/tests/__init__.py", line 315, in setUp
	cls.mapper = ApplyDataMap()
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/applydatamap.py", line 74, in __init__
	self._reporter = ADMReporter()
      File "/opt/zenoss/Products/DataCollector/ApplyDataMap/reporter.py", line 32, in __init__
	self.__publisher = getUtility(IEventPublisher, 'batch')
      File "/opt/zenoss/lib/python2.7/site-packages/zope/component/_api.py", line 169, in getUtility
	raise ComponentLookupError(interface, name)
    ComponentLookupError: (<InterfaceClass Products.ZenMessaging.queuemessaging.interfaces.IEventPublisher>, 'batch')

    Tests with errors:
       Layer: ZenPacks.zenoss.ZenPackLib.tests.SharedLayer
       Layer: ZenPacks.zenoss.ZenPackLib.tests.StandaloneLayer
       Layer: ZenPacks.zenoss.ZenPackLib.tests.TemplateExtraParamsLayer
       Layer: ZenPacks.zenoss.ZenPackLib.tests.TemplateReplacementLayer
       Layer: ZenPacks.zenoss.ZenPackLib.tests.test_layered_unit_tests.SharedLayer2
    Total: 78 tests, 0 failures, 5 errors in 5 minutes 49.005 seconds.

Fixes ZEN-31754.