### PR TITLE
ZEN-32634 Changed this.eachColumn in BaseGrid.js (isValid func) into …

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/BaseGrid.js
@@ -384,7 +384,7 @@
          **/
         isValid: function () {
             var isValid = true;
-            this.eachColumn(function (col) {
+            this.eachFilterColumn(function (col) {
                 if (col.filterField.isValid) {
                     isValid = isValid && col.filterField.isValid();
                 }


### PR DESCRIPTION
…this.eachFilterColumn

This change fixes the problem which leads to inability to view Impact UI.
col.filterField.isValid was failing because col.filterField was undefined. Using of this.eachFilterColumn adds check only for filter fields