### PR TITLE
Added filtering for Devices' Monitoring Templates

### DIFF
--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -759,6 +759,19 @@ class DeviceFacade(TreeFacade):
         else:
             rrdTemplates = object.getRRDTemplates()
 
+        def isReplaced(tmpl, tmpls):
+            replacement = tmpl.id + '-replacement'
+            for t in tmpls:
+                if replacement == t.id:
+                    return True
+            return False
+
+        filteredTemplates = []
+        for template in rrdTemplates:
+            if not isReplaced(template, rrdTemplates):
+                filteredTemplates.append(template)
+        rrdTemplates = filteredTemplates
+
         # used to sort the templates
         def byTitleOrId(left, right):
             return cmp(left.titleOrId().lower(), right.titleOrId().lower())


### PR DESCRIPTION
Devices displayed all Monitoring templates, included replaced templates which should be hidden.  This corrects the device view list by hiding templates replaced by "-replacement" as defined in zenpack documentation. 
fix for https://jira.zenoss.com/browse/ZEN-32704
