### PR TITLE
Give device config calls a lower priority.

### DIFF
--- a/Products/ZenHub/server/config.py
+++ b/Products/ZenHub/server/config.py
@@ -98,6 +98,7 @@ priorities = {
         "EVENTS",
         "SINGLE_MODELING",
         "OTHER",
+        "CONFIG",
         "MODELING",
     ),
 
@@ -108,6 +109,8 @@ priorities = {
         "EventService:sendEvents": "EVENTS",
         "*:singleApplyDataMaps": "SINGLE_MODELING",
         "*:*": "OTHER",
+        "*:getDeviceConfigs": "CONFIG",
+        "*:getDeviceConfig": "CONFIG",
         "*:applyDataMaps": "MODELING",
     },
 

--- a/Products/ZenHub/server/executors/event.py
+++ b/Products/ZenHub/server/executors/event.py
@@ -30,6 +30,15 @@ class SendEventExecutor(object):
     and sendEvents tasks directly on a MySqlEventManager instance.
     """
 
+    @classmethod
+    def create(cls, name, **ignored):
+        """Return a new executor instance.
+
+        :param str name: The executor's name
+        :return: A new SendEventExecutor instance.
+        """
+        return cls(name)
+
     def __init__(self, name):
         """Initialize an SendEventExecutor instance.
 

--- a/Products/ZenHub/server/executors/tests/test_event.py
+++ b/Products/ZenHub/server/executors/tests/test_event.py
@@ -48,6 +48,11 @@ class SendEventExecutorTest(TestCase):
         self.name = "event"
         self.executor = SendEventExecutor(self.name)
 
+    def test_create(self):
+        result = SendEventExecutor.create("test")
+        self.assertIsInstance(result, SendEventExecutor)
+        self.assertEqual(result.name, "test")
+
     def test_initialization(self):
         self.getUtility.assert_called_once_with(IDataRootFactory)
         self.assertEqual(self.name, self.executor.name)

--- a/Products/ZenHub/server/tests/test_main.py
+++ b/Products/ZenHub/server/tests/test_main.py
@@ -9,7 +9,7 @@
 
 from __future__ import absolute_import
 
-from mock import call, MagicMock, Mock, NonCallableMock, patch
+from mock import call, Mock, NonCallableMock, patch
 from twisted.internet import defer
 from unittest import TestCase
 
@@ -117,11 +117,7 @@ class MakeServiceManagerTest(TestCase):
         _getUtility.assert_called_once_with(IHubServerConfig)
         _ServiceRegistry.assert_called_once_with()
         _ServiceCallRouter.from_config.assert_called_once_with(config.routes)
-        _make_executors.assert_called_once_with(
-            config.executors, pools,
-            config.priorities["modeling"],
-            config.modeling_pause_timeout,
-        )
+        _make_executors.assert_called_once_with(config, pools)
         _ServiceLoader.assert_called_once_with()
         _ServiceReferenceFactory.assert_called_once_with(
             WorkerInterceptor,

--- a/Products/ZenHub/server/tests/test_priority.py
+++ b/Products/ZenHub/server/tests/test_priority.py
@@ -276,7 +276,7 @@ class ConfiguredPrioritiesTest(TestCase):
     """Test the ServiceCallPriority enumeration."""
 
     def test_has_required_priority_names(self):
-        expected = {"OTHER", "EVENTS", "SINGLE_MODELING", "MODELING"}
+        expected = {"OTHER", "EVENTS", "SINGLE_MODELING", "MODELING", "CONFIG"}
         actual = {p.name for p in ServiceCallPriority}
         self.assertSetEqual(actual, expected)
 
@@ -285,6 +285,7 @@ class ConfiguredPrioritiesTest(TestCase):
             ServiceCallPriority.EVENTS,
             ServiceCallPriority.SINGLE_MODELING,
             ServiceCallPriority.OTHER,
+            ServiceCallPriority.CONFIG,
             ServiceCallPriority.MODELING,
         ]
         actual = sorted(ServiceCallPriority)
@@ -304,6 +305,10 @@ class ConfiguredServiceCallPriorityMapTest(TestCase):
                 ServiceCallPriority.SINGLE_MODELING,
             ("Package.ServiceOne", "doThis"): ServiceCallPriority.OTHER,
             ("Package.ServiceTwo", "doThat"): ServiceCallPriority.OTHER,
