### PR TITLE
JobManager now mimics transactions.

### DIFF
--- a/Products/Jobber/configure.zcml
+++ b/Products/Jobber/configure.zcml
@@ -22,6 +22,11 @@
         handler=".model.save_jobrecord"
         />
 
+    <celery:signal
+        name="before_task_publish"
+        handler=".model.commit_jobrecord"
+        />
+
     <adapter
         provides="Products.Zuul.interfaces.IMarshaller"
         for=".interfaces.IJobRecord"

--- a/Products/Jobber/jobs/subprocess.py
+++ b/Products/Jobber/jobs/subprocess.py
@@ -43,8 +43,9 @@ class SubprocessJob(Job):
         return "Shell Command"
 
     @classmethod
-    def getJobDescription(cls, cmd, environ=None):
+    def getJobDescription(cls, *args, **ignored):
         """Return a description of the job."""
+        cmd = args[0] if args else ""
         return cmd if isinstance(cmd, basestring) else " ".join(cmd)
 
     def _run(self, cmd, environ=None):

--- a/Products/Jobber/task/base.py
+++ b/Products/Jobber/task/base.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, print_function
 
 import logging
 import time
+import uuid
 
 from AccessControl.SecurityManagement import getSecurityManager
 from celery import Task, states
@@ -76,6 +77,7 @@ class ZenTask(SendZenossEventMixin, Task):
         headers = kw.setdefault("headers", {})
         userid = getSecurityManager().getUser().getId()
         headers["userid"] = userid
+        kw["task_id"] = str(uuid.uuid4())
         return super(ZenTask, self).subtask(*args, **kw)
 
     def after_return(self, status, retval, task_id, args, kwargs, eninfo):

--- a/Products/Jobber/tests/test_zentask.py
+++ b/Products/Jobber/tests/test_zentask.py
@@ -95,8 +95,11 @@ class ZenTaskTest(TestCase):
         _get_task_logger.assert_called_with(t.task_name)
         t.assertEqual(_get_task_logger.return_value, log)
 
-    def test_subtask(t):
-        expected = {"headers": {"userid": None}}
+    @patch("Products.Jobber.task.base.uuid", autospec=True)
+    def test_subtask(t, _uuid):
+        jobid = "1234"
+        _uuid.uuid4.return_value = jobid
+        expected = {"headers": {"userid": None}, "task_id": jobid}
         task = t.simple_task.subtask()
         t.assertIsInstance(task, Signature)
         t.assertDictEqual(expected, task.options)


### PR DESCRIPTION
When submitting jobs via JobManager, jobs are not submitted to zenjobs until the current database transaction is committed.  JobManager's other methods for retrieving jobs should return jobs that have been submitted, but not committed yet.

Fixes ZEN-33084.