### PR TITLE
Resource in Event Console Detail window is displaying the HTML

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventDetail.js
@@ -371,7 +371,7 @@ Ext.onReady(function() {
                             sourceData.device_url,
                             sourceData.device_title);
                     }
-                    return Ext.htmlEncode(val);
+                    return val;
                 },
                 component: function(value, sourceData) {
                     var val = Ext.htmlEncode(sourceData.component_title);


### PR DESCRIPTION
Seems like we already encode HTML tags in the `device` field using Ext.htmlEncode method, but we need to always show links and have it clickable so, I just removed that method