+            ("Package.ServiceOne", "getDeviceConfigs"):
+                ServiceCallPriority.CONFIG,
+            ("Package.ServiceOne", "getDeviceConfig"):
+                ServiceCallPriority.CONFIG,
         }
         for mesg, expected in expected_mapping.iteritems():
             actual = servicecall_priority_map.get(mesg)
@@ -313,3 +318,7 @@ class ConfiguredServiceCallPriorityMapTest(TestCase):
                     mesg, expected.name, actual.name,
                 ),
             )
+        # Catch to ensure this test is updated for new priorities
+        available = set(ServiceCallPriority)
+        used = set(expected_mapping.values())
+        self.assertSetEqual(available - used, set())

--- a/Products/ZenModel/migrate/tests/test_common.py
+++ b/Products/ZenModel/migrate/tests/test_common.py
@@ -14,103 +14,134 @@ Tests for the testing harness
 import unittest
 
 from common import compare
+
+
 class test_compare_string(unittest.TestCase):
     def test_None(self):
         s1 = "foo"
         s2 = None
-        expected = (False, [], compare.Diff(s1, s2))
-        self.assertEqual(expected, compare(s1, s2))
+        expected = ([], compare.Diff(s1, s2))
+        self.assertEqual(expected, tuple(compare(s1, s2))[0])
 
     def test_same(self):
         s1 = "foo"
         s2 = "foo"
-        expected = (True, None, None)
-        self.assertEqual(expected, compare(s1, s2))
+        expected = ()
+        self.assertEqual(expected, tuple(compare(s1, s2)))
 
     def test_diff(self):
         s1 = "foo"
         s2 = "bar"
-        expected = (False, [], compare.Diff(s1, s2))
-        self.assertEqual(expected, compare(s1, s2))
+        expected = ([], compare.Diff(s1, s2))
+        self.assertEqual(expected, tuple(compare(s1, s2))[0])
 
     def test_multiline_same(self):
         s1 = "foo\nbar\nbaz\n"
         s2 = "foo\nbar\nbaz\n"
-        expected = (True, None, None)
-        self.assertEqual(expected, compare(s1, s2))
+        expected = ()
+        self.assertEqual(expected, tuple(compare(s1, s2)))
 
     def test_multiline_diff(self):
         s1 = "foo\nbar\nbaz\n"
         s2 = "foo\nBAR\nbaz\n"
-        expected = (False, [], None)
-        actual = compare(s1, s2)
-        diff = '\n'.join(actual[-1])
+        expected = ([], None)
+        actual = tuple(compare(s1, s2))[0]
+        diff = "\n".join(actual[-1])
         self.assertEqual(expected[:-1], actual[:-1])
-        self.assertIn('-bar', diff)
-        self.assertIn('+BAR', diff)
+        self.assertIn("-bar", diff)
+        self.assertIn("+BAR", diff)
 
 
 class test_compare_dict(unittest.TestCase):
     def test_none(self):
-        d1 = {"a":1, "b":2}
+        d1 = {"a": 1, "b": 2}
         d2 = None
-        expected = (False, [], compare.Diff(d1, d2))
-        self.assertEqual(expected, compare(d1, d2))
+        expected = ([], compare.Diff(d1, d2))
+        self.assertEqual(expected, tuple(compare(d1, d2))[0])
 
     def test_same(self):
-        d1 = {"a":1, "b":2}
-        d2 = {"a":1, "b":2}
-        expected = (True, None, None)
-        self.assertEqual(expected, compare(d1, d2))
+        d1 = {"a": 1, "b": 2}
+        d2 = {"a": 1, "b": 2}
+        expected = ()
+        self.assertEqual(expected, tuple(compare(d1, d2)))
 
     def test_value(self):
-        d1 = {"a":1, "b":2}
-        d2 = {"a":1, "b":22}
-        expected = (False, ["b"], compare.Diff(d1['b'], d2['b']))
-        self.assertEqual(expected, compare(d1, d2))
+        d1 = {"a": 1, "b": 2}
+        d2 = {"a": 1, "b": 22}
+        expected = (
+            (["b"], compare.Diff(d1["b"], d2["b"])),
+        )
+        actual = tuple(compare(d1, d2))
+        self.assertEqual(expected, actual)
 
     def test_size(self):
