### PR TITLE
Add support for the globalkey auth0 flag

### DIFF
--- a/Products/ZenUtils/Auth0/Auth0.py
+++ b/Products/ZenUtils/Auth0/Auth0.py
@@ -194,13 +194,15 @@ class Auth0(BasePlugin):
             # + The tenantkey is used to lookup the tenant from the jwt.
             tenantkey = conf.get('tenantkey', 'https://dev.zing.ninja/tenant')
             tenant = payload.get(tenantkey, None) # ie: "https://dev.zing.ninja/tenant": "alphacorp", in jwt
-            if not tenant:
+            # Check the jwt for the globalkey setting.
+            is_global_key = payload.get('https://dev.zing.ninja/globalkey', None)
+            if not is_global_key and not tenant:
                 log.warn('No auth0 tenant specified in jwt for tenantkey: {}'.format(tenantkey))
                 Auth0.removeToken(request)
                 return None
             # + Get the whitelist from global.conf and verify that it's in the list.
             whitelist = conf.get('whitelist', [])
-            if not tenant in whitelist:
+            if not is_global_key and tenant not in whitelist:
                 log.warn('Tenant {} is invalid. Not in whitelist: {}'.format(tenant, whitelist))
                 Auth0.removeToken(request)
                 return None


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-31755

In order to better support self-monitoring for ops, add support for a globalkey flag on the jwt that allows the same API Key to be used against any tenant.  This flag is set in the signed Auth0 jwt, and is *only* set for the zaas-ops@zenoss.io/zenoss-com account token.

An example of this code working against two different tenants (with the flag set):

```
$ curl https://qa-long.zenoss.io/cz0/zport/dmd/detailnav_router -H 'content-type: application/json' -H 'accept: */*' --data-binary '[{"action":"DetailNavRouter","method":"getContextMenus","data":[{"uid":"/cz0/zport/dmd/Devices","menuIds":["More","Manage","Edit","Actions","Add","TopLevel"]}],"type":"rpc","tid":8},{"action":"DetailNavRouter","method":"getSecurityPermissions","data":[{"uid":"/cz0/zport/dmd/Devices"}],"type":"rpc","tid":9}]' -H "z-api-key: ${KEY}"
[{"uuid": "81e094ea-9a83-43a6-a21e-f633a265ec8c", "action": "DetailNavRouter", "result": {"menuItems": [{"text": "Add to ZenPack...", "id": "addtozenpack", "viewName": "dialog_addOneToZenPack"}], "success": true}, "tid": 8, "type": "rpc", "method": "getContextMenus"}, {"uuid": "181866ae-7c9f-4748-ad09-08a06a3851ba", "action": "DetailNavRouter", "result": {"data": {"manage global settings": true, "change admin objects": true, "webdav access": true, "manage ldap settings": true, "view software versions": true, "maintenance windows view": true, "maintenance windows edit": true, "define commands edit": true, "update trigger": true, "run commands": true, "manage dmd": true, "view users": true, "search zcatalog": true, "access contents information": true, "manage notification subscriptions": true, "manage ui settings": true, "zproperties edit": true, "edit local templates": true, "admin device": true, "manage control center": true, "manage groups": true, "delete objects": true, "update notification": true, "delete device": true, "access session data": true, "change device": true, "access transient objects": true, "add dmd objects": true, "manage impact settings": true, "add portal member": true, "edit users": true, "manage events": true, "manage users": true, "send events": true, "zencommon": true, "change settings": true, "use database methods": true, "zproperties view": true, "administrators edit": true, "manage zenpacks": true, "view licensing": true, "mail forgotten password": true, "manage global commands": true, "copy or move": true, "view trigger": true, "manage eventmanager": true, "manage device": true, "manage trigger": true, "change event views": true, "manage event configuration": true, "change alerting rules": true, "administrators view": true, "define commands view": true, "change device production state": true, "view": true}, "success": true}, "tid": 9, "type": "rpc", "method": "getSecurityPermissions"}]

$ curl https://rp.zenoss.io/cz0/zport/dmd/detailnav_router -H 'content-type: application/json' -H 'accept: */*' --data-binary '[{"action":"DetailNavRouter","method":"getContextMenus","data":[{"uid":"/cz0/zport/dmd/Devices","menuIds":["More","Manage","Edit","Actions","Add","TopLevel"]}],"type":"rpc","tid":8},{"action":"DetailNavRouter","method":"getSecurityPermissions","data":[{"uid":"/cz0/zport/dmd/Devices"}],"type":"rpc","tid":9}]' -H "z-api-key: ${KEY}"
[{"uuid": "9ddaf714-75e5-44bf-b508-4232f454febf", "action": "DetailNavRouter", "result": {"menuItems": [{"text": "Add to ZenPack...", "id": "addtozenpack", "viewName": "dialog_addOneToZenPack"}], "success": true}, "tid": 8, "type": "rpc", "method": "getContextMenus"}, {"uuid": "8bc13a60-da8f-4fa9-9fa8-663fd7f2de5d", "action": "DetailNavRouter", "result": {"data": {"manage global settings": true, "change admin objects": true, "webdav access": true, "manage ldap settings": true, "view software versions": true, "maintenance windows view": true, "maintenance windows edit": true, "define commands edit": true, "update trigger": true, "run commands": true, "manage dmd": true, "view users": true, "search zcatalog": true, "access contents information": true, "manage notification subscriptions": true, "manage ui settings": true, "zproperties edit": true, "edit local templates": true, "admin device": true, "manage control center": true, "manage groups": true, "delete objects": true, "update notification": true, "delete device": true, "access session data": true, "change device": true, "access transient objects": true, "add dmd objects": true, "manage impact settings": true, "add portal member": true, "edit users": true, "manage events": true, "manage users": true, "send events": true, "zencommon": true, "change settings": true, "use database methods": true, "zproperties view": true, "administrators edit": true, "manage zenpacks": true, "view licensing": true, "mail forgotten password": true, "manage global commands": true, "copy or move": true, "view trigger": true, "manage eventmanager": true, "manage device": true, "manage trigger": true, "change event views": true, "manage event configuration": true, "change alerting rules": true, "administrators view": true, "define commands view": true, "change device production state": true, "view": true}, "success": true}, "tid": 9, "type": "rpc", "method": "getSecurityPermissions"}]

```