### PR TITLE
Fix log formatter context usage.

### DIFF
--- a/Products/Jobber/jobs/job.py
+++ b/Products/Jobber/jobs/job.py
@@ -87,7 +87,7 @@ class Job(Abortable, DMD, ZenTask):
         self.dmd.JobManager.update(jobid, **details)
 
     def _get_config(self, key, default=_MARKER):
-        value = ZenJobs.get(key, default=default)
+        value = ZenJobs.get(key, default)
         if value is _MARKER:
             raise KeyError("Config option '{}' is not defined".format(key))
         return value

--- a/Products/Jobber/jobs/subprocess.py
+++ b/Products/Jobber/jobs/subprocess.py
@@ -101,7 +101,7 @@ class SubprocessJob(Job):
         while exitcode is None:
             line = reader.readline()
             if line:
-                with formatting_context:
+                with formatting_context():
                     self.log.info(line.strip())
                     output += line.strip()
             else:
@@ -123,6 +123,9 @@ class LogFormatterContext(object):
         self.__handler = handler
         self.__original = handler.formatter
         self.__alternate = formatter
+
+    def __call__(self):
+        return self
 
     def __enter__(self):
         self.__handler.setFormatter(self.__alternate)

--- a/Products/Jobber/tests/test_log.py
+++ b/Products/Jobber/tests/test_log.py
@@ -13,11 +13,9 @@ import logging
 
 from cStringIO import StringIO
 
-# from contextlib import contextmanager
 from mock import MagicMock, Mock, patch, sentinel, call
 from unittest import TestCase
 
-# from .utils import subTest
 from ..log import (
     apply_levels,
     configure_logging,

--- a/Products/Jobber/tests/test_log.py
+++ b/Products/Jobber/tests/test_log.py
@@ -24,6 +24,7 @@ from ..log import (
     load_log_level_config,
     _loglevelconf_filepath,
 )
+from .utils import LoggingLayer
 
 UNEXPECTED = type("UNEXPECTED", (object,), {})()
 PATH = {"src": "Products.Jobber.log"}
@@ -182,22 +183,6 @@ class LoadLogLevelConfigTest(TestCase):
         actual = load_log_level_config(filename)
 
         t.assertDictEqual(expected, actual)
-
-
-class LoggingLayer(object):
-    """Test layer to support testing with Python's logging API."""
-
-    @classmethod
-    def setUp(cls):
-        cls.original_manager = logging.Logger.manager
-        cls.manager = logging.Manager(logging.root)
-        logging.Logger.manager = cls.manager
-
-    @classmethod
-    def tearDown(cls):
-        logging.Logger.manager = cls.original_manager
-        del cls.manager
-        del cls.original_manager
 
 
 class ApplyLevelsTest(TestCase):

--- a/Products/Jobber/tests/test_logformattercontext.py
+++ b/Products/Jobber/tests/test_logformattercontext.py
@@ -1,0 +1,49 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+import logging
+
+from unittest import TestCase
+
+# from .utils import subTest
+from ..jobs.subprocess import (
+    LogFormatterContext, getLogFormattingContext, null_context,
+)
+from ..utils.log import TaskLogFileHandler
+from .utils import LoggingLayer
+
+
+class LogFormatterContextTest(TestCase):
+    """Test the LogFormatterContext class."""
+
+    layer = LoggingLayer
+
+    def setUp(t):
+        t.layer.manager.loggerDict.clear()
+        t.formatter = logging.Formatter("%(message)s")
+        t.handler = logging.NullHandler()
+
+    def test_usage(t):
+        ctx = LogFormatterContext(t.handler, t.formatter)
+        with ctx():
+            pass
+
+    def test_getLogFormattingContext_notask(t):
+        ctx = getLogFormattingContext()
+        t.assertIs(ctx, null_context)
+
+    def test_getLogFormattingContext_hastask(t):
+        zen = logging.getLogger("zen")
+        handler = TaskLogFileHandler("/tmp/logformattercontext.log")
+        zen.addHandler(handler)
+
+        ctx = getLogFormattingContext()
+        t.assertIsInstance(ctx, (LogFormatterContext,))

--- a/Products/Jobber/tests/test_logformattercontext.py
+++ b/Products/Jobber/tests/test_logformattercontext.py
@@ -13,7 +13,6 @@ import logging
 
 from unittest import TestCase
 
-# from .utils import subTest
 from ..jobs.subprocess import (
     LogFormatterContext, getLogFormattingContext, null_context,
 )

--- a/Products/Jobber/tests/utils.py
+++ b/Products/Jobber/tests/utils.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, print_function
 
 import contextlib
+import logging
 import redis
 import sys
 import traceback
@@ -47,3 +48,19 @@ class RedisLayer(object):
     @classmethod
     def tearDown(cls):
         del cls.redis
+
+
+class LoggingLayer(object):
+    """Test layer to support testing with Python's logging API."""
+
+    @classmethod
+    def setUp(cls):
+        cls.original_manager = logging.Logger.manager
+        cls.manager = logging.Manager(logging.root)
+        logging.Logger.manager = cls.manager
+
+    @classmethod
+    def tearDown(cls):
+        logging.Logger.manager = cls.original_manager
+        del cls.manager
+        del cls.original_manager


### PR DESCRIPTION
The log formatter context must be called when used in a `with` statement.

Fixes ZEN-33032.