### PR TITLE
Retry with backoff delay on ConflictErrors.

### DIFF
--- a/Products/Jobber/config.py
+++ b/Products/Jobber/config.py
@@ -29,6 +29,7 @@ _default_configs = {
 
     "zodb-config-file": "/opt/zenoss/etc/zodb.conf",
     "zodb-max-retries": 5,
+    "zodb-retry-interval-limit": 30,  # 30 seconds
     "max-jobs-per-worker": "100",
     "concurrent-jobs": "1",
     "job-expires": 604800,  # 7 days

--- a/Products/Jobber/task/utils.py
+++ b/Products/Jobber/task/utils.py
@@ -9,8 +9,13 @@
 
 from __future__ import absolute_import
 
+import functools
 import inspect
+import random
+import threading
+import transaction
 
+from ZODB.POSException import ConflictError, ReadConflictError
 from zope.component import getUtility
 
 from ..interfaces import IJobStore
@@ -50,3 +55,92 @@ def job_log_has_errors(task_id):
             )
     except Exception:
         return False
+
+
+def transact(f, retries, numbers, sleep=None, ctx=None):
+    """Transactional version of f with backoff between retries.
+
+    :param int retries: maximum number of retries before giving up.
+    :param numbers: An infinite generator of floats.
+    :param sleep: An object that has a wait() method that accepts a float
+        produced by numbers.
+    :param ctx: the transaction having commit and abort methods.
+    """
+
+    sleeper = threading.Event() if sleep is None else sleep
+    tx = transaction if ctx is None else ctx
+
+    @functools.wraps(f)
+    def transactional(*args, **kw):
+        tries_remaining = retries
+
+        while tries_remaining:
+            tries_remaining -= 1
+
+            # Call the wrapped function
+            try:
+                result = f(*args, **kw)
+            except ReadConflictError:
+                try:
+                    if not tries_remaining:
+                        raise
+                    # Wait before aborting the transaction so that the
+                    # process is not sitting idle with a new transaction.
+                    duration = next(numbers)
+                    sleeper.wait(duration)
+                finally:
+                    tx.abort()
+                continue
+
+            # Commit the transaction.
+            try:
+                tx.commit()
+            except ConflictError:
+                try:
+                    if not tries_remaining:
+                        raise
+                    # Wait before aborting the transaction so that the
+                    # process is not sitting idle with a new transaction.
+                    duration = next(numbers)
+                    sleeper.wait(duration)
+                finally:
+                    tx.abort()
+                continue
+
+            return result
+        raise RuntimeError("Couldn't commit transaction")
+
+    return transactional
+
+
+def backoff(limit, numbers):
+    """Returns a float producing infinite generator.
+
+    The backoff generator will produce a range of floats corresponding to the
+    distribution of values produced from the numbers generator.  In general,
+    the values are in the range of 0 < x <= limit.
+
+    The numbers function accepts a number and returns a generator that
+    produces floats.
+
+    @param int limit: The largest number possible that can be returned.
+    @param numbers: A function that takes a float and returns
+        an infinite generator.
+    @type numbers: Callable[float, Generator]
+    """
+    maxv = float(limit) / 2
+    gen = numbers(maxv)
+    while True:
+        base = next(gen)
+        offset = random.uniform(0, base)
+        yield base + offset
+
+
+def fibonacci(max_value):
+    """An infinite generator returning Fibonacci number <= max_value.
+    """
+    a, b = 0, 1  # the zero is never emitted from the generator.
+    while True:
+        if b <= max_value:
+            a, b = b, a + b
+        yield a

--- a/Products/Jobber/tests/test_task_utils.py
+++ b/Products/Jobber/tests/test_task_utils.py
@@ -316,9 +316,10 @@ class TransactTest(TestCase):
             tx()
 
         c.commit.assert_not_called()
-        abort_calls = [call() for _ in range(retries)]
+        total_aborts = (retries * 2) - 1
+        abort_calls = [call() for _ in range(total_aborts)]
         c.abort.assert_has_calls(abort_calls, any_order=True)
