### PR TITLE
Zenjobs now uses a custom task serializer.

### DIFF
--- a/Products/Jobber/config.py
+++ b/Products/Jobber/config.py
@@ -78,7 +78,7 @@ class Celery(object):
     """Celery configuration."""
 
     BROKER_URL = _buildBrokerUrl()
-    CELERY_ACCEPT_CONTENT = ["json"]
+    CELERY_ACCEPT_CONTENT = ["without-unicode"]
 
     # List of modules to import when the Celery worker starts
     CELERY_IMPORTS = (
@@ -87,7 +87,7 @@ class Celery(object):
 
     # Result backend (redis)
     CELERY_RESULT_BACKEND = "redis://localhost/0"
-    CELERY_RESULT_SERIALIZER = "json"
+    CELERY_RESULT_SERIALIZER = "without-unicode"
     CELERY_TASK_RESULT_EXPIRES = int(ZenJobs.get("job-expires"))
 
     # Worker configuration
@@ -101,7 +101,7 @@ class Celery(object):
     CELERY_ACKS_LATE = True
     CELERY_IGNORE_RESULT = False
     CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
-    CELERY_TASK_SERIALIZER = "json"
+    CELERY_TASK_SERIALIZER = "without-unicode"
     CELERY_TRACK_STARTED = True
 
     # Event settings

--- a/Products/Jobber/jobs/misc.py
+++ b/Products/Jobber/jobs/misc.py
@@ -81,10 +81,10 @@ class DelayedFailure(Job):
 def pathexists(self, uid):
     try:
         obj = self.dmd.unrestrictedTraverse(uid)
-        self.log.info("%s", obj)
+        self.log.info("Found object %s: %s", uid, obj)
         return True
     except Exception:
-        self.log.exception("%s", uid)
+        self.log.exception("Had a problem finding %s", uid)
         return False
 
 

--- a/Products/Jobber/jobs/misc.py
+++ b/Products/Jobber/jobs/misc.py
@@ -74,6 +74,23 @@ class DelayedFailure(Job):
 @app.task(
     bind=True,
     base=requires(DMD, Abortable),
+    name="zen.zenjobs.test.pathexists",
+    summary="Test whether a ZODB UID exists",
+    description_template="Test whether {0} exists in ZODB.",
+)
+def pathexists(self, uid):
+    try:
+        obj = self.dmd.unrestrictedTraverse(uid)
+        self.log.info("%s", obj)
+        return True
+    except Exception:
+        self.log.exception("%s", uid)
+        return False
+
+
+@app.task(
+    bind=True,
+    base=requires(DMD, Abortable),
     name="zen.zenjobs.test.pause",
     summary="Wait Task",
     description_template="Wait for {0} seconds, then exit.",

--- a/Products/Jobber/serialization.py
+++ b/Products/Jobber/serialization.py
@@ -1,0 +1,66 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020 all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+from json import (
+    loads as json_loads,
+    dumps as json_dumps,
+    JSONDecoder,
+)
+from kombu.utils.encoding import bytes_t
+
+__all__ = ("without_unicode",)
+
+
+def _process_list(seq):
+    stack = [seq]
+    while stack:
+        lst = stack.pop()
+        for idx, item in enumerate(lst):
+            if isinstance(item, unicode):
+                lst[idx] = str(item)
+            if isinstance(item, list):
+                stack.append(item)
+    return seq
+
+
+def _decode_hook(*args, **kw):
+    result = {}
+    for n, i in enumerate(args):
+        for pair in i:
+            k, v = pair
+            if isinstance(v, unicode):
+                v = str(v)
+            elif isinstance(v, list):
+                v = _process_list(v)
+            result.update({str(k): v})
+    return result
+
+
+class _WithoutUnicode(JSONDecoder):
+
+    def __init__(self, *args, **kw):
+        super(_WithoutUnicode, self).__init__(
+            object_pairs_hook=_decode_hook, *args, **kw
+        )
+
+    def decode(self, s):
+        if isinstance(s, bytes_t):
+            s = s.decode("utf-8")
+        return super(_WithoutUnicode, self).decode(s)
+
+
+def _without_unicode_loads(s, **kw):
+    return json_loads(s, cls=_WithoutUnicode, **kw)
+
+
+class without_unicode(object):
+    dump = staticmethod(json_dumps)
+    load = staticmethod(_without_unicode_loads)

--- a/Products/Jobber/tests/test_serialization.py
+++ b/Products/Jobber/tests/test_serialization.py
@@ -1,0 +1,60 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+from unittest import TestCase
+
+from ..serialization import without_unicode
+
+
+class WithoutUnicodeTest(TestCase):
+    """Test the without_unicode serialization functions."""
+
+    def test_empty_set(t):
+        data = {}
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertDictEqual(data, loaded)
+
+    def test_simple_dict(t):
+        data = {"a": "/"}
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertDictEqual(data, loaded)
+
+    def test_lists(t):
+        data = ["a", "b"]
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertSequenceEqual(data, loaded)
+
+    def test_nested_lists(t):
+        data = ["a", ["b", "c"]]
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertSequenceEqual(data, loaded)
+
+    def test_variety(t):
+        data = {
+            "id": "woeijfoejf",
+            "args": ["a", ["c", "f"]],
+            "info": [
+                {"a": 1},
+                {"b": "y"}
+            ],
+        }
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertDictEqual(data, loaded)

--- a/Products/Jobber/tests/test_serialization.py
+++ b/Products/Jobber/tests/test_serialization.py
@@ -45,13 +45,27 @@ class WithoutUnicodeTest(TestCase):
         t.assertIsInstance(dumped, str)
         t.assertSequenceEqual(data, loaded)
 
+    def test_nested_dicts(t):
+        data = {
+            "a": {
+                "b": 3,
+                "c": {
+                    "d": "blah",
+                },
+            },
+        }
+        dumped = without_unicode.dump(data)
+        loaded = without_unicode.load(dumped)
+        t.assertIsInstance(dumped, str)
+        t.assertSequenceEqual(data, loaded)
+
     def test_variety(t):
         data = {
             "id": "woeijfoejf",
             "args": ["a", ["c", "f"]],
             "info": [
                 {"a": 1},
-                {"b": "y"}
+                {"b": {"d": "y", "e": 42}}
             ],
         }
         dumped = without_unicode.dump(data)

--- a/Products/Jobber/zenjobs.py
+++ b/Products/Jobber/zenjobs.py
@@ -10,6 +10,19 @@
 from __future__ import absolute_import
 
 from celery import Celery
+from kombu.serialization import register
+
+from .serialization import without_unicode
+
+
+# Register custom serializer
+register(
+    "without-unicode",
+    without_unicode.dump,
+    without_unicode.load,
+    content_type="application/x-without-unicode",
+    content_encoding="utf-8",
+)
 
 app = Celery(
     "zenjobs",


### PR DESCRIPTION
The custom serializer decodes strings as str instead of unicode.

Fixes ZEN-33035, ZEN-33071, and maybe others.