### PR TITLE
ZEN-32520: Restore autoscrolling for transforms

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
@@ -767,6 +767,7 @@ Ext.onReady(function(){
     Ext.define('Zenoss.eventclass.XformMasterPanel', {
         extend: 'Ext.panel.Panel',
         alias: 'widget.xformmasterpanel',
+        autoScroll: true,
         initComponent: function() {
             this.callParent(arguments);
         },


### PR DESCRIPTION
autoScroll was added to XformMasterPanel to fix ZEN-31741, but then
appears to have be accidentally reverted when the fix for ZEN-30800 was
cherry-picked to fix ZEN-32012.

This change fixes that accident.