### PR TITLE
Resolves ZEN-32558 by changing the task state from completed to idle …

### DIFF
--- a/Products/ZenEvents/zenpop3.py
+++ b/Products/ZenEvents/zenpop3.py
@@ -292,8 +292,7 @@ class MailCollectingTask(BaseTask):
                 message=message,
             ))
             
-            # Force the task to quit
-            self.state = TaskStates.STATE_COMPLETED
+            self.state = TaskStates.STATE_IDLE
 
         log.error(message)
         return defer.succeed(message)


### PR DESCRIPTION
…when an error is encountered.

The task will run again at its next schedule interval time, rather than completing and never running again.

(cherry picked from commit dde170698c1362ca42f7177ce59a9096159085f2)
Signed-off-by: Roman Bakaleyko <roman.bakaleyko@gmail.com>