### PR TITLE
Make RemoteException a subclass of pb.Error.

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -68,16 +68,29 @@ LIMITS={
 }
 
 
-class RemoteException(Exception, pb.Copyable, pb.RemoteCopy):
+class RemoteException(pb.Error, pb.Copyable, pb.RemoteCopy):
     """Exception that can cross the PB barrier"""
 
     def __init__(self, msg, tb):
-        Exception.__init__(self, msg)
+        super(RemoteException, self).__init__(msg)
         self.traceback = tb
 
+    def getStateToCopy(self):
+        return {
+            "args": tuple(self.args),
+            "traceback": self.traceback,
+        }
+
+    def setCopyableState(self, state):
+        self.args = state["args"]
+        self.traceback = state["traceback"]
+
     def __str__(self):
-        return "%s: %s" % (
-            Exception.__str__(self), self.traceback or '<no traceback>')
+        return "%s:%s" % (
+            super(RemoteException, self).__str__(),
+            ("\n" + self.traceback) if self.traceback else " <no traceback>",
+        )
+
 
 pb.setUnjellyableForClass(RemoteException, RemoteException)
 


### PR DESCRIPTION
This change will allow RemoteException objects to be sent to the client without being written to zenhub's log.

Fixes ZEN-31786.