### PR TITLE
Set job to FAILURE if ERROR in its log file.

### DIFF
--- a/Products/Jobber/jobs/facade.py
+++ b/Products/Jobber/jobs/facade.py
@@ -25,7 +25,6 @@ class FacadeMethodJob(Job):
 
     name = "Products.Jobber.FacadeMethodJob"
     ignore_result = False
-    throws = Job.throws + (FacadeMethodJobFailed,)
 
     @classmethod
     def getJobType(cls):

--- a/Products/Jobber/jobs/subprocess.py
+++ b/Products/Jobber/jobs/subprocess.py
@@ -67,7 +67,7 @@ class SubprocessJob(Job):
             else:
                 exitcode, output = self._handle_process(process)
                 if exitcode == 0:
-                    return
+                    return exitcode
                 summary = "Command failed with exit code %s" % exitcode
                 message = "Exit code %s for command %s; %s" % (
                     exitcode, self.getJobDescription(cmd), output,

--- a/Products/Jobber/storage.py
+++ b/Products/Jobber/storage.py
@@ -231,7 +231,8 @@ class JobStore(Container, Iterable, Sized):
             k: Fields[k].dumps(v)
             for k, v in fields.items() if v is not None
         }
-        self.__client.hmset(key, fields)
+        if fields:
+            self.__client.hmset(key, fields)
         self.__expire_key_if_finished(key)
 
     def keys(self):

--- a/Products/Jobber/task/base.py
+++ b/Products/Jobber/task/base.py
@@ -12,10 +12,11 @@ from __future__ import absolute_import, print_function
 import logging
 
 from AccessControl.SecurityManagement import getSecurityManager
-from celery import Task
+from celery import Task, states
 from celery.exceptions import Ignore, SoftTimeLimitExceeded
 
 from .event import SendZenossEventMixin
+from .utils import job_log_has_errors
 from ..utils.log import get_task_logger, get_logger
 
 _default_summary = "Task {0.__class__.__name__}"
@@ -71,6 +72,14 @@ class ZenTask(SendZenossEventMixin, Task):
         userid = getSecurityManager().getUser().getId()
         headers["userid"] = userid
         return super(ZenTask, self).subtask(*args, **kw)
+
+    def after_return(self, status, retval, task_id, args, kwargs, eninfo):
+        if status == states.SUCCESS and job_log_has_errors(task_id):
+            status = states.FAILURE
+            self.update_state(state=status)
+        return super(ZenTask, self).after_return(
+            status, retval, task_id, args, kwargs, eninfo,
+        )
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         result = super(ZenTask, self).on_failure(

--- a/Products/Jobber/task/utils.py
+++ b/Products/Jobber/task/utils.py
@@ -11,6 +11,9 @@ from __future__ import absolute_import
 
 import inspect
 
+from zope.component import getUtility
+
+from ..interfaces import IJobStore
 from ..zenjobs import app
 
 
@@ -30,3 +33,20 @@ def requires(*features):
     name = ''.join(t.__name__ for t in features) + "Task"
     basetask = type(name, tuple(culled), {"abstract": True})
     return basetask
+
+
+def job_log_has_errors(task_id):
+    """Return True if the job's log contains any ERROR messages.
+    """
+    storage = getUtility(IJobStore, "redis")
+    logfile = storage.getfield(task_id, "logfile")
+    if not logfile:
+        return False
+    try:
+        with open(logfile, "r") as f:
+            return any(
+                "ERROR zen." in line
+                for line in f.readlines()
+            )
+    except Exception:
+        return False

--- a/Products/Jobber/tests/test_storage.py
+++ b/Products/Jobber/tests/test_storage.py
@@ -294,6 +294,18 @@ class ModifyJobStoreTest(TestCase):
         actual = set(raw.keys())
         t.assertSetEqual(expected, actual)
 
+    def test_update_with_only_Nones(t):
+        jobid = t.initial["jobid"]
+        update = {"logfile": None}
+        expected = {k for k in t.initial if k != "logfile"}
+
+        t.store[jobid] = t.initial
+
+        t.store.update(jobid, **update)
+        raw = t.layer.redis.hgetall("zenjobs:job:%s" % jobid)
+        actual = set(raw.keys())
+        t.assertSetEqual(expected, actual)
+
 
 def _buildData(jobnames, userids, base):
     baseid = 100

--- a/Products/Jobber/tests/test_task_utils.py
+++ b/Products/Jobber/tests/test_task_utils.py
@@ -1,0 +1,92 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+from mock import MagicMock, mock_open, patch
+from unittest import TestCase
+from Products.Jobber.task.utils import job_log_has_errors
+from zope.component import getGlobalSiteManager, ComponentLookupError
+
+from ..interfaces import IJobStore
+from ..storage import JobStore
+from .utils import RedisLayer
+
+PATH = {"src": "Products.Jobber.task.utils"}
+
+
+class JobLogHasErrorsTest(TestCase):
+    """Test the task.utils.job_log_has_errors function.
+    """
+
+    layer = RedisLayer
+
+    record = {
+        "jobid": "123",
+        "name": "TestJob",
+        "summary": "Products.Jobber.jobs.TestJob",
+        "description": "A test job",
+        "userid": "zenoss",
+        "logfile": "/opt/zenoss/log/jobs/123.log",
+        "created": 1551804881.024517,
+        "status": "PENDING",
+    }
+
+    def setUp(t):
+        t.store = JobStore(t.layer.redis)
+        t.store[t.record["jobid"]] = t.record
+        getGlobalSiteManager().registerUtility(
+            t.store, IJobStore, name="redis",
+        )
+
+    def tearDown(t):
+        t.layer.redis.flushall()
+        getGlobalSiteManager().unregisterUtility(
+            t.store, IJobStore, name="redis",
+        )
+        del t.store
+
+    def test_missing_jobstore(t):
+        getGlobalSiteManager().unregisterUtility(
+            t.store, IJobStore, name="redis",
+        )
+        with t.assertRaises(ComponentLookupError):
+            job_log_has_errors("123")
+
+    def test_undefined_logfile_name(t):
+        t.store.update("123", logfile=None)
+        t.assertFalse(job_log_has_errors("123"))
+
+    def test_blank_logfile_name(t):
+        t.store.update("123", logfile="")
+        t.assertFalse(job_log_has_errors("123"))
+
+    def test_bad_logfile(t):
+        m = MagicMock(side_effect=RuntimeError("boom"))
+        _open = mock_open(m)
+        with patch("__builtin__.open", _open):
+            t.assertFalse(job_log_has_errors("123"))
+
+    def test_no_errors(t):
+        _open = mock_open(read_data=(
+            "INFO zen.zenjobs good things\n"
+            "WARNING zen.zenjobs be alert\n"
+            "DEBUG zen.zenjobs noisy things\n"
+        ))
+        with patch("__builtin__.open", _open):
+            t.assertFalse(job_log_has_errors("123"))
+
+    def test_has_errors(t):
+        _open = mock_open(read_data=(
+            "INFO zen.zenjobs good things\n"
+            "ERROR zen.zenjobs bad things\n"
+            "DEBUG zen.zenjobs noisy things\n"
+        ))
+        with patch("__builtin__.open", _open):
+            t.assertTrue(job_log_has_errors("123"))


### PR DESCRIPTION
Set a job to the FAILURE state if an ERROR log message is found in the job's log file.  Many jobs do not propagate their errors into zenjobs (celery), so zenjobs has to examine their log file to determine the jobs' final state.

Also fixed an issue with the Redis wrapper (storage) when updating a job record with nothing but None valued fields.

Fixes ZEN-33036.