### PR TITLE
Add the zen_schema_tags metadata to the ZING data maps

### DIFF
--- a/Products/Zing/datamaps.py
+++ b/Products/Zing/datamaps.py
@@ -317,13 +317,12 @@ class ZingDatamapHandler(object):
         f.metadata[ZFact.DimensionKeys.META_TYPE_KEY] = om_context.meta_type
         f.data[ZFact.MetadataKeys.NAME_KEY] = om_context.name
 
-        if om_context.is_device:
+        if om_context.is_device_component:
+            f.data[ZFact.MetadataKeys.ZEN_SCHEMA_TAGS_KEY] = "DeviceComponent"
+        elif om_context.is_device:
             f.data[ZFact.MetadataKeys.ZEN_SCHEMA_TAGS_KEY] = "Device"
             if om_context.mem_capacity is not None:
                 f.data[ZFact.MetadataKeys.MEM_CAPACITY_KEY] = om_context.mem_capacity
-
-        if om_context.is_device_component:
-            f.data[ZFact.MetadataKeys.ZEN_SCHEMA_TAGS_KEY] = "DeviceComponent"
 
         if om_context.dimensions:
             f.metadata.update(om_context.dimensions)

--- a/Products/Zing/datamaps.py
+++ b/Products/Zing/datamaps.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2018-2020, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -51,6 +51,7 @@ class ObjectMapContext(object):
         self.name = None
         self.mem_capacity = None
         self.is_device = False
+        self.is_device_component = False
         self.dimensions = {}
         self.metadata = {}
         self._extract_relevant_fields(obj)
@@ -77,6 +78,10 @@ class ObjectMapContext(object):
                 self.mem_capacity = obj.hw.totalMemory
             except Exception:
                 pass
+
+        from Products.ZenModel.DeviceComponent import DeviceComponent
+        if isinstance(obj, DeviceComponent):
+            self.is_device_component = True
 
         # Get extra context from IObjectMapContextProvider adapters.
         for provider in subscribers([obj], IObjectMapContextProvider):
@@ -313,8 +318,12 @@ class ZingDatamapHandler(object):
         f.data[ZFact.MetadataKeys.NAME_KEY] = om_context.name
 
         if om_context.is_device:
+            f.data[ZFact.MetadataKeys.ZEN_SCHEMA_TAGS_KEY] = "Device"
             if om_context.mem_capacity is not None:
                 f.data[ZFact.MetadataKeys.MEM_CAPACITY_KEY] = om_context.mem_capacity
+
+        if om_context.is_device_component:
+            f.data[ZFact.MetadataKeys.ZEN_SCHEMA_TAGS_KEY] = "DeviceComponent"
 
         if om_context.dimensions:
             f.metadata.update(om_context.dimensions)

--- a/Products/Zing/fact.py
+++ b/Products/Zing/fact.py
@@ -1,10 +1,10 @@
 ##############################################################################
-# 
-# Copyright (C) Zenoss, Inc. 2018, all rights reserved.
-# 
+#
+# Copyright (C) Zenoss, Inc. 2018-2020, all rights reserved.
+#
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
-# 
+#
 ##############################################################################
 
 from .shortid import shortid
@@ -46,6 +46,7 @@ class MetadataKeys(object):
     COMPONENT_GROUPS_KEY = "component_groups"
     IMPACT_DS_ORG_KEY = "impact_ds_organizer"
     IMPACT_DS_IMPACTERS_KEY = "dynamic_service_impacters"
+    ZEN_SCHEMA_TAGS_KEY = "zen_schema_tags"
 
 class Fact(object):
     def __init__(self, f_id=None):

--- a/Products/Zing/tests/test_datamaps.py
+++ b/Products/Zing/tests/test_datamaps.py
@@ -310,6 +310,7 @@ class TestZingDatamapHandler(TestCase):
                 'metadata4': {'key3': 'omcp1 value4', 'key4': 'omcp2 value4'},
                 'metadata5': 'omcp1 value5',
                 'metadata6': 'omcp2 value6',
+                'zen_schema_tags': 'Device',
             },
             facts[0].data,
         )


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-8700

In order to properly type devices and device components, we're adding a new metadata field to the ZING entities for devices and device components.  This tag will be used to add additional schemas to the entities in model-id.