-        t.assertEqual(c.abort.call_count, retries)
+        t.assertEqual(c.abort.call_count, total_aborts)
 
         # Only four calls to wait(); there is no wait after the final attempt.
         wait_calls = [call(v) for v in delays[:retries - 1]]
@@ -349,9 +350,10 @@ class TransactTest(TestCase):
         c.commit.assert_has_calls(commit_calls, any_order=True)
         t.assertEqual(c.commit.call_count, retries)
 
-        abort_calls = [call() for _ in range(retries)]
+        total_aborts = (retries * 2) - 1
+        abort_calls = [call() for _ in range(total_aborts)]
         c.abort.assert_has_calls(abort_calls, any_order=True)
-        t.assertEqual(c.abort.call_count, retries)
+        t.assertEqual(c.abort.call_count, total_aborts)
 
         # Only four calls to wait(); there is no wait after the final attempt.
         wait_calls = [call(v) for v in delays[:retries - 1]]
@@ -390,11 +392,11 @@ class TransactTest(TestCase):
         t.assertEqual(c.commit.call_count, 3)
 
         # Abort call count is one less than the commit call count.
-        abort_calls = [call(), call()]
+        abort_calls = [call(), call(), call(), call()]
         c.abort.assert_has_calls(abort_calls, any_order=True)
-        t.assertEqual(c.abort.call_count, 2)
+        t.assertEqual(c.abort.call_count, len(abort_calls))
 
         # The number of wait calls should match the number of abort calls.
-        wait_calls = [call(v) for v in delays[:len(abort_calls)]]
+        wait_calls = [call(v) for v in delays[:len(abort_calls) / 2]]
         s.wait.assert_has_calls(wait_calls, any_order=True)
-        t.assertEqual(s.wait.call_count, 2)
+        t.assertEqual(s.wait.call_count, len(wait_calls))

--- a/Products/Jobber/tests/test_task_utils.py
+++ b/Products/Jobber/tests/test_task_utils.py
@@ -9,10 +9,20 @@
 
 from __future__ import absolute_import, print_function
 
-from mock import MagicMock, mock_open, patch
+import math
+
+from mock import call, MagicMock, mock_open, patch
 from unittest import TestCase
-from Products.Jobber.task.utils import job_log_has_errors
 from zope.component import getGlobalSiteManager, ComponentLookupError
+
+from Products.Jobber.task.utils import (
+    backoff,
+    ConflictError,
+    fibonacci,
+    job_log_has_errors,
+    ReadConflictError,
+    transact,
+)
 
 from ..interfaces import IJobStore
 from ..storage import JobStore
@@ -90,3 +100,301 @@ class JobLogHasErrorsTest(TestCase):
         ))
         with patch("__builtin__.open", _open):
             t.assertTrue(job_log_has_errors("123"))
