### PR TITLE
Add more robust error handling.

### DIFF
--- a/Products/ZenRRD/runner.py
+++ b/Products/ZenRRD/runner.py
@@ -288,11 +288,15 @@ class SshRunner(object):
         Either creates a deferred to append to the pool list otherwise, wraps
         the result
         """
-        if isinstance(self._pool[self._poolkey], list):
+        if self._poolkey not in self._pool:
+            return defer.fail(RuntimeError("No connector found"))
+
+        connection_or_list = self._pool.get(self._poolkey)
+        if isinstance(connection_or_list, list):
             d = defer.Deferred()
-            self._pool[self._poolkey].append(d)
+            connection_or_list.append(d)
         else:
-            d = defer.succeed(self._pool[self._poolkey])
+            d = defer.succeed(connection_or_list)
         return d
 
     def send(self, datasource):

--- a/Products/ZenUtils/tests/test_open_browser_connection.py
+++ b/Products/ZenUtils/tests/test_open_browser_connection.py
@@ -1,0 +1,64 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import unittest
+
+from mock import patch
+from Products.ZenUtils.Utils import is_browser_connection_open, zhttp_channel
+
+PATH = {'src': 'Products.ZenUtils.Utils'}
+
+
+class TestIsBrowserConnectionOpen(unittest.TestCase):
+
+    def setUp(t):
+        t.request = type("request", (object,), {})()
+
+    def test_missing_environ(t):
+        result = is_browser_connection_open(t.request)
+        t.assertFalse(result)
+
+    def test_missing_env_creation_time(t):
+        t.request.environ = {}
+        result = is_browser_connection_open(t.request)
+        t.assertFalse(result)
+
+    @patch("{src}.asyncore".format(**PATH), autospec=True)
+    def test_no_channels(t, _asyncore):
+        t.request.environ = {"channel.creation_time": 10}
+        _asyncore.socket_map = {"foo": object()}
+        result = is_browser_connection_open(t.request)
+        t.assertFalse(result)
+
+    @patch("{src}.asyncore".format(**PATH), autospec=True)
+    def test_no_creation_time_on_channel(t, _asyncore):
+        t.request.environ = {"channel.creation_time": 10}
+        _asyncore.socket_map = {"foo": _FakeChannel()}
+        result = is_browser_connection_open(t.request)
+        t.assertFalse(result)
+
+    @patch("{src}.asyncore".format(**PATH), autospec=True)
+    def test_mismatch_creation_time(t, _asyncore):
+        t.request.environ = {"channel.creation_time": 10}
+        _asyncore.socket_map = {"foo": _FakeChannel(creation_time=20)}
+        result = is_browser_connection_open(t.request)
+        t.assertFalse(result)
+
+    @patch("{src}.asyncore".format(**PATH), autospec=True)
+    def test_matching_creation_time(t, _asyncore):
+        t.request.environ = {"channel.creation_time": 10}
+        _asyncore.socket_map = {"foo": _FakeChannel(creation_time=10)}
+        result = is_browser_connection_open(t.request)
+        t.assertTrue(result)
+
+
+class _FakeChannel(zhttp_channel):
+
+    def __init__(self, **kw):
+        self.socket = type("socket", (object,), kw)


### PR DESCRIPTION
* is_browser_connection_open no longer makes assumptions about the incoming request object.
* SshRunner validates the pool key before using it.

Fixes ZEN-33042.