### PR TITLE
Use the correct search field for job storage.

### DIFF
--- a/Products/Jobber/manager.py
+++ b/Products/Jobber/manager.py
@@ -375,7 +375,7 @@ class _SendTask(object):
 def _getByStatusAndType(statuses, jobtype=None):
     fields = {"status": statuses}
     if jobtype is not None:
-        fields["type"] = _getJobTypeStr(jobtype)
+        fields["name"] = _getJobTypeStr(jobtype)
     storage = getUtility(IJobStore, "redis")
     jobids = storage.search(**fields)
     result = storage.mget(*jobids)
@@ -384,8 +384,8 @@ def _getByStatusAndType(statuses, jobtype=None):
 
 def _getJobTypeStr(jobtype):
     if isinstance(jobtype, type):
-        if hasattr(jobtype, "getJobType"):
-            return jobtype.getJobType()
-        else:
-            return jobtype.__name__
-    return str(jobtype)
+        return jobtype.name
+    task = app.tasks.get(str(jobtype))
+    if not task:
+        raise ValueError("No such job: {!r}".format(jobtype))
+    return task.name

--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -155,6 +155,26 @@ class JobRecord(object):
             for fld in self.__slots__
         )
 
+    def __ne__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return any(
+            getattr(self, fld, None) != getattr(other, fld, None)
+            for fld in self.__slots__
+        )
+
+    def __str__(self):
+        return "<{0.__class__.__name__}: {1}>".format(
+            self,
+            " ".join(
+                "{0}={1!r}".format(name, getattr(self, name, None))
+                for name in self.__slots__
+            )
+        )
+
+    def __hash__(self):
+        raise TypeError("unhashable type: %r" % (type(self).__name__))
+
 
 @implementer(IMarshaller)
 class JobRecordMarshaller(object):

--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -147,6 +147,14 @@ class JobRecord(object):
     def result(self):
         return app.tasks[self.name].AsyncResult(self.jobid)
 
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+        return all(
+            getattr(self, fld, None) == getattr(other, fld, None)
+            for fld in self.__slots__
+        )
+
 
 @implementer(IMarshaller)
 class JobRecordMarshaller(object):


### PR DESCRIPTION
Locating types of jobs is done using the 'name' field.

Fixes ZEN-33075.