-        d1 = {"a":1, "b":2}
-        d2 = {"a":1, "b":2, "c":3}
-        expected = (False, ['c'], compare.Diff(compare.missingKey, d2['c']))
-        self.assertEqual(expected, compare(d1, d2))
+        d1 = {"a": 1, "b": 2}
+        d2 = {"a": 1, "b": 2, "c": 3}
+        expected = (
+            (["c"], compare.Diff(compare.missingKey, d2["c"])),
+        )
+        actual = tuple(compare(d1, d2))
+        self.assertEqual(expected, actual)
 
     def test_case_same(self):
         """case insensitive keys, use value of "most-lowercase" key"""
         d1 = dict(AA=1, Aa=2, aA=3, aa=4, bB=6, BB=7)
         d2 = dict(Aa=4, BB=6)
-        expected = (True, None, None)
-        self.assertEqual(expected, compare(d1, d2))
+        expected = ()
+        self.assertEqual(expected, tuple(compare(d1, d2)))
 
     def test_case_diff(self):
         """case insensitive keys, use value of "most-lowercase" key"""
         d1 = dict(AA=1, Aa=2, aA=3, aa=22, bB=6, BB=7)
         d2 = dict(Aa=4, BB=6)
-        expected = (False, ['aa'], compare.Diff(d1['aa'], d2['Aa']))
-        self.assertEqual(expected, compare(d1, d2))
+        expected = (["aa"], compare.Diff(d1["aa"], d2["Aa"]))
+        self.assertEqual(expected, tuple(compare(d1, d2))[0])
+
+    def test_multiple_diffs(self):
+        d1 = {"a": 1, "b": 2, "c": 3, "d": 4}
+        d2 = {"a": 1, "b": 22, "c": 3, "d": 44, "e": 5}
+        expected = (
+            (["b"], compare.Diff(d1["b"], d2["b"])),
+            (["d"], compare.Diff(d1["d"], d2["d"])),
+            (["e"], compare.Diff(compare.missingKey, d2["e"])),
+        )
+        actual = tuple(compare(d1, d2))
+        self.assertEqual(expected, actual)
 
 
 class test_compare_list(unittest.TestCase):
     def test_same(self):
-        l1 = [1,2,3]
-        l2 = [1,2,3]
-        expected = (True, None, None)
-        self.assertEqual(expected, compare(l1, l2))
+        l1 = [1, 2, 3]
+        l2 = [1, 2, 3]
+        expected = ()
+        self.assertEqual(expected, tuple(compare(l1, l2)))
 
     def test_none(self):
-        l1 = [1,2,3]
+        l1 = [1, 2, 3]
         l2 = None
-        expected = (False, [], compare.Diff(l1, l2))
-        self.assertEqual(expected, compare(l1, l2))
+        expected = ([], compare.Diff(l1, l2))
+        self.assertEqual(expected, tuple(compare(l1, l2))[0])
 
     def test_value(self):
-        l1 = [1,2,3]
-        l2 = [1,22,3]
-        expected = (False, [1], compare.Diff(l1[1], l2[1]))
-        self.assertEqual(expected, compare(l1, l2))
+        l1 = [1, 2, 3]
+        l2 = [1, 22, 3]
+        expected = (
+            ([1], compare.Diff(l1[1], l2[1])),
+        )
+        self.assertEqual(expected, tuple(compare(l1, l2)))
 
     def test_size(self):
-        l1 = [1,2,3]
-        l2 = [1,2]
-        expected = (False, [], compare.Diff(l1, l2))
-        self.assertEqual(expected, compare(l1, l2))
+        l1 = [1, 2, 3]
+        l2 = [1, 2]
+        expected = ([], compare.Diff(l1, l2))
+        actual = tuple(compare(l1, l2))[0]
+        self.assertEqual(expected, actual)
+
+    def test_multiple_diffs(self):
+        l1 = [1, 2, 3, 4, 5]
+        l2 = [1, 22, 3, 44, 5]
+        expected = (
+            ([1], compare.Diff(l1[1], l2[1])),
+            ([3], compare.Diff(l1[3], l2[3])),
+        )
+        self.assertEqual(expected, tuple(compare(l1, l2)))


### PR DESCRIPTION
This PR contains three changes
1. Add a new **CONFIG** priority, set it lower than the existing **OTHER** priority, and assign the `getDeviceConfigs` and `getDeviceConfig` service calls to the **CONFIG** priority.  This will give other service calls to execute without getting having to wait for all the `getDeviceConfigs` calls to complete.  Fixes ZEN-32342.
2. Factory methods have been added to ZenHub service call executors to simplify ZenHub configuration.  With this change, adding new pools and executors will require changing only the `config.py` module.
3. Modified the service migration test to dump all differences between the actual and expected service definitions.  With this change, it is no longer necessary to run the test multiple times to find all the differences.