### PR TITLE
Add support for timing out jobs in zenjobs.

### DIFF
--- a/Products/Jobber/config.py
+++ b/Products/Jobber/config.py
@@ -28,6 +28,8 @@ _default_configs = {
     "max-jobs-per-worker": "100",
     "concurrent-jobs": "1",
     "job-expires": 604800,  # 7 days
+    "job-hard-time-limit": 21600,  # 6 hours
+    "job-soft-time-limit": 18000,  # 5 hours
 }
 
 
@@ -92,6 +94,8 @@ class Celery(object):
     CELERYD_CONCURRENCY = int(ZenJobs.get("concurrent-jobs"))
     CELERYD_PREFETCH_MULTIPLIER = 1
     CELERYD_MAX_TASKS_PER_CHILD = int(ZenJobs.get("max-jobs-per-worker"))
+    CELERYD_TASK_TIME_LIMIT = int(ZenJobs.get("job-hard-time-limit"))
+    CELERYD_TASK_SOFT_TIME_LIMIT = int(ZenJobs.get("job-soft-time-limit"))
 
     # Task settings
     CELERY_ACKS_LATE = True

--- a/Products/Jobber/log.py
+++ b/Products/Jobber/log.py
@@ -86,6 +86,7 @@ _default_config = {
         },
         "zen.zenjobs.job": {
             "level": _default_log_level,
+            "propagate": False,
         },
         "celery": {
             "level": _default_log_level,
@@ -207,8 +208,7 @@ def setup_job_instance_logger(log, task_id=None, task=None, **kwargs):
             if e.errno != errno.EEXIST:
                 raise
         handler = TaskLogFileHandler(logfile)
-        for logger in (logging.getLogger("zen"), get_task_logger()):
-            logger.addHandler(handler)
+        get_task_logger().addHandler(handler)
     except Exception:
         log.exception("Failed to add job instance logger")
     finally:
@@ -220,14 +220,14 @@ def teardown_job_instance_logger(log, task=None, **kwargs):
     """Tear down and delete the job instance logger."""
     log.debug("Removing job instance logger from {}", task.name)
     try:
-        for logger in (logging.getLogger("zen"), get_task_logger()):
-            handlers = []
-            for handler in logger.handlers:
-                if isinstance(handler, TaskLogFileHandler):
-                    handler.close()
-                else:
-                    handlers.append(handler)
-            logger.handlers = handlers
+        logger = get_task_logger()
+        handlers = []
+        for handler in logger.handlers:
+            if isinstance(handler, TaskLogFileHandler):
+                handler.close()
+            else:
+                handlers.append(handler)
+        logger.handlers = handlers
     except Exception:
         log.exception("Failed to remove job instance logger")
     finally:

--- a/Products/Jobber/monitor.py
+++ b/Products/Jobber/monitor.py
@@ -1,0 +1,140 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+# import ast
+
+from celery.bin.base import Command
+from collections import defaultdict
+from datetime import timedelta
+from zope.component import getUtility
+
+from .interfaces import IJobStore
+from .utils.datetime import humanize_timedelta
+
+
+def catch_error(f):
+    # Decorator that catches and prints the exception thrown from the
+    # decorated function.
+    def call_func(*args, **kw):
+        try:
+            return f(*args, **kw)
+        except Exception as ex:
+            print(ex)
+
+    return call_func
+
+
+class ZenJobsMonitor(Command):
+    """Monitor Celery events."""
+
+    @catch_error
+    def task_failed(self, event):
+        self.state.event(event)
+        jobid = event["uuid"]
+        instance = self.state.tasks.get(jobid)
+        job = self.app.tasks.get(instance.name)
+        result = job.AsyncResult(jobid)
+        classkey, summary = _getErrorInfo(self.app, result.result)
+        # args = ast.literal_eval(instance.args)
+        # kwargs = ast.literal_eval(instance.kwargs)
+        name = job.getJobType() if hasattr(job, "getJobType") else job.name
+        print(
+            "Job failed  worker=%s jobid=%s name=%s" % (
+                event["hostname"], jobid, name,
+            )
+        )
+
+    def run(self, **kw):
+        self.state = self.app.events.State(
+            on_node_join=on_node_join,
+            on_node_leave=on_node_leave,
+        )
+        self.seconds_since = defaultdict(float)
+        self.storage = getUtility(IJobStore, "redis")
+
+        conn = self.app.connection().clone()
+
+        def _error_handler(exc, interval):
+            print("Internal error: %s" % (exc,))
+
+        while True:
+            print("Begin monitoring for zenjobs/celery events")
+            try:
+                conn.ensure_connection(_error_handler)
+                recv = self.app.events.Receiver(
+                    conn,
+                    handlers={
+                        "task-failed": self.task_failed,
+                        "*": self.state.event,
+                    },
+                )
+                recv.capture(wakeup=True)
+            except (KeyboardInterrupt, SystemExit):
+                return conn and conn.close()
+            except conn.connection_errors + conn.channel_errors:
+                print("Connection lost, attempting reconnect")
+
+
+def _getTimeoutSummary(app, ex):
+    return "Job killed after {}.".format(
+        humanize_timedelta(
+            timedelta(
+                seconds=app.conf.get("CELERYD_TASK_SOFT_TIME_LIMIT"),
+            ),
+        ),
+    )
+
+
+def _getAbortedSummary(app, ex):
+    return "Job aborted by user"
+
+
+def _getErrorSummary(app, ex):
+    return "{0.__class__.__name__}: {0}".format(ex)
+
+
+_error_eventkey_map = {
+    "TaskAborted": (
+        "zenjobs-aborted", _getAbortedSummary,
+    ),
+    "SoftTimeLimitExceeded": (
+        "zenjobs-timeout", _getTimeoutSummary,
+    )
+}
+
+
+def _getErrorInfo(app, ex):
+    """Returns (eventkey, summary).
+    """
+    key, summary_fn = _error_eventkey_map.get(
+        type(ex).__name__, ("zenjobs-failure", _getErrorSummary),
+    )
+    return key, summary_fn(app, ex)
+
+
+def on_node_join(*args, **kw):
+    worker = args[0]
+    print(
+        "Worker node added to monitor  worker=%s uptime=%s" % (
+            worker.hostname,
+            humanize_timedelta(timedelta(seconds=worker.clock)),
+        ),
+    )
+
+
+def on_node_leave(*args, **kw):
+    worker = args[0]
+    print(
+        "Worker node left monitor  worker=%s uptime=%s" % (
+            worker.hostname,
+            humanize_timedelta(timedelta(seconds=worker.clock)),
+        ),
+    )

--- a/Products/Jobber/task/abortable.py
+++ b/Products/Jobber/task/abortable.py
@@ -27,6 +27,9 @@ from Products.ZenUtils.Threading import inject_exception_into_thread
 
 from ..exceptions import JobAborted, TaskAborted
 from ..interfaces import IJobStore
+from ..utils.log import get_logger
+
+mlog = get_logger("zen.zenjobs.task.abortable")
 
 
 class AbortableResult(AbortableAsyncResult):
@@ -58,9 +61,9 @@ class Abortable(AbortableTask):
         if isinstance(exc, TaskAborted):
             result = self.AsyncResult(task_id)
             result.backend.store_result(
-                task_id, result=None, status=states.ABORTED, traceback=None,
+                task_id, result=exc, status=states.ABORTED, traceback=None,
             )
-            self.log.debug(
+            mlog.debug(
                 "On TaskAborted exception, reset the task status to ABORTED",
             )
 
@@ -72,13 +75,15 @@ class Abortable(AbortableTask):
         jobstore = getUtility(IJobStore, "redis")
         status = jobstore.getfield(self.request.id, "status")
         if status == ABORTED:
-            self.log.info("Ignoring aborted job: %s", self.request.id)
+            log_mesg = ("Ignoring aborted job: %s", self.request.id)
+            self.log.info(*log_mesg)
+            mlog.info(*log_mesg)
             raise Ignore()
 
         # Alias the original run to __run
         # Alias _exec to run
         # _exec will call __run
-        self.__run, self.run = self.run, self._exec
+        self.__run, self.run = self.run, self.__exec
 
         try:
             return super(Abortable, self).__call__(*args, **kwargs)
@@ -86,20 +91,16 @@ class Abortable(AbortableTask):
             self.run = self.__run
             del self.__run
 
-    def _exec(self, *args, **kwargs):
-        if self.request.id is None:
-            self.log.error("task has no ID")
-            return
+    def __exec(self, *args, **kwargs):
         aborter = _TaskAborter(self, thread.get_ident())
         try:
             aborter.start()
-            self.log.info("Job started")
-            result = self.__run(*args, **kwargs)
-        except Exception as ex:
-            self.log.error("Job failed: %r", ex)
-            raise
+            mlog.debug("Started the ABORTED status monitor thread")
+            return self.__run(*args, **kwargs)
         except JobAborted:
-            self.log.warning("Job aborted")
+            aborted_mesg = "Job aborted"
+            self.log.warning(aborted_mesg)
+            mlog.warning(aborted_mesg)
             # Convert JobAborted into TaskAborted.
             # JobAborted is derived from BaseException and TaskAborted
             # is derviced from Exception.  Raising TaskAborted will result
@@ -107,13 +108,10 @@ class Abortable(AbortableTask):
             # cause the Celery worker process to exit.
             cls, instance, tb = sys.exc_info()[0:3]
             raise TaskAborted, TaskAborted(), tb
-        else:
-            self.log.info("Job finished")
-            return result
         finally:
             aborter.stop.set()
             aborter.join()
-            self.log.debug("Stopped the ABORTED status monitor thread")
+            mlog.debug("Stopped the ABORTED status monitor thread")
 
 
 class _TaskAborter(threading.Thread):
@@ -147,7 +145,7 @@ class _TaskAborter(threading.Thread):
                 if self._stopped():
                     break
             if not self.stop.wait(5.0):
-                self.log.warning("Forcing worker process to exit")
+                mlog.warning("Forcing worker process to exit")
                 os.kill(os.getpid(), signal.SIGKILL)
         finally:
             # Pop the request and task from their respective
@@ -158,13 +156,17 @@ class _TaskAborter(threading.Thread):
     def _stopped(self):
         if not self.stop.wait(0.1):
             return False
-        self.log.debug("Stopping ABORTED status monitor thread")
+        mlog.debug("Stopping ABORTED status monitor thread")
         return True
 
     def _job_aborted(self, result):
         if not result.is_aborted():
             return False
-        self.log.warning("Aborting job")
+        abort_mesg = "Aborting job"
+        inject_mesg = "Injected the JobAbort exception"
+        self.log.warning(abort_mesg)
+        mlog.warning(abort_mesg)
         inject_exception_into_thread(self.tid, JobAborted)
-        self.log.debug("Injected the JobAbort exception")
+        self.log.debug(inject_mesg)
+        mlog.debug(inject_mesg)
         return True

--- a/Products/Jobber/task/event.py
+++ b/Products/Jobber/task/event.py
@@ -1,0 +1,96 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+from datetime import timedelta
+from zope.component import getUtility
+
+import Products.ZenUtils.guid as guid
+
+from Products.ZenEvents import Event
+from Products.ZenMessaging.queuemessaging.interfaces import IEventPublisher
+
+from ..utils.datetime import humanize_timedelta
+from ..utils.log import get_logger
+
+mlog = get_logger("zen.zenjobs.task.event")
+
+
+class SendZenossEventMixin(object):
+    """Mixin class to send an Zenoss event when a job fails.
+    """
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        try:
+            return super(SendZenossEventMixin, self).on_failure(
+                exc, task_id, args, kwargs, einfo,
+            )
+        finally:
+            _send_event(self, exc, task_id, args, kwargs)
+
+
+def _send_event(task, exc, task_id, args, kwargs):
+    classkey, summary = _getErrorInfo(task.app, exc)
+    name = task.getJobType() if hasattr(task, "getJobType") else task.name
+    publisher = getUtility(IEventPublisher)
+    event = Event.Event(**{
+        "evid": guid.generate(1),
+        "device": name,
+        "severity": Event.Error,
+        "component": "zenjobs",
+        "eventClassKey": classkey,
+        "eventKey": "{}|{}".format(classkey, name),
+        "message": task.description_from(*args, **kwargs),
+        "summary": summary,
+        "jobid": str(task_id),
+    })
+    publisher.publish(event)
+    log_message = (
+        "Event sent  event-class-key=%s summary=%s", classkey, summary,
+    )
+    task.log.info(*log_message)
+    mlog.info(*log_message)
+
+
+def _getTimeoutSummary(app, ex):
+    return "Job killed after {}.".format(
+        humanize_timedelta(
+            timedelta(
+                seconds=app.conf.get("CELERYD_TASK_SOFT_TIME_LIMIT"),
+            ),
+        ),
+    )
+
+
+def _getAbortedSummary(app, ex):
+    return "Job aborted by user"
+
+
+def _getErrorSummary(app, ex):
+    return "{0.__class__.__name__}: {0}".format(ex)
+
+
+_error_eventkey_map = {
+    "TaskAborted": (
+        "zenjobs-aborted", _getAbortedSummary,
+    ),
+    "SoftTimeLimitExceeded": (
+        "zenjobs-timeout", _getTimeoutSummary,
+    )
+}
+
+
+def _getErrorInfo(app, ex):
+    """Returns (eventkey, summary).
+    """
+    key, summary_fn = _error_eventkey_map.get(
+        type(ex).__name__, ("zenjobs-failure", _getErrorSummary),
+    )
+    return key, summary_fn(app, ex)

--- a/Products/Jobber/tests/test_job.py
+++ b/Products/Jobber/tests/test_job.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, print_function
 import inspect
 
 from celery.contrib.abortable import AbortableTask
-from mock import patch
 from unittest import TestCase
 
 from ..exceptions import NoSuchJobException

--- a/Products/Jobber/tests/test_manager.py
+++ b/Products/Jobber/tests/test_manager.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, print_function
 
 import inspect
 
-from mock import patch
 from unittest import TestCase
 from zope.component import getGlobalSiteManager
 

--- a/Products/Jobber/tests/test_model.py
+++ b/Products/Jobber/tests/test_model.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, print_function
 
 import itertools
+import types
 
 from celery import states
 from mock import patch
@@ -71,6 +72,41 @@ class JobRecordTest(TestCase):
         j = JobRecord.make({})
         missing_names = set(Fields.viewkeys()) - set(dir(j))
         t.assertSetEqual(set(), missing_names)
+
+    def test_has_methods(t):
+        # Assert that the appropriate methods exist.
+        methods = ("abort", "wait")
+        for m in methods:
+            with subTest(method=m):
+                result = getattr(JobRecord, m, None)
+                t.assertIsInstance(result, types.UnboundMethodType)
+
+    def test_dir_keys(t):
+        j = JobRecord.make(t.data)
+        expected = t.data.keys()
+        expected.remove("details")
+        expected.extend(t.data["details"].keys())
+        expected.extend((
+            "details", "id", "make", "uid",
+            "uuid", "duration", "complete", "abort", "wait", "result",
+        ))
+        expected = sorted(expected)
+        actual = [a for a in dir(j) if not a.startswith("__")]
+        t.assertListEqual(expected, actual)
+
+    def test_details_are_exposed(t):
+        j = JobRecord.make({})
+        j.details = {"foo": 1}
+        t.assertEqual(1, j.foo)
+        t.assertIn("foo", dir(j))
+        t.assertIn("foo", j.__dict__)
+        t.assertEqual(1, j.__dict__["foo"])
+
+    def test_details_are_not_writable(t):
+        j = JobRecord.make({})
+        j.details = {"foo": 1}
+        with t.assertRaises(AttributeError):
+            j.foo = 3
 
     def test_make_badfield(t):
         with t.assertRaises(AttributeError):

--- a/Products/Jobber/utils/datetime.py
+++ b/Products/Jobber/utils/datetime.py
@@ -1,0 +1,70 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+
+class TimeDeltaStruct(object):
+
+    __slots__ = (
+        "weeks",
+        "days",
+        "hours",
+        "minutes",
+        "seconds",
+    )
+
+    @classmethod
+    def from_timedelta(cls, td):
+        weeks = td.days // _days_per_week
+        days = td.days % _days_per_week
+
+        hours = td.seconds // _secs_per_hour
+        secs_remaining = td.seconds % _secs_per_hour
+
+        minutes = secs_remaining // _secs_per_minute
+        seconds = secs_remaining % _secs_per_minute
+
+        return cls(
+            weeks=weeks,
+            days=days,
+            hours=hours,
+            minutes=minutes,
+            seconds=seconds,
+        )
+
+    def __init__(self, weeks=0, days=0, hours=0, minutes=0, seconds=0):
+        self.weeks = weeks
+        self.days = days
+        self.hours = hours
+        self.minutes = minutes
+        self.seconds = seconds
+
+
+_days_per_week = 7
+_secs_per_hour = 3600
+_secs_per_minute = 60
+
+
+def humanize_timedelta(td):
+    tds = TimeDeltaStruct.from_timedelta(td)
+    text = []
+    if tds.weeks > 0:
+        text.append("{} weeks".format(tds.weeks))
+    if tds.days > 0:
+        text.append("{} days".format(tds.days))
+    if tds.hours > 0:
+        text.append("{} hours".format(tds.hours))
+    if tds.minutes > 0:
+        text.append("{} minutes".format(tds.minutes))
+    if tds.seconds > 0:
+        text.append("{} seconds".format(tds.seconds))
+    if len(text) == 0:
+        return "immediately"
+    return ", ".join(text)

--- a/Products/ZenModel/migrate/addEventClassInstancesForZenJobs.py
+++ b/Products/ZenModel/migrate/addEventClassInstancesForZenJobs.py
@@ -1,0 +1,60 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+
+from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION  # noqa: E501
+
+import Migrate
+
+log = logging.getLogger("zen.migrate")
+
+
+_data = [{
+    "id": "zenjobs-aborted",
+    "example": "Job aborted by user",
+    "explanation": "A job was aborted by a user",
+}, {
+    "id": "zenjobs-failure",
+    "example": "AttributeError: foo",
+    "explanation":
+        "A job has failed due to an error while the job was running",
+}, {
+    "id": "zenjobs-timeout",
+    "example": "Job killed after 5 hours",
+    "explanation":
+        "A job was killed because its running time exceeded the time limit",
+}]
+
+
+class AddEventClassInstancesForZenJobs(Migrate.Step):
+    """Adds three EventClassInst objects to the /App/Zenoss event class.
+    """
+
+    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+
+    def cutover(self, dmd):
+        zenoss = dmd.Events.App.Zenoss
+        instances = zenoss.getInstances()
+        for fields in _data:
+            inst_id = fields["id"]
+            exists = next(
+                (True for i in instances if i.id == inst_id), False,
+            )
+            if exists:
+                log.info("/App/Zenoss instance '%s' already exists.", inst_id)
+                continue
+            log.info("Adding '%s' as an /App/Zenoss instance.", inst_id)
+            instance = zenoss.createInstance(inst_id)
+            instance.sequence = 1001
+            instance.example = fields["example"]
+            instance.explanation = fields["explanation"]
+
+
+AddEventClassInstancesForZenJobs()

--- a/legacy/zenoss-version/setup.py.in
+++ b/legacy/zenoss-version/setup.py.in
@@ -1,25 +1,28 @@
 from setuptools import setup, find_packages
-import sys, os
+import os
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 install_requires = []
 
 
-setup(name='Zenoss',
+setup(
+    name='Zenoss',
     version="%VERSION%",
     description="Zenoss",
-    classifiers=[
-      # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
-    ],
     keywords='',
     author='Zenoss, Inc.',
     author_email='dev@zenoss.com',
     url='http://www.zenoss.com',
     license='',
     packages=find_packages('src'),
-    package_dir = {'': 'src'},include_package_data=True,
+    package_dir={'': 'src'},
+    include_package_data=True,
     zip_safe=False,
     install_requires=install_requires,
+    entry_points={
+        "celery.commands": {
+            "monitor=Products.Jobber.monitor:ZenJobsMonitor",
+        },
+    },
 )
-


### PR DESCRIPTION
* Jobs are killed when their running time exceeds a configured duration.
* Send a Zenoss event when a job times out, is aborted, or fails.

Fixes ZEN-29200.