### PR TITLE
ZEN-31546 Change name of metrics in storagestats.py

### DIFF
--- a/bin/metrics/storagestats.py
+++ b/bin/metrics/storagestats.py
@@ -53,12 +53,12 @@ class StorageMetricGatherer(MetricGatherer):
                 continue
             parsed = line.split('\t')
             table, size, free = parsed[0], parsed[1], parsed[2]
-            table_size = 'zenoss.%s.%s.size' % (self.name, table)
-            table_free = 'zenoss.%s.%s.free' % (self.name, table)
+            table_size = 'zenoss.mariadb.%s.%s.size' % (self.name, table)
+            table_free = 'zenoss.mariadb.%s.%s.free' % (self.name, table)
             total_size += int(size)
             metrics.append(self.build_metric(table_size, size, ts, tags))
             metrics.append(self.build_metric(table_free, free, ts, tags))
-        metrics.append(self.build_metric('zenoss.%s.total.size' % self.name, total_size, ts, tags))
+        metrics.append(self.build_metric('zenoss.mariadb.%s.total.size' % self.name, total_size, ts, tags))
         return metrics
 
 


### PR DESCRIPTION
Related to https://github.com/zenoss/ZenPacks.zenoss.RMMonitor/pull/181