### PR TITLE
Reverted legacy metric configuration.

### DIFF
--- a/Products/ZenHub/server/configure.zcml
+++ b/Products/ZenHub/server/configure.zcml
@@ -18,5 +18,6 @@
 
    <subscriber handler=".metrics.incrementLegacyMetricCounters"/>
    <subscriber handler=".metrics.decrementLegacyMetricCounters"/>
+   <subscriber handler=".metrics.markEventsSent"/>
 
 </configure>


### PR DESCRIPTION
* Restored the legacy zenhub worklists to Metrology gauge types
* Re-added the dropped zenhub eventsSent Metrology meter.

Fixes ZEN-31977.