### PR TITLE
Set DeviceExistsError as an expected exception.

### DIFF
--- a/Products/ZenModel/ZDeviceLoader.py
+++ b/Products/ZenModel/ZDeviceLoader.py
@@ -183,6 +183,10 @@ class CreateDeviceJob(Job):
     Create a new device object.
     """
 
+    # Declare DeviceExistsError as an expected exception so that a traceback
+    # is not written to zenjobs' log.
+    throws = Job.throws + (DeviceExistsError,)
+
     @classmethod
     def getJobType(cls):
         return "Create Device"


### PR DESCRIPTION
Prevents zenjobs from writing a traceback to the log.

Fixes ZEN-33053.