### PR TITLE
Fix editServicesStartUp migration.

### DIFF
--- a/Products/ZenModel/migrate/editServicesStartUp.py
+++ b/Products/ZenModel/migrate/editServicesStartUp.py
@@ -233,6 +233,9 @@ def _tostring(parser):
 
 
 def _add_supervisord_options(parser, section):
+    if not parser.has_section(section):
+        log.info("Skipping section %s: not found", section)
+        return
     options = OrderedDict(parser.items(section))
     for k, v in _new_supervisord_options:
         if k not in options:
@@ -300,9 +303,10 @@ def _update_metric_consumer_conf(svc):
         _add_supervisord_options(parser, "program:metric-consumer-app")
         _fix_paths(parser, ("metric-consumer-app", "metric-consumer_metrics"))
 
-        section = "program:metric-consumer_metrics"
-        if not parser.has_option(section, "stopwaitsecs"):
-            parser.set(section, "stopwaitsecs", "30")
+        section = "program:metric-consumer-app"
+        if parser.has_section(section):
+            if not parser.has_option(section, "stopwaitsecs"):
+                parser.set(section, "stopwaitsecs", "30")
 
         updated = _tostring(parser).replace(" = ", "=")
 

--- a/Products/ZenModel/migrate/tests/zenoss-cse-7.0.3-editServicesStartUp.json
+++ b/Products/ZenModel/migrate/tests/zenoss-cse-7.0.3-editServicesStartUp.json
@@ -22054,7 +22054,7 @@
         "Filename": "/opt/zenoss/etc/metric-consumer-app/metric-consumer-app_supervisor.conf",
         "Owner": "zenoss:zenoss",
         "Permissions": "0644",
-        "Content": "[program:metric-consumer-app]\ncommand=/opt/zenoss/bin/metric-consumer-app.sh\nautorestart=true\nautostart=true\nstartsecs=5\nenvironment=JVM_ARGS=\"-Xmx{{bytesToMB .RAMCommitment}}m\"\ndirectory=/opt/zenoss\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n\n[program:metric-consumer_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/jvmstats.py\nautorestart=true\nautostart=true\nstartsecs=5\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\nstopwaitsecs=30\n\n"
+        "Content": "[program:metric-consumer-app]\ncommand=/opt/zenoss/bin/metric-consumer-app.sh\nautorestart=true\nautostart=true\nstartsecs=5\nenvironment=JVM_ARGS=\"-Xmx{{bytesToMB .RAMCommitment}}m\"\ndirectory=/opt/zenoss\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\nstopwaitsecs=30\n\n[program:metric-consumer_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/jvmstats.py\nautorestart=true\nautostart=true\nstartsecs=5\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n\n"
       }
     },
     "ConfigFiles": {
@@ -22068,7 +22068,7 @@
         "Filename": "/opt/zenoss/etc/metric-consumer-app/metric-consumer-app_supervisor.conf",
         "Owner": "zenoss:zenoss",
         "Permissions": "0644",
-        "Content": "[program:metric-consumer-app]\ncommand=/opt/zenoss/bin/metric-consumer-app.sh\nautorestart=true\nautostart=true\nstartsecs=5\nenvironment=JVM_ARGS=\"-Xmx{{bytesToMB .RAMCommitment}}m\"\ndirectory=/opt/zenoss\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n\n[program:metric-consumer_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/jvmstats.py\nautorestart=true\nautostart=true\nstartsecs=5\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\nstopwaitsecs=30\n\n"
+        "Content": "[program:metric-consumer-app]\ncommand=/opt/zenoss/bin/metric-consumer-app.sh\nautorestart=true\nautostart=true\nstartsecs=5\nenvironment=JVM_ARGS=\"-Xmx{{bytesToMB .RAMCommitment}}m\"\ndirectory=/opt/zenoss\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\nstopwaitsecs=30\n\n[program:metric-consumer_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/jvmstats.py\nautorestart=true\nautostart=true\nstartsecs=5\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=2\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n\n"
       }
     },
     "Instances": 1,


### PR DESCRIPTION
* Add stopwaitsecs to the correct section of the supervisord config file
* Make the migration more resilient to missing data

Fixes ZEN-32453.