### PR TITLE
Handle DeadReferenceError from zenhubworker.

### DIFF
--- a/Products/ZenHub/server/avatar.py
+++ b/Products/ZenHub/server/avatar.py
@@ -85,7 +85,6 @@ class HubAvatar(pb.Avatar):
         :param str worklistId: The worker will work jobs from this worklist
         :rtype: None
         """
-        worker.busy = False
         worker.workerId = workerId
         worker.sessionId = uuid4()
         pool = self.__pools.get(worklistId)

--- a/Products/ZenHub/server/tests/test_avatar.py
+++ b/Products/ZenHub/server/tests/test_avatar.py
@@ -108,8 +108,7 @@ class HubAvatarTest(TestCase):
 
     def test_perspective_reportingForWork_nominal(self):
         worker = Mock(spec_set=[
-            "workerId", "sessionId", "queue_name",
-            "busy", "notifyOnDisconnect",
+            "workerId", "sessionId", "queue_name", "notifyOnDisconnect",
         ])
         workerId = "default-1"
 
@@ -122,8 +121,6 @@ class HubAvatarTest(TestCase):
 
         # Add the worker
         self.avatar.perspective_reportingForWork(worker, workerId, "foo")
-        self.assertTrue(hasattr(worker, "busy"))
-        self.assertFalse(worker.busy)
         self.assertTrue(hasattr(worker, "sessionId"))
         self.assertIsNotNone(worker.sessionId)
         self.assertTrue(hasattr(worker, "workerId"))


### PR DESCRIPTION
Also simplify workerpool's logic to rely on just the worker reference's sessionId value.

Fixes ZEN-32620.