### PR TITLE
Fixes ZEN-32893

### DIFF
--- a/Products/ZenModel/actions.py
+++ b/Products/ZenModel/actions.py
@@ -410,7 +410,7 @@ class EmailAction(IActionBase, TargetableAction):
                 tz_targets.setdefault(recipient.timezone, set()).add(recipient.email)
                 targetsCopy.discard(recipient.email)
         if targetsCopy: #some emails are not from users in the system
-            tz = time.tzname[0] #should be UTC
+            tz = time.tzname[time.daylight] # get current timezone factoring in daylight saving
             tz_targets.setdefault(tz, set()).update(targetsCopy)
         return tz_targets
 


### PR DESCRIPTION
This fixes ZEN-32893 where the timezone for timestamps in emails sent to manually defined email addresses in notifications was being improperly calculated (was not factoring in daylight saving when the container timezone is set to something other than UTC).