### PR TITLE
Restore legacy attributes to JobRecord class.

### DIFF
--- a/Products/Jobber/manager.py
+++ b/Products/Jobber/manager.py
@@ -22,7 +22,7 @@ from Products.ZenModel.ZenossSecurity import ZEN_MANAGE_DMD
 
 from .exceptions import NoSuchJobException
 from .interfaces import IJobStore
-from .model import LegacySuport, JobRecord, RedisRecord, sortable_keys
+from .model import LegacySupport, JobRecord, RedisRecord, sortable_keys
 from .utils.accesscontrol import ZClassSecurityInfo, ZInitializeClass
 from .zenjobs import app
 
@@ -188,7 +188,7 @@ class JobManager(ZenModelRM):
         """
         criteria = criteria if criteria is not None else {}
         normalized_criteria = {
-            LegacySuport.from_key(k): criteria[k] for k in criteria
+            LegacySupport.from_key(k): criteria[k] for k in criteria
         }
         valid = ["status", "userid"]
         invalid_fields = set(normalized_criteria.keys()) - set(valid)
@@ -196,7 +196,7 @@ class JobManager(ZenModelRM):
             raise ValueError(
                 "Invalid criteria field: %s" % ", ".join(invalid_fields),
             )
-        normalized_key = LegacySuport.from_key(key)
+        normalized_key = LegacySupport.from_key(key)
         if normalized_key not in sortable_keys:
             raise ValueError("Invalid sort key: %s" % (key,))
         try:

--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -104,6 +104,24 @@ class JobRecord(object):
         return self.jobid
 
     @property
+    def job_description(self):
+        return self.description
+
+    @property
+    def job_name(self):
+        return self.name
+
+    @property
+    def job_type(self):
+        task = app.tasks.get(self.name)
+        if task is None:
+            return self.name if self.name else ""
+        try:
+            return task.getJobType()
+        except AttributeError:
+            return self.name
+
+    @property
     def duration(self):
         if (
             self.status in (states.PENDING, states.RECEIVED)
@@ -159,11 +177,11 @@ class JobRecordMarshaller(object):
         return {name: self._get_value(name) for name in fields}
 
     def _get_value(self, name):
-        key = LegacySuport.from_key(name)
+        key = LegacySupport.from_key(name)
         return getattr(self.__obj, key, None)
 
 
-class LegacySuport(object):
+class LegacySupport(object):
     """A namespace class for functions to aid in supporting legacy APIs.
     """
 

--- a/Products/Jobber/tests/test_model.py
+++ b/Products/Jobber/tests/test_model.py
@@ -25,7 +25,7 @@ from ..model import (
     IJobStore,
     JobRecord,
     JobRecordMarshaller,
-    LegacySuport,
+    LegacySupport,
     update_job_status,
 )
 from ..storage import JobStore, Fields
@@ -86,10 +86,26 @@ class JobRecordTest(TestCase):
         expected.extend((
             "details", "id", "make", "uid",
             "uuid", "duration", "complete", "abort", "wait", "result",
+            "job_description", "job_name", "job_type",
         ))
         expected = sorted(expected)
         actual = [a for a in dir(j) if not a.startswith("__")]
         t.assertListEqual(expected, actual)
+
+    def test_job_description(t):
+        j = JobRecord.make(t.data)
+        t.assertEqual(j.job_description, j.description)
+
+    def test_job_name(t):
+        j = JobRecord.make(t.data)
+        t.assertEqual(j.job_name, j.name)
+
+    def test_job_type(t):
+        from Products.Jobber.jobs import FacadeMethodJob
+        data = dict(t.data)
+        data["name"] = FacadeMethodJob.name
+        j = JobRecord.make(data)
+        t.assertEqual(j.job_type, FacadeMethodJob.getJobType())
 
     def test_details_are_exposed(t):
         j = JobRecord.make({})
@@ -351,7 +367,7 @@ class JobRecordMarshallerTest(TestCase):
         t.assertDictEqual(expected, serialized)
 
 
-class LegacySuportTest(TestCase):
+class LegacySupportTest(TestCase):
     """Test the LegacySupport class."""
 
     def test_new_keys(t):
@@ -369,7 +385,7 @@ class LegacySuportTest(TestCase):
         )
         for key in keys:
             with subTest(key=key):
-                actual = LegacySuport.from_key(key)
+                actual = LegacySupport.from_key(key)
                 t.assertEqual(key, actual)
 
     def test_legacy_keys(t):
@@ -380,5 +396,5 @@ class LegacySuportTest(TestCase):
         }
         for key in keys:
             with subTest(key=key):
-                actual = LegacySuport.from_key(key)
+                actual = LegacySupport.from_key(key)
                 t.assertEqual(keys[key], actual)


### PR DESCRIPTION
The job_name, job_type, and job_description attributes have been added back to the JobRecord class.

Fixes ZEN-33073.