### PR TITLE
ZEN-32752 Debug messages from pynetsnmp aren't displayed when switch on debug-mode using 'zentrap debug'

### DIFF
--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -241,9 +241,8 @@ class TrapTask(BaseTask, CaptureReplay):
                 listening_address = '%s:%d' % (listening_protocol, trapPort)
                 fileno = -1
             self._pre_parse_callback = _pre_parse_factory(self._pre_parse)
-            debug = self.log.isEnabledFor(logging.DEBUG)
             self.session.awaitTraps(
-                listening_address, fileno, self._pre_parse_callback, debug
+                listening_address, fileno, self._pre_parse_callback, debug=True
             )
             self.session.callback = self.receiveTrap
             twistedsnmp.updateReactor()


### PR DESCRIPTION
Debug messages aren't displayed because by default debug mode is disabled and pynetsnmp don't write debug logs. When we use 'zentrap debug', it actually changes log level, but doesn't enable debug mode in net-snmp (C-library). This commits enables debug mode in net-snmp always (but log messages are displayed only when debug level for logging is enabled)