### PR TITLE
zencommand (SSH): 'CommandChannel instance has no attribute stderr' t…

### DIFF
--- a/Products/DataCollector/SshClient.py
+++ b/Products/DataCollector/SshClient.py
@@ -584,6 +584,7 @@ class CommandChannel(channel.SSHChannel):
         channel.SSHChannel.__init__(self, conn=conn)
         self.command = command
         self.exitCode = None
+        self.stderr = None
 
     @property
     def targetIp(self):

--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -578,6 +578,11 @@ class SshPerformanceCollectionTask(BaseTask):
         @parameter results: empty results object
         @type results: ParsedResults object
         """
+        if datasource.result.output is None :
+            datasource.result.output = ''
+        if datasource.result.stderr is None:
+            datasource.result.stderr = ''
+
         exitCode = datasource.result.exitCode
         output = datasource.result.output.strip()
         stderr = datasource.result.stderr.strip()


### PR DESCRIPTION
…raceback causes missed runs