### PR TITLE
Specify a job's expected exceptions to Celery.

### DIFF
--- a/Products/Jobber/jobs/facade.py
+++ b/Products/Jobber/jobs/facade.py
@@ -26,6 +26,10 @@ class FacadeMethodJob(Job):
     name = "Products.Jobber.FacadeMethodJob"
     ignore_result = False
 
+    # Specifying the exceptions a job can raise will avoid the
+    # "Unexpected exception" traceback message in zenjobs' log.
+    throws = Job.throws + (FacadeMethodJobFailed,)
+
     @classmethod
     def getJobType(cls):
         """Return a general, but brief, description of the job."""
@@ -84,7 +88,9 @@ class FacadeMethodJob(Job):
                     raise FacadeMethodJobFailed(str(result))
                 return result["message"]
             except (TypeError, KeyError):
-                self.log.error(
-                    "The output from job %s is not in the right format: %s",
-                    self.request.id, result,
+                self.log.warn(
+                    "The output from job %s is not in the right format: "
+                    "%s.%s returned %s",
+                    self.request.id, facadefqdn, bound_method, result,
                 )
+                return result

--- a/Products/Jobber/jobs/job.py
+++ b/Products/Jobber/jobs/job.py
@@ -19,7 +19,7 @@ from Products.ZenEvents import Event
 from Products.ZenMessaging.queuemessaging.interfaces import IEventPublisher
 
 from ..config import ZenJobs
-from ..exceptions import NoSuchJobException, TaskAborted
+from ..exceptions import NoSuchJobException
 from ..task import Abortable, DMD, ZenTask
 from ..zenjobs import app
 
@@ -30,6 +30,9 @@ class Job(Abortable, DMD, ZenTask):
     """Base class for legacy jobs."""
 
     abstract = True  # Job class itself is not registered.
+
+    # Specifying the exceptions a job can raise will avoid the
+    # "Unexpected exception" traceback message in zenjobs' log.
     throws = Abortable.throws + ZenTask.throws
 
     @classmethod

--- a/Products/Jobber/jobs/misc.py
+++ b/Products/Jobber/jobs/misc.py
@@ -51,10 +51,15 @@ class PausingJob(Job):
         threading.Event().wait(seconds)
 
 
+class DelayedFailureError(ValueError):
+    pass
+
+
 class DelayedFailure(Job):
     """Waits for some interval of time before failing."""
 
     name = "zen.zenjobs.test.DelayedFailure"
+    throws = Job.throws + (DelayedFailureError,)
 
     @classmethod
     def getJobDescription(cls, *args, **kw):
@@ -63,7 +68,7 @@ class DelayedFailure(Job):
     def _run(self, seconds, *args, **kw):
         self.log.info("Sleeping for %s seconds", seconds)
         threading.Event().wait(seconds)
-        raise ValueError("slept for %s seconds" % seconds)
+        raise DelayedFailureError("slept for %s seconds" % seconds)
 
 
 @app.task(

--- a/Products/Jobber/jobs/subprocess.py
+++ b/Products/Jobber/jobs/subprocess.py
@@ -28,6 +28,14 @@ class SubprocessJob(Job):
 
     name = "Products.Jobber.SubprocessJob"
 
+    # Specifying the exceptions a job can raise will avoid the
+    # "Unexpected exception" traceback message in zenjobs' log.
+    # NOTE: JobAborted is not specified on purpose.  The Abortable base
+    # class catches JobAborted and handles it.  Also, JobAborted does
+    # not originate from the SubprocessJob class so it has no business
+    # specifying whether it's an expected exception.
+    throws = Job.throws + (SubprocessJobFailed,)
+
     @classmethod
     def getJobType(cls):
         """Return a general, but brief, description of the job."""


### PR DESCRIPTION
Expected exceptions are still an error and fail the job, but do not cause celery to write a traceback to the log.  For expected exceptions, tracebacks are unnecessary as they do not add any useful information.

Fixes ZEN-33054.