### PR TITLE
ZEN-32560: (backport) Fix model in UI if device id has spaces

### DIFF
--- a/Products/ZenModel/PerformanceConf.py
+++ b/Products/ZenModel/PerformanceConf.py
@@ -582,7 +582,7 @@ class PerformanceConf(Monitor, StatusColor):
         cmd = [zm]
         deviceName = self._escapeParentheses(deviceName)
         options = [
-            'run', '--now', '-d', deviceName, '--monitor', performanceMonitor,
+            'run', '--now', '-d', '"{}"'.format(deviceName), '--monitor', performanceMonitor,
             '--collect={}'.format(collectPlugins)
         ]
         cmd.extend(options)


### PR DESCRIPTION
If your device id has spaces, you can't model from the UI.
The action appears to only use the characters up to the
first space when modeling.

Fixes ZEN-32560