### PR TITLE
JobRecord doesn't have a getId method.

### DIFF
--- a/Products/ZenModel/DeviceOrganizer.py
+++ b/Products/ZenModel/DeviceOrganizer.py
@@ -430,7 +430,7 @@ class DeviceOrganizer(Organizer, DeviceManagerBase, Commandable, ZenMenuable,
             job = self.dmd.JobManager.addJob(
                 DeviceSetLocalRolesJob, description="Update Local Roles on %s" % path,
                 kwargs=dict(organizerUid=path))
-            href = "/zport/dmd/joblist#jobs:%s" % (job.getId())
+            href = "/zport/dmd/joblist#jobs:%s" % (job.jobid,)
             messaging.IMessageSender(self).sendToBrowser(
                 'Job Added',
                 'Job Added for setting the roles on the organizer %s, view the <a href="%s"> job log</a>' % (path, href)


### PR DESCRIPTION
The correct syntax to retrieve a job's ID is `jobid`.

Fixes ZEN-33079.