### PR TITLE
Implement 'celery beat' as a service.

### DIFF
--- a/Products/Jobber/config.py
+++ b/Products/Jobber/config.py
@@ -23,6 +23,10 @@ _default_configs = {
     "maxbackuplogs": "3",
     "job-log-path": "/opt/zenoss/log/jobs",
 
+    "scheduler-config-file": "/opt/zenoss/etc/zenjobs_schedule.yaml",
+    "scheduler-max-loop-interval": 300,  # 5 minutes
+    "scheduler-sync-interval": 180,  # 3 minutes
+
     "zodb-config-file": "/opt/zenoss/etc/zodb.conf",
     "zodb-max-retries": 5,
     "max-jobs-per-worker": "100",
@@ -103,6 +107,17 @@ class Celery(object):
     CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
     CELERY_TASK_SERIALIZER = "without-unicode"
     CELERY_TRACK_STARTED = True
+
+    # Beat (scheduler) configuration
+    CELERYBEAT_MAX_LOOP_INTERVAL = int(
+        ZenJobs.get("scheduler-max-loop-interval"),
+    )
+    CELERYBEAT_SYNC_EVERY = int(ZenJobs.get("scheduler-sync-interval"))
+    CELERYBEAT_LOG_FILE = os.path.join(
+        ZenJobs.get("logpath"), "zenjobs-scheduler.log",
+    )
+    CELERYBEAT_REDIRECT_STDOUTS = True
+    CELERYBEAT_REDIRECT_STDOUTS_LEVEL = "INFO"
 
     # Event settings
     CELERY_SEND_EVENTS = True

--- a/Products/Jobber/jobs/__init__.py
+++ b/Products/Jobber/jobs/__init__.py
@@ -17,6 +17,7 @@ from .misc import (  # noqa: F401
     DelayedFailure,
     pause,
 )
+from .purge_logs import purge_logs  # noqa F401
 from .roles import DeviceSetLocalRolesJob  # noqa: F401
 from .subprocess import SubprocessJob  # noqa: F401
 

--- a/Products/Jobber/jobs/purge_logs.py
+++ b/Products/Jobber/jobs/purge_logs.py
@@ -1,0 +1,46 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020 all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+import os
+
+from ..config import ZenJobs
+from ..task import requires, Abortable
+from ..zenjobs import app
+
+
+@app.task(
+    bind=True,
+    base=requires(Abortable),
+    name="zen.zenjobs.purge_logs",
+    summary="Delete the logs of deleted jobs",
+    ignore_result=True,
+)
+def purge_logs(self):
+    backend = app.backend
+    saved_keys = set(
+        key.replace(backend.task_keyprefix, "")
+        for key in backend.client.keys("%s*" % backend.task_keyprefix)
+    )
+    logpath = ZenJobs.get("job-log-path")
+    logfiles = os.listdir(logpath)
+    if not logfiles:
+        self.log.info("No log files to remove")
+    removed = []
+    for logfile in logfiles:
+        keyname = logfile.rstrip(".log")
+        if keyname not in saved_keys:
+            try:
+                os.remove(os.path.join(logpath, logfile))
+                self.log.info("Removed %s", logfile)
+                removed.append(logfile)
+            except Exception as ex:
+                self.log.error("Could not remove %s: %s", logfile, ex)
+    self.log.info("Removed %s log files", len(removed))

--- a/Products/Jobber/scheduler.py
+++ b/Products/Jobber/scheduler.py
@@ -1,0 +1,221 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+import json
+import redis
+import time
+import yaml
+
+from celery.beat import Scheduler
+from celery.schedules import crontab
+from datetime import datetime, timedelta
+
+from .config import ZenJobs, Celery
+
+
+class ZenJobsScheduler(Scheduler):
+    """A Celery beat scheduler for periodic jobs.
+
+    The last run time and count of runs for each schedule entry are stored
+    in Redis.
+
+    The schedule is defined in a configuration file.  The configuration file
+    is in YAML.  Each schedule entry has the following format:
+
+        name-of-entry:
+          task: "name of task"
+          args: [list, of, positional, arguments, to, task]
+          kwargs:
+            key: value
+          options:
+            key: value
+          schedule:
+            <cron | interval>:
+              <key/value for schedule>
+
+    The required keys for an entry are 'task' and 'schedule'.
+
+    An 'interval' schedule looks like the following:
+
+        interval-example:
+          task: "some.job"
+          schedule:
+            interval:
+              seconds: 90
+
+    This specifies that the 'interval-example' schedule will run the
+    "some.job" task every 90 seconds.  Interval schedules accept only
+    the 'seconds' key/value argument.
+
+    A 'cron' schedule looks like the following:
+
+        cron-example:
+          task: "some.job"
+          schedule:
+            cron:
+              minute: "*/15"
+              hour: "8-17"
+              day_of_week: "mon-fri"
+
+    This specifies that the 'cron-example' schedule will run the "some.job"
+    task every fifteen minutes, between the hours of 8am and 5pm, monday
+    through friday.  The key/value arguments for a 'cron' schedule are
+    'minute', 'hour', 'day_of_week', 'day_of_month', and 'month_of_year'.
+    More details on cron are found here:
+    https://docs.celeryproject.org/en/3.1/userguide/periodic-tasks.html#crontab-schedules
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__entries = {}
+        super(ZenJobsScheduler, self).__init__(*args, **kwargs)
+
+    def setup_schedule(self):
+        """Initialize the scheduler.
+        """
+        # Retrieve the previously saved schedule from redis.
+        raw_data = _getClient().get(_key("entries")) or "{}"
+        schedule_stats = ScheduleStatsDecoder().decode(raw_data)
+
+        # Retrieve the schedule from the configuration file
+        schedule = load_schedule()
+
+        relevant_stats = (
+            (k, v) for k, v in schedule.iteritems() if k in schedule_stats
+        )
+        for name, entry in relevant_stats:
+            entry_stats = schedule_stats[name]
+            last_run_at = entry_stats["last_run_at"]
+            if last_run_at is not None:
+                last_run_at = datetime.fromtimestamp(last_run_at)
+            entry["last_run_at"] = last_run_at
+            entry["total_run_count"] = entry_stats["total_run_count"]
+
+        # Update scheduler state
+        self.update_from_dict(schedule)
+
+        # Add 'default' entries to the schedule
+        self.install_default_entries(schedule)
+
+        # Save to redis.
+        self.sync()
+
+    @property
+    def schedule(self):
+        return self.__entries
+
+    @property
+    def info(self):
+        return "    . schedule-file -> {}".format(
+            ZenJobs.get("scheduler-config-file"),
+        )
+
+    def sync(self):
+        stats = {
+            k: {
+                "total_run_count": v.total_run_count,
+                "last_run_at": v.last_run_at,
+            }
+            for k, v in self.__entries.iteritems()
+        }
+        encoded = json.dumps(stats, cls=DatetimeEncoder)
+        _getClient().set(_key("entries"), encoded)
+
+    def close(self):
+        self.sync()
+
+
+_valid_fields = set(("task", "args", "kwargs", "options", "schedule"))
+
+
+def load_schedule():
+    configfile = ZenJobs.get("scheduler-config-file")
+    with open(configfile, "r") as f:
+        raw = yaml.load(f, Loader=yaml.loader.SafeLoader)
+    parsed_schedule = {}
+    for name, entry in raw.viewitems():
+
+        # Check for unknown fields
+        unknowns = set(entry) - _valid_fields
+        if unknowns:
+            raise RuntimeError(
+                "Schedule '{}' contains invalid fields: {}".format(
+                    name, ",".join(unknowns),
+                )
+            )
+
+        # Extract known fields.
+        fields = {
+            k: entry[k]
+            for k in ("task", "args", "kwargs", "options")
+            if k in entry
+        }
+
+        # Convert the value of the 'args' field, if present, into a tuple.
+        if "args" in fields:
+            fields["args"] = tuple(fields["args"])
+
+        # Transform the value of the 'schedule' field into its
+        # specified object.
+        schedule = entry["schedule"]
+        if len(schedule) != 1:
+            raise RuntimeError(
+                "Schedule '{}' may have only one schedule".foramt(name)
+            )
+        if "cron" in schedule:
+            cron_args = schedule["cron"]
+            fields["schedule"] = crontab(**cron_args)
+        elif "interval" in schedule:
+            interval_args = schedule["interval"]
+            fields["schedule"] = timedelta(**interval_args)
+        else:
+            raise RuntimeError(
+                "Schedule '{}' has an unknown schedule type: {}".format(
+                    name, schedule.keys()[0]
+                )
+            )
+
+        parsed_schedule[name] = fields
+
+    return parsed_schedule
+
+
+class ScheduleStatsDecoder(json.JSONDecoder):
+    """Convert "last_run_at" field values from UNIX times to datetimes.
+    """
+
+    def default(self, obj):
+        if "last_run_at" in obj:
+            obj["last_run_at"] = datetime.fromtimestamp(obj["last_run_at"])
+        return obj
+
+
+class DatetimeEncoder(json.JSONEncoder):
+    """Encode datetime.datetime types into UNIX epoch timestamp.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, datetime):
+            return time.mktime(obj.timetuple()) + (obj.microsecond * 1e-6)
+
+
+_keybase = "zenjobs:schedule:"
+_keytemplate = "{}{{}}".format(_keybase)
+# _keypattern = _keybase + "*"
+
+
+def _key(name):
+    """Return the redis key for the given name."""
+    return _keytemplate.format(name)
+
+
+def _getClient():
+    """Create and return the ZenJobs JobStore client."""
+    return redis.StrictRedis.from_url(Celery.CELERY_RESULT_BACKEND)


### PR DESCRIPTION
Adds a custom scheduler for the Celery's 'beat' command.
Adds a task that deletes job logs which is executed periodically by the 'beat' command.

Fixes ZEN-30586.