### PR TITLE
Fixes ZEN-30428

### DIFF
--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -195,6 +195,37 @@ class MaintenanceWindow(ZenModelRM):
             return self.occurrence + ' ' + self.days + ' of the month'
         return self.repeat
 
+    @staticmethod
+    def durationStringParser(duration_string):
+        parsed_duration = {}
+        if 'days' not in duration_string:
+            hours_minutes_seconds = duration_string.split(':')
+            if len(hours_minutes_seconds) == 3:
+                parsed_duration.update({
+                    'hours': str(hours_minutes_seconds[0]),
+                    'minutes': str(hours_minutes_seconds[1]),
+                    'seconds': str(hours_minutes_seconds[2])
+                })
+            elif len(hours_minutes_seconds) == 2:
+                parsed_duration.update({
+                    'minutes': str(hours_minutes_seconds[0]),
+                    'seconds': str(hours_minutes_seconds[1])
+                })
+            elif len(hours_minutes_seconds) == 1:
+                parsed_duration.update({
+                    'seconds': str(hours_minutes_seconds[0])
+                })
+        else:
+            days_hours_minutes = duration_string.split(' days ')
+            hours_minutes_seconds = days_hours_minutes[1].split(':')
+            parsed_duration.update({
+                'days': str(days_hours_minutes[0]),
+                'hours': str(hours_minutes_seconds[0]),
+                'minutes': str(hours_minutes_seconds[1]),
+                'seconds': str(hours_minutes_seconds[2])
+            })
+        return parsed_duration
+
     security.declareProtected(ZEN_MAINTENANCE_WINDOW_EDIT,
                               'manage_editMaintenanceWindow')
     def manage_editMaintenanceWindow(self,

--- a/Products/Zuul/routers/devicemanagement.py
+++ b/Products/Zuul/routers/devicemanagement.py
@@ -15,6 +15,7 @@ from Products import Zuul
 from Products.Zuul.decorators import require, serviceConnectionError
 from Products.ZenUtils.Ext import DirectRouter
 from Products.ZenUtils import Time
+from Products.ZenMessaging.audit import audit
 
 class DeviceManagementRouter(DirectRouter): 
     """
@@ -33,6 +34,7 @@ class DeviceManagementRouter(DirectRouter):
         """    
         facade = self._getFacade()
         facade.addMaintWindow(params)
+        audit('UI.MaintenanceWindow.Add', params['name'])
         return DirectResponse.succeed(msg="Maintenance Window %s added successfully." % (params['name']))    
             
     def deleteMaintWindow(self, uid, id):
@@ -41,6 +43,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.deleteMaintWindow(uid, id)
+        audit('UI.MaintenanceWindow.Delete', id)
         return DirectResponse.succeed(data=Zuul.marshal(data))           
 
     def getTimeZone(self):
@@ -72,6 +75,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.editMaintWindow(params)
+        audit('UI.MaintenanceWindow.Edit', params['id'])
         return DirectResponse( data=Zuul.marshal(data) ) 
         
 # ---------------------------------------------------- User Commands:       
@@ -98,6 +102,7 @@ class DeviceManagementRouter(DirectRouter):
         facade = self._getFacade()
         facade.addUserCommand(params)
         #work in password and not just succeed()
+        audit('UI.UserCommand.Add', params['name'])
         return DirectResponse.succeed()
         
     @require('Define Commands Edit')
@@ -107,6 +112,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.deleteUserCommand(uid, id)
+        audit('UI.UserCommand.Delete', id)
         return DirectResponse.succeed(data=Zuul.marshal(data))         
 
     @require('Define Commands Edit')
@@ -116,7 +122,8 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.updateUserCommand(params)
-        #work in password and not just succeed()        
+        #work in password and not just succeed() 
+        audit('UI.UserCommand.Edit', params['id'])
         return DirectResponse.succeed()
         
 # ---------------------------------------------------- Admin Roles:    
@@ -163,6 +170,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.addAdminRole(params)
+        audit('UI.AdminRole.Add', params['name'])
         return DirectResponse.succeed(msg="New Administrator added successfully.")
         
     def updateAdminRole(self, params):
@@ -171,6 +179,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.updateAdminRole(params)
+        audit('UI.AdminRole.Update', params['name'])
         return DirectResponse.succeed()   
         
     def removeAdmin(self, uid, id):
@@ -179,6 +188,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.removeAdmin(uid, id)
+        audit('UI.AdminRole.Delete', id)
         return DirectResponse.succeed()         
         
    

--- a/Products/Zuul/routers/devicemanagement.py
+++ b/Products/Zuul/routers/devicemanagement.py
@@ -34,7 +34,7 @@ class DeviceManagementRouter(DirectRouter):
         """    
         facade = self._getFacade()
         facade.addMaintWindow(params)
-        audit('UI.MaintenanceWindow.Add', params['name'])
+        audit('UI.MaintenanceWindow.Add', params['uid'] + '/' + params['name'], data_=params)
         return DirectResponse.succeed(msg="Maintenance Window %s added successfully." % (params['name']))    
             
     def deleteMaintWindow(self, uid, id):
@@ -43,7 +43,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.deleteMaintWindow(uid, id)
-        audit('UI.MaintenanceWindow.Delete', id)
+        audit('UI.MaintenanceWindow.Delete', uid + '/' + id)
         return DirectResponse.succeed(data=Zuul.marshal(data))           
 
     def getTimeZone(self):
@@ -75,7 +75,6 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.editMaintWindow(params)
-        audit('UI.MaintenanceWindow.Edit', params['id'])
         return DirectResponse( data=Zuul.marshal(data) ) 
         
 # ---------------------------------------------------- User Commands:       
@@ -102,7 +101,7 @@ class DeviceManagementRouter(DirectRouter):
         facade = self._getFacade()
         facade.addUserCommand(params)
         #work in password and not just succeed()
-        audit('UI.UserCommand.Add', params['name'])
+        audit('UI.UserCommand.Add', params['name'], data_=params)
         return DirectResponse.succeed()
         
     @require('Define Commands Edit')
@@ -112,7 +111,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         data = facade.deleteUserCommand(uid, id)
-        audit('UI.UserCommand.Delete', id)
+        audit('UI.UserCommand.Delete', uid + '/' + id)
         return DirectResponse.succeed(data=Zuul.marshal(data))         
 
     @require('Define Commands Edit')
@@ -123,7 +122,7 @@ class DeviceManagementRouter(DirectRouter):
         facade = self._getFacade()
         facade.updateUserCommand(params)
         #work in password and not just succeed() 
-        audit('UI.UserCommand.Edit', params['id'])
+        audit('UI.UserCommand.Edit', params['uid'] + '/' + params['id'])
         return DirectResponse.succeed()
         
 # ---------------------------------------------------- Admin Roles:    
@@ -170,7 +169,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.addAdminRole(params)
-        audit('UI.AdminRole.Add', params['name'])
+        audit('UI.AdminRole.Add', params['uid'] + '/' + params['name'])
         return DirectResponse.succeed(msg="New Administrator added successfully.")
         
     def updateAdminRole(self, params):
@@ -179,7 +178,7 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.updateAdminRole(params)
-        audit('UI.AdminRole.Update', params['name'])
+        audit('UI.AdminRole.Update', params['uid'] + '/' + params['name'])
         return DirectResponse.succeed()   
         
     def removeAdmin(self, uid, id):
@@ -188,10 +187,5 @@ class DeviceManagementRouter(DirectRouter):
         """
         facade = self._getFacade()
         facade.removeAdmin(uid, id)
-        audit('UI.AdminRole.Delete', id)
-        return DirectResponse.succeed()         
-        
-   
-
-
-       
+        audit('UI.AdminRole.Delete', uid + '/' + id)
+        return DirectResponse.succeed()


### PR DESCRIPTION
Add audit logging to the devicemanagement router. Most complaints were around the lack of audit logging for Maintenance Window actions, however we were missing audit logging for User Command and Role assignments as well, this adds logging for all of those actions.