### PR TITLE
Resolves ZEN-32153 by changing the task state from completed to idle …

### DIFF
--- a/Products/ZenEvents/zenpop3.py
+++ b/Products/ZenEvents/zenpop3.py
@@ -292,8 +292,7 @@ class MailCollectingTask(BaseTask):
                 message=message,
             ))
             
-            # Force the task to quit
-            self.state = TaskStates.STATE_COMPLETED
+            self.state = TaskStates.STATE_IDLE
 
         log.error(message)
         return defer.succeed(message)


### PR DESCRIPTION
Resolves ZEN-32153 by changing the task state from completed to idle when an error is encountered. The task will run again at its next schedule interval time. The old behavior was to encounter an error (task marked as completed), and then never run the task again.