+
+
+def is_perfect_square(n):
+    s = int(math.sqrt(n))
+    return (s * s) == n
+
+
+def is_fibonacci(n):
+    x = 5 * n * n
+    return is_perfect_square(x + 4) or is_perfect_square(x - 4)
+
+
+class FibonacciTest(TestCase):
+    """Test the fibonacci generator function.
+    """
+
+    def test_correctness(t):
+        limit = 10
+        for i, n in enumerate(fibonacci(100)):
+            if i >= limit:
+                break
+            t.assertTrue(is_fibonacci(n))
+
+    def test_infiniteness(t):
+        gen = fibonacci(30)
+        iterations = 20
+        repetitions = 0
+        p, n = 0, next(gen)
+        for i in range(iterations):
+            if p == n:
+                repetitions += 1
+            p, n = n, next(gen)
+        t.assertEqual(repetitions, 13)
+
+    def test_limit_inexact(t):
+        limit = 15
+        gen = fibonacci(limit)
+        samples = []
+        for i in range(100):
+            samples.append(next(gen))
+        t.assertTrue(all(n <= limit for n in samples), samples)
+
+    def test_limit_exact(t):
+        limit = 34
+        gen = fibonacci(limit)
+        samples = []
+        for i in range(100):
+            samples.append(next(gen))
+        t.assertTrue(all(n <= limit for n in samples), samples)
+
+
+class BackoffWithFibonacciTest(TestCase):
+    """Test the backoff function with the fibonacci generator.
+    """
+
+    def setUp(t):
+        t.limit = 30
+        gen = backoff(t.limit, fibonacci)
+        t.samples = []
+        for i in range(1000):
+            t.samples.append(next(gen))
+
+    def tearDown(t):
+        del t.samples
+
+    # A limit of 30 gives a median of 15.  Since we're using fibonacci
+    # numbers, the median is actually 13 (highest number <= 15).
+
+    def test_initial(t):
+        expected = [1, 1, 2, 3, 5, 8, 13]
+        actual = t.samples[:len(expected)]
+        for e, a in zip(expected, actual):
+            t.assertLessEqual(a, e * 2)
+            t.assertGreaterEqual(a, e)
+
+    def test_backoff_range(t):
+        # All samples starting with offset 7 should be 13 <= x <= 26.
+        offset = 7
+        minimum = 13
+        actual = t.samples[offset:]
+        for a in actual:
+            t.assertLessEqual(a, minimum * 2)
+            t.assertGreaterEqual(a, minimum)
+
+    def test_backoff_average(t):
+        # The median value should be around 19.5 (<- 13 + 6.5)
+        offset = 7
+        subrange = t.samples[offset:]
+        avg = math.fsum(subrange) / len(subrange)
+        t.assertAlmostEqual(avg, 19.5, delta=0.5)
+
+    def test_backoff_median(t):
+        # The median value should be around 19.5 (<- 13 + 6.5)
+        offset = 7
+        subrange = t.samples[offset:]
+        maxv = max(subrange)
+        minv = min(subrange)
+        median = math.fsum((maxv, minv)) / 2
+        t.assertAlmostEqual(median, 19.5, places=1)
+
+
+def _linear(limit):
+    a = 0
+    while True:
+        if a < limit:
+            a += 1
+        yield a
+
+
+class BackoffWithLinearTest(TestCase):
+    """Test the backoff function with a linear number generator.
+    """
+
+    def setUp(t):
+        gen = backoff(30, _linear)
+        t.samples = []
+        for i in range(1000):
+            t.samples.append(next(gen))
+
+    def tearDown(t):
+        del t.samples
+
+    # A limit of 30 means a max median of 15.
+
+    def test_initial(t):
+        expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        actual = t.samples[:len(expected)]
+        for e, a in zip(expected, actual):
+            t.assertLessEqual(a, e * 2)
+            t.assertGreaterEqual(a, e)
+
+    def test_backoff_range(t):
+        # All samples starting with offset 15 should be 15 <= x <= 30.
+        offset = 15
+        minimum = 15
+        actual = t.samples[offset:]
+        for a in actual:
+            t.assertLessEqual(a, minimum * 2)
+            t.assertGreaterEqual(a, minimum)
+
+    def test_backoff_average(t):
+        # The median value should be around 19.5 (<- 13 + 6.5)
+        offset = 15
+        subrange = t.samples[offset:]
+        avg = math.fsum(subrange) / len(subrange)
+        t.assertAlmostEqual(avg, 22.5, delta=0.5)
+
+    def test_backoff_median(t):
+        # The median value should be around 19.5 (<- 13 + 6.5)
+        offset = 15
+        subrange = t.samples[offset:]
+        maxv = max(subrange)
+        minv = min(subrange)
+        median = math.fsum((maxv, minv)) / 2
+        t.assertAlmostEqual(median, 22.5, places=1)
+
+
+class TransactTest(TestCase):
+    """Test the transact decorator.
+    """
+
+    def test_nominal_no_args(t):
+        expected = (10, 1)
+
+        def func():
+            return expected
+
+        b = MagicMock()
+        s = MagicMock()
+        c = MagicMock()
+        retries = 5
+        tx = transact(func, retries, b, sleep=s, ctx=c)
+        actual = tx()
+        t.assertSequenceEqual(expected, actual)
+        c.commit.assert_called_once_with()
+        c.abort.assert_not_called()
+
+    def test_nominal_with_args(t):
+        args = (10,)
+        kw = {"a": 1}
+
+        def func(arg, a=None):
+            return arg, a
+
+        expected = (10, 1)
+
+        b = MagicMock()
+        s = MagicMock()
+        c = MagicMock()
+        retries = 5
+        tx = transact(func, retries, b, sleep=s, ctx=c)
+        actual = tx(*args, **kw)
+        t.assertSequenceEqual(expected, actual)
+        c.commit.assert_called_once_with()
+        c.abort.assert_not_called()
+
+    def test_readconflict(t):
+        def func():
+            raise ReadConflictError()
+
+        delays = list(range(1, 10))
+
+        def b():
+            for i in delays:
+                yield i
+
+        bgen = b()
+        s = MagicMock()
+        c = MagicMock()
+        retries = 5
+        tx = transact(func, retries, bgen, sleep=s, ctx=c)
+
+        with t.assertRaises(ReadConflictError):
+            tx()
+
+        c.commit.assert_not_called()
+        abort_calls = [call() for _ in range(retries)]
+        c.abort.assert_has_calls(abort_calls, any_order=True)
+        t.assertEqual(c.abort.call_count, retries)
+
+        # Only four calls to wait(); there is no wait after the final attempt.
+        wait_calls = [call(v) for v in delays[:retries - 1]]
+        s.wait.assert_has_calls(wait_calls, any_order=True)
+        t.assertEqual(s.wait.call_count, retries - 1)
+
+    def test_conflict(t):
+        def func():
+            pass
+
+        delays = list(range(1, 10))
+
+        def b():
+            for i in delays:
+                yield i
+
+        bgen = b()
+        s = MagicMock()
+        c = MagicMock()
+        c.commit.side_effect = ConflictError()
+        retries = 5
+        tx = transact(func, retries, bgen, sleep=s, ctx=c)
+
+        with t.assertRaises(ConflictError):
+            tx()
+
+        commit_calls = [call() for _ in range(retries)]
+        c.commit.assert_has_calls(commit_calls, any_order=True)
+        t.assertEqual(c.commit.call_count, retries)
+
+        abort_calls = [call() for _ in range(retries)]
+        c.abort.assert_has_calls(abort_calls, any_order=True)
+        t.assertEqual(c.abort.call_count, retries)
+
+        # Only four calls to wait(); there is no wait after the final attempt.
+        wait_calls = [call(v) for v in delays[:retries - 1]]
+        s.wait.assert_has_calls(wait_calls, any_order=True)
+        t.assertEqual(s.wait.call_count, retries - 1)
+
+    def test_resolves_conflict(t):
+        def func():
+            pass
+
+        delays = list(range(1, 10))
+
+        def b():
+            for i in delays:
+                yield i
+
+        def effect(data):
+            def effecter():
+                if data.count < 2:
+                    data.count += 1
+                    raise ConflictError()
+            return effecter
+
+        bgen = b()
+        s = MagicMock()
+
+        data = type("data", (object,), {"count": 0})()
+        c = MagicMock()
+        c.commit.side_effect = effect(data)
+        retries = 5
+        tx = transact(func, retries, bgen, sleep=s, ctx=c)
+        tx()
+
+        commit_calls = [call(), call(), call()]
+        c.commit.assert_has_calls(commit_calls, any_order=True)
+        t.assertEqual(c.commit.call_count, 3)
+
+        # Abort call count is one less than the commit call count.
+        abort_calls = [call(), call()]
+        c.abort.assert_has_calls(abort_calls, any_order=True)
+        t.assertEqual(c.abort.call_count, 2)
+
+        # The number of wait calls should match the number of abort calls.
+        wait_calls = [call(v) for v in delays[:len(abort_calls)]]
+        s.wait.assert_has_calls(wait_calls, any_order=True)
+        t.assertEqual(s.wait.call_count, 2)


### PR DESCRIPTION
Use a randomized fibonacci-ish delay before retrying a transaction that failed with a ConflictError or a ReadConflictError.

Fixes ZEN-30746.