### PR TITLE
Drop network releationship on deleted devices.

### DIFF
--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -641,7 +641,17 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
             self._setObject(ip_id, new_net)
             new_net = self._getOb(ip_id)
             netobj = aq_base(netobj)
+            log.info(
+                "Adding %s as supernet of %s",
+                new_net.getNetworkName(), netobj.getNetworkName(),
+            )
             new_net._setObject(ip_id, netobj)
+            ips = filter(
+                lambda n: isinstance(n, IpAddress) and n.interface(),
+                netobj.getSubObjects(),
+            )
+            for i in ips:
+                i.interface().ipaddresses._setObject(i.id, i)
 
         return self.getSubNetwork(ip)
 


### PR DESCRIPTION
Fixes ZEN-32287.

Adapted from https://github.com/zenoss/zenoss-prodbin/pull/3438.