### PR TITLE
ZEN-32255 Updated varbind behavior breaks RFC conventions

### DIFF
--- a/Products/ZenEvents/tests/test_zentrap.py
+++ b/Products/ZenEvents/tests/test_zentrap.py
@@ -2,8 +2,8 @@ import base64
 import logging
 
 from struct import pack
+from unittest import TestCase
 
-from Products.ZenTestCase.BaseTestCase import BaseTestCase
 from Products.ZenEvents.zentrap import (
     decode_snmp_value, TrapTask, FakePacket, SNMPv1, SNMPv2
 )
@@ -11,7 +11,13 @@ from Products.ZenEvents.zentrap import (
 log = logging.getLogger("test_zentrap")
 
 
-class DecodersUnitTest(BaseTestCase):
+class DecodersUnitTest(TestCase):
+
+    def setUp(self):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        logging.disable(logging.NOTSET)
 
     def test_decode_oid(self):
         value = (1, 2, 3, 4)
@@ -158,7 +164,7 @@ class MockTrapTask(TrapTask):
         self.log = log
 
 
-class TestOid2Name(BaseTestCase):
+class TestOid2Name(TestCase):
 
     def test_NoExactMatch(self):
         oidMap = {}
@@ -210,7 +216,7 @@ class TestOid2Name(BaseTestCase):
         self.assertEqual(task.oid2name((1, 2, 3, 4)), "1.2.3.4")
 
 
-class TestDecodeSnmpV1(BaseTestCase):
+class _SnmpV1Base(object):
 
     def makeInputs(self, trapType=6, oidMap={}, variables=()):
         pckt = FakePacket()
@@ -230,6 +236,9 @@ class TestDecodeSnmpV1(BaseTestCase):
         pckt.community = "community"
 
         return pckt, MockTrapTask(oidMap)
+
+
+class TestDecodeSnmpV1(TestCase, _SnmpV1Base):
 
     def test_NoAgentAddr(self):
         pckt, task = self.makeInputs()
@@ -297,202 +306,8 @@ class TestDecodeSnmpV1(BaseTestCase):
         self.assertEqual(eventType, "1.2.3.4.5")
         self.assertEqual(result["snmpV1GenericTrapType"], 6)
 
-    def test_VarBindOneValue(self):
-        pckt, task = self.makeInputs(variables=(
-            ((1, 2, 6, 7), "foo"),
-        ))
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        self.assertEqual(result["1.2.6.7"], "foo")
 
-    def test_VarBindMultiValue(self):
-        pckt, task = self.makeInputs(variables=(
-            ((1, 2, 6, 7), "foo"),
-            ((1, 2, 6, 7), "bar"),
-            ((1, 2, 6, 7), "baz"),
-        ))
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
-
-    def test_UnknownMultiVarBind(self):
-        pckt, task = self.makeInputs(variables=(
-            ((1, 2, 6, 0), "foo"),
-            ((1, 2, 6, 1), "bar"),
-        ))
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("1.2.6.0", result)
-        self.assertIn("1.2.6.1", result)
-        self.assertEqual(result["1.2.6.0"], "foo")
-        self.assertEqual(result["1.2.6.1"], "bar")
-
-    def test_NamedVarBindOneValue(self):
-        pckt, task = self.makeInputs(
-            variables=(((1, 2, 6, 7), "foo"),),
-            oidMap={"1.2.6.7": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertIn("testVar", result)
-        self.assertEqual(result["testVar"], "foo")
-
-    def test_NamedVarBindMultiValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 7), "baz"),
-            ),
-            oidMap={"1.2.6.7": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertIn("testVar", result)
-        self.assertEqual(result["testVar"], "foo,bar,baz")
-
-    def test_PartialNamedVarBindOneValue(self):
-        pckt, task = self.makeInputs(
-            variables=(((1, 2, 6, 7), "foo"),),
-            oidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.7"], "foo")
-        self.assertEqual(result["testVar.sequence"], "7")
-
-    def test_PartialNamedVarBindMultiValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 7), "baz"),
-            ),
-            oidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.7"], "foo,bar,baz")
-        self.assertEqual(result["testVar.sequence"], "7,7,7")
-
-    def test_PartialNamedMultiVarBind(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 0), "foo"),
-                ((1, 2, 6, 1), "bar"),
-                ((1, 2, 6, 2), "baz"),
-            ),
-            oidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 4)
-        self.assertIn("testVar.0", result)
-        self.assertIn("testVar.1", result)
-        self.assertIn("testVar.2", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.0"], "foo")
-        self.assertEqual(result["testVar.1"], "bar")
-        self.assertEqual(result["testVar.2"], "baz")
-        self.assertEqual(result["testVar.sequence"], "0,1,2")
-
-    def test_PartialNamedVarBindNoneValue(self):
-        pckt, task = self.makeInputs(
-            variables=(((1, 2, 6, 0), None),),
-            oidMap={"1.2.6.0": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertIn("testVar", result)
-        self.assertEqual(result["testVar"], "None")
-
-    def test_PartialNamedMultiVarBindOrder(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 0), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 3), "baz"),
-            ),
-            oidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 4)
-        self.assertIn("testVar.0", result)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.3", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.0"], "foo")
-        self.assertEqual(result["testVar.7"], "bar")
-        self.assertEqual(result["testVar.3"], "baz")
-        self.assertEqual(result["testVar.sequence"], "0,7,3")
-
-    def test_ifentry_trap(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
-                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 7, 143), 2),
-                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 8, 143), 2),
-                ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
-                ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
-            ),
-            oidMap={
-                "1.3.6.1.2.1.2.2.1.1": "ifIndex",
-                "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
-                "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
-                "1.3.6.1.2.1.2.2.1.2": "ifDescr",
-                "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
-            }
-        )
-        eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
-
-        totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifIndex.143", result)
-        self.assertIn("ifIndex.sequence", result)
-        self.assertEqual(result["ifIndex.143"], "143")
-        self.assertEqual(result["ifIndex.sequence"], "143")
-
-        totalVarKeys = sum(1 for k in result if k.startswith("ifAdminStatus"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifAdminStatus.143", result)
-        self.assertIn("ifAdminStatus.sequence", result)
-        self.assertEqual(result["ifAdminStatus.143"], "2")
-        self.assertEqual(result["ifAdminStatus.sequence"], "143")
-
-        totalVarKeys = sum(1 for k in result if k.startswith("ifOperStatus"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifOperStatus.143", result)
-        self.assertIn("ifOperStatus.sequence", result)
-        self.assertEqual(result["ifOperStatus.143"], "2")
-        self.assertEqual(result["ifOperStatus.sequence"], "143")
-
-        totalVarKeys = sum(1 for k in result if k.startswith("ifDescr"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifDescr.143", result)
-        self.assertIn("ifDescr.sequence", result)
-        self.assertEqual(result["ifDescr.143"], "F23")
-        self.assertEqual(result["ifDescr.sequence"], "143")
-
-        totalVarKeys = sum(1 for k in result if k.startswith("ifAlias"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifAlias.143", result)
-        self.assertIn("ifAlias.sequence", result)
-        self.assertEqual(result["ifAlias.143"], "")
-        self.assertEqual(result["ifAlias.sequence"], "143")
-
-
-class TestDecodeSnmpV2(BaseTestCase):
+class _SnmpV2Base(object):
 
     baseOidMap = {
         # Std var binds in SnmpV2 traps/notifications
@@ -531,10 +346,14 @@ class TestDecodeSnmpV2(BaseTestCase):
         return MockTrapTask(oidMap)
 
     def makeInputs(
-            self, trapOID="1.3.6.1.6.3.1.1.5.1", variables=(), extraOidMap={}):
+        self, trapOID="1.3.6.1.6.3.1.1.5.1", variables=(), oidMap={},
+    ):
         pckt = self.makePacket(trapOID=trapOID, variables=variables)
-        task = self.makeTask(extraOidMap=extraOidMap)
+        task = self.makeTask(extraOidMap=oidMap)
         return pckt, task
+
+
+class TestDecodeSnmpV2(TestCase, _SnmpV2Base):
 
     def test_UnknownTrapType(self):
         pckt, task = self.makeInputs(trapOID="1.2.3")
@@ -562,7 +381,7 @@ class TestDecodeSnmpV2(BaseTestCase):
             variables=(
                 ((1, 3, 6, 1, 6, 3, 18, 1, 3), "192.168.51.100"),
             ),
-            extraOidMap={
+            oidMap={
                 "1.3.6.1.6.3.18.1.3": "snmpTrapAddress"
             }
         )
@@ -585,113 +404,6 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertEqual(eventType, "snmp_linkUp")
         self.assertEqual(result["oid"], "1.3.6.1.6.3.1.1.5.4")
 
-    def test_VarBindMultiValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 7), "baz"),
-            )
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
-
-    def test_UnknownMultiVarBind(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 0), "foo"),
-                ((1, 2, 6, 1), "bar"),
-            )
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("1.2.6.0", result)
-        self.assertIn("1.2.6.1", result)
-        self.assertEqual(result["1.2.6.0"], "foo")
-        self.assertEqual(result["1.2.6.1"], "bar")
-
-    def test_NamedVarBindOneValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-            ),
-            extraOidMap={"1.2.6.7": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertIn("testVar", result)
-        self.assertEqual(result["testVar"], "foo")
-
-    def test_NamedVarBindMultiValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 7), "baz"),
-            ),
-            extraOidMap={"1.2.6.7": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 1)
-        self.assertIn("testVar", result)
-        self.assertEqual(result["testVar"], "foo,bar,baz")
-
-    def test_PartialNamedVarBindOneValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-            ),
-            extraOidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.7"], "foo")
-        self.assertEqual(result["testVar.sequence"], "7")
-
-    def test_PartialNamedVarBindMultiValue(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 7), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 7), "baz"),
-            ),
-            extraOidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 2)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.7"], "foo,bar,baz")
-        self.assertEqual(result["testVar.sequence"], "7,7,7")
-
-    def test_PartialNamedMultiVarBind(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 0), "foo"),
-                ((1, 2, 6, 1), "bar"),
-                ((1, 2, 6, 2), "baz"),
-            ),
-            extraOidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 4)
-        self.assertIn("testVar.0", result)
-        self.assertIn("testVar.1", result)
-        self.assertIn("testVar.2", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.0"], "foo")
-        self.assertEqual(result["testVar.1"], "bar")
-        self.assertEqual(result["testVar.2"], "baz")
-        self.assertEqual(result["testVar.sequence"], "0,1,2")
-
     def test_PartialNamedVarBindNoneValue(self):
         pckt = self.makePacket("1.3.6.1.6.3.1.1.5.3")
         pckt.variables.append(
@@ -704,28 +416,281 @@ class TestDecodeSnmpV2(BaseTestCase):
         self.assertIn("testVar", result)
         self.assertEqual(result["testVar"], "None")
 
-    def test_PartialNamedMultiVarBindOrder(self):
-        pckt, task = self.makeInputs(
-            variables=(
-                ((1, 2, 6, 0), "foo"),
-                ((1, 2, 6, 7), "bar"),
-                ((1, 2, 6, 3), "baz"),
-            ),
-            extraOidMap={"1.2.6": "testVar"}
-        )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
-        totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
-        self.assertEqual(totalVarKeys, 4)
-        self.assertIn("testVar.0", result)
-        self.assertIn("testVar.7", result)
-        self.assertIn("testVar.3", result)
-        self.assertIn("testVar.sequence", result)
-        self.assertEqual(result["testVar.0"], "foo")
-        self.assertEqual(result["testVar.7"], "bar")
-        self.assertEqual(result["testVar.3"], "baz")
-        self.assertEqual(result["testVar.sequence"], "0,7,3")
 
-    def test_ifentry_trap(self):
+class _VarbindTests(object):
+
+    def case_unknown_id_single(self):
+        tests = (
+            self.makeInputs(variables=(
+                ((1, 2, 6, 7), "foo"),
+            )),
+        )
+        for test in tests:
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+            self.assertEqual(totalVarKeys, 1)
+            self.assertEqual(result["1.2.6.7"], "foo")
+
+    def case_unknown_id_repeated(self):
+        tests = (
+            self.makeInputs(variables=(
+                ((1, 2, 6, 7), "foo"),
+                ((1, 2, 6, 7), "bar"),
+                ((1, 2, 6, 7), "baz"),
+            )),
+        )
+        for test in tests:
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+            self.assertEqual(totalVarKeys, 1)
+            self.assertEqual(result["1.2.6.7"], "foo,bar,baz")
+
+    def case_unknown_ids_multiple(self):
+        tests = (
+            self.makeInputs(variables=(
+                ((1, 2, 6, 0), "foo"),
+                ((1, 2, 6, 1), "bar"),
+            )),
+        )
+        expected_results = ({
+            "1.2.6.0": "foo",
+            "1.2.6.1": "bar",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            totalVarKeys = sum(1 for k in result if k.startswith("1.2.6"))
+            self.assertEqual(totalVarKeys, 2)
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_one_id(self):
+        tests = (
+            self.makeInputs(
+                variables=(((1, 2, 6, 7), "foo"),),
+                oidMap={"1.2.6.7": "testVar"}
+            ),
+        )
+        expected_results = ({
+            "testVar": "foo",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            totalVarKeys = sum(1 for k in result if k.startswith("testVar"))
+            self.assertEqual(totalVarKeys, 1)
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_one_id_one_sub_id(self):
+        oidMap = {"1.2.6": "testVar"}
+        tests = (
+            self.makeInputs(
+                variables=(((1, 2, 6, 0), "foo"),), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(((1, 2, 6, 5), "foo"),), oidMap=oidMap,
+            ),
+        )
+        expected_results = ({
+            "testVar": "foo",
+            "testVar.ifIndex": "0",
+        }, {
+            "testVar": "foo",
+            "testVar.ifIndex": "5",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            count = sum(1 for k in result if k.startswith("testVar"))
+            self.assertEqual(count, len(expected.keys()))
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_one_id_multiple_sub_ids(self):
+        oidMap = {"1.2.6": "testVar"}
+        tests = (
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0), "foo"),
+                    ((1, 2, 6, 1), "bar"),
+                    ((1, 2, 6, 2), "baz"),
+                ), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 7), "foo"),
+                    ((1, 2, 6, 2), "bar"),
+                ), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 3), "foo"),
+                    ((1, 2, 6, 3), "bar"),
+                ), oidMap=oidMap,
+            ),
+        )
+        expected_results = ({
+            "testVar.0": "foo",
+            "testVar.1": "bar",
+            "testVar.2": "baz",
+            "testVar.sequence": "0,1,2",
+        }, {
+            "testVar.7": "foo",
+            "testVar.2": "bar",
+            "testVar.sequence": "7,2",
+        }, {
+            "testVar.3": "foo,bar",
+            "testVar.sequence": "3,3",
+        })
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            count = sum(1 for k in result if k.startswith("testVar"))
+            self.assertEqual(count, len(expected.keys()))
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_multiple_ids(self):
+        oidMap = {
+            "1.2.6": "foo",
+            "1.2.7": "bar",
+        }
+        tests = (
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6), "is a foo"),
+                    ((1, 2, 7), "lower the bar"),
+                ), oidMap=oidMap,
+            ),
+        )
+        expected_results = ({
+            "foo": "is a foo",
+            "bar": "lower the bar",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            count = sum(
+                1 for k in result
+                if k.startswith("bar") or k.startswith("foo")
+            )
+            self.assertEqual(count, len(expected.keys()))
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_multiple_ids_one_sub_id_each(self):
+        oidMap = {
+            "1.2.6": "foo",
+            "1.2.7": "bar",
+        }
+        tests = (
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0), "is a foo"),
+                    ((1, 2, 7, 2), "lower the bar"),
+                ), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0, 1), "is a foo"),
+                    ((1, 2, 7, 2, 1), "lower the bar"),
+                ), oidMap=oidMap,
+            ),
+        )
+        expected_results = ({
+            "foo": "is a foo",
+            "foo.ifIndex": "0",
+            "bar": "lower the bar",
+            "bar.ifIndex": "2",
+        }, {
+            "foo": "is a foo",
+            "foo.ifIndex": "0.1",
+            "bar": "lower the bar",
+            "bar.ifIndex": "2.1",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            count = sum(
+                1 for k in result
+                if k.startswith("bar") or k.startswith("foo")
+            )
+            self.assertEqual(count, len(expected.keys()))
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_multiple_ids_multiple_sub_ids(self):
+        oidMap = {
+            "1.2.6": "foo",
+            "1.2.7": "bar",
+        }
+        tests = (
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0), "here a foo"),
+                    ((1, 2, 6, 1), "there a foo"),
+                    ((1, 2, 7, 2), "lower the bar"),
+                    ((1, 2, 7, 4), "raise the bar"),
+                ), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0, 1), "here a foo"),
+                    ((1, 2, 6, 1, 1), "there a foo"),
+                    ((1, 2, 7, 2, 1), "lower the bar"),
+                    ((1, 2, 7, 2, 2), "raise the bar"),
+                ), oidMap=oidMap,
+            ),
+            self.makeInputs(
+                variables=(
+                    ((1, 2, 6, 0), "here a foo"),
+                    ((1, 2, 6, 0), "there a foo"),
+                    ((1, 2, 7, 3), "lower the bar"),
+                    ((1, 2, 7, 3), "raise the bar"),
+                ), oidMap=oidMap,
+            ),
+        )
+        expected_results = ({
+            "foo.0": "here a foo",
+            "foo.1": "there a foo",
+            "foo.sequence": "0,1",
+            "bar.2": "lower the bar",
+            "bar.4": "raise the bar",
+            "bar.sequence": "2,4",
+        }, {
+            "foo.0.1": "here a foo",
+            "foo.1.1": "there a foo",
+            "foo.sequence": "0.1,1.1",
+            "bar.2.1": "lower the bar",
+            "bar.2.2": "raise the bar",
+            "bar.sequence": "2.1,2.2",
+        }, {
+            "foo.0": "here a foo,there a foo",
+            "foo.sequence": "0,0",
+            "bar.3": "lower the bar,raise the bar",
+            "bar.sequence": "3,3",
+        },)
+        for test, expected in zip(tests, expected_results):
+            result = yield test
+            # eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+            count = sum(
+                1 for k in result
+                if k.startswith("bar") or k.startswith("foo")
+            )
+            self.assertEqual(count, len(expected.keys()))
+            for key, value in expected.items():
+                self.assertIn(key, result)
+                self.assertEqual(value, result[key])
+
+    def case_ifentry_trap(self):
         pckt, task = self.makeInputs(
             variables=(
                 ((1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 143), 143),
@@ -734,7 +699,7 @@ class TestDecodeSnmpV2(BaseTestCase):
                 ((1, 3, 6, 1, 2, 1, 2, 2, 1, 2, 143), "F23"),
                 ((1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18, 143), ""),
             ),
-            extraOidMap={
+            oidMap={
                 "1.3.6.1.2.1.2.2.1.1": "ifIndex",
                 "1.3.6.1.2.1.2.2.1.7": "ifAdminStatus",
                 "1.3.6.1.2.1.2.2.1.8": "ifOperStatus",
@@ -742,42 +707,127 @@ class TestDecodeSnmpV2(BaseTestCase):
                 "1.3.6.1.2.1.31.1.1.1.18": "ifAlias",
             }
         )
-        eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+
+        result = yield (pckt, task)
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifIndex"))
         self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifIndex.143", result)
-        self.assertIn("ifIndex.sequence", result)
-        self.assertEqual(result["ifIndex.143"], "143")
-        self.assertEqual(result["ifIndex.sequence"], "143")
+        self.assertIn("ifIndex", result)
+        self.assertIn("ifIndex.ifIndex", result)
+        self.assertEqual(result["ifIndex"], "143")
+        self.assertEqual(result["ifIndex.ifIndex"], "143")
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifAdminStatus"))
         self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifAdminStatus.143", result)
-        self.assertIn("ifAdminStatus.sequence", result)
-        self.assertEqual(result["ifAdminStatus.143"], "2")
-        self.assertEqual(result["ifAdminStatus.sequence"], "143")
+        self.assertIn("ifAdminStatus", result)
+        self.assertIn("ifAdminStatus.ifIndex", result)
+        self.assertEqual(result["ifAdminStatus"], "2")
+        self.assertEqual(result["ifAdminStatus.ifIndex"], "143")
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifOperStatus"))
         self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifOperStatus.143", result)
-        self.assertIn("ifOperStatus.sequence", result)
-        self.assertEqual(result["ifOperStatus.143"], "2")
-        self.assertEqual(result["ifOperStatus.sequence"], "143")
+        self.assertIn("ifOperStatus", result)
+        self.assertIn("ifOperStatus.ifIndex", result)
+        self.assertEqual(result["ifOperStatus"], "2")
+        self.assertEqual(result["ifOperStatus.ifIndex"], "143")
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifDescr"))
         self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifDescr.143", result)
-        self.assertIn("ifDescr.sequence", result)
-        self.assertEqual(result["ifDescr.143"], "F23")
-        self.assertEqual(result["ifDescr.sequence"], "143")
+        self.assertIn("ifDescr", result)
+        self.assertIn("ifDescr.ifIndex", result)
+        self.assertEqual(result["ifDescr"], "F23")
+        self.assertEqual(result["ifDescr.ifIndex"], "143")
 
         totalVarKeys = sum(1 for k in result if k.startswith("ifAlias"))
         self.assertEqual(totalVarKeys, 2)
-        self.assertIn("ifAlias.143", result)
-        self.assertIn("ifAlias.sequence", result)
-        self.assertEqual(result["ifAlias.143"], "")
-        self.assertEqual(result["ifAlias.sequence"], "143")
+        self.assertIn("ifAlias", result)
+        self.assertIn("ifAlias.ifIndex", result)
+        self.assertEqual(result["ifAlias"], "")
+        self.assertEqual(result["ifAlias.ifIndex"], "143")
+
+
+class TestSnmpV1VarbindHandling(TestCase, _SnmpV1Base, _VarbindTests):
+
+    def _execute(self, cases):
+        try:
+            pckt, task = next(cases)
+            while True:
+                eventType, result = task.decodeSnmpv1(("localhost", 162), pckt)
+                pckt, task = cases.send(result)
+        except StopIteration:
+            pass
+
+    def test_unknown_id_single(self):
+        self._execute(self.case_unknown_id_single())
+
+    def test_unknown_id_repeated(self):
+        self._execute(self.case_unknown_id_repeated())
+
+    def test_unknown_ids_multiple(self):
+        self._execute(self.case_unknown_ids_multiple())
+
+    def test_one_id(self):
+        self._execute(self.case_one_id())
+
+    def test_one_id_one_sub_id(self):
+        self._execute(self.case_one_id_one_sub_id())
+
+    def test_one_id_multiple_sub_ids(self):
+        self._execute(self.case_one_id_multiple_sub_ids())
+
+    def test_multiple_ids(self):
+        self._execute(self.case_multiple_ids())
+
+    def test_multiple_ids_one_sub_id_each(self):
+        self._execute(self.case_multiple_ids_one_sub_id_each())
+
+    def test_multiple_ids_multiple_sub_ids(self):
+        self._execute(self.case_multiple_ids_multiple_sub_ids())
+
+    def test_ifentry_trap(self):
+        self._execute(self.case_ifentry_trap())
+
+
+class TestSnmpV2VarbindHandling(TestCase, _SnmpV2Base, _VarbindTests):
+
+    def _execute(self, cases):
+        try:
+            pckt, task = next(cases)
+            while True:
+                eventType, result = task.decodeSnmpv2(("localhost", 162), pckt)
+                pckt, task = cases.send(result)
+        except StopIteration:
+            pass
+
+    def test_unknown_id_single(self):
+        self._execute(self.case_unknown_id_single())
+
+    def test_unknown_id_repeated(self):
+        self._execute(self.case_unknown_id_repeated())
+
+    def test_unknown_ids_multiple(self):
+        self._execute(self.case_unknown_ids_multiple())
+
+    def test_one_id(self):
+        self._execute(self.case_one_id())
+
+    def test_one_id_one_sub_id(self):
+        self._execute(self.case_one_id_one_sub_id())
+
+    def test_one_id_multiple_sub_ids(self):
+        self._execute(self.case_one_id_multiple_sub_ids())
+
+    def test_multiple_ids(self):
+        self._execute(self.case_multiple_ids())
+
+    def test_multiple_ids_one_sub_id_each(self):
+        self._execute(self.case_multiple_ids_one_sub_id_each())
+
+    def test_multiple_ids_multiple_sub_ids(self):
+        self._execute(self.case_multiple_ids_multiple_sub_ids())
+
+    def test_ifentry_trap(self):
+        self._execute(self.case_ifentry_trap())
 
 
 def test_suite():
@@ -787,4 +837,6 @@ def test_suite():
     suite.addTest(makeSuite(TestOid2Name))
     suite.addTest(makeSuite(TestDecodeSnmpV1))
     suite.addTest(makeSuite(TestDecodeSnmpV2))
+    suite.addTest(makeSuite(TestSnmpV1VarbindHandling))
+    suite.addTest(makeSuite(TestSnmpV2VarbindHandling))
     return suite

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -563,24 +563,22 @@ class TrapTask(BaseTask, CaptureReplay):
         for base_name, data in groups.items():
             offset = len(base_name) + 1
 
-            # One instance of the object is normal data
+            # If there's only one instance for a given object, then add
+            # the varbind to the event details using pre Zenoss 6.2.0 rules.
             if len(data) == 1:
                 full_name, value = data[0]
-                result[base_name].append(value)
+                suffix = full_name[offset:]
+                if base_name != full_name:
+                    result[base_name].append(value)
+                if suffix:
+                    result[base_name + ".ifIndex"].append(suffix)
 
-                # if the base name ('var') and full_name ('var.0') do
-                # not match, add an extra ".ifIndex" detail to record the
-                # "0" value.
-                if full_name not in original_ids and base_name != full_name:
-                    result[base_name + ".ifIndex"].append(full_name[offset:])
-                continue
-
+            # Record the varbind instance(s) in their 'raw' form.
             for full_name, value in data:
+                suffix = full_name[offset:]
                 result[full_name].append(value)
-                # For multiple instances of the same base name,
-                # record their suffixes into a ".sequence" detail.
-                if full_name not in original_ids:
-                    result[base_name + ".sequence"].append(full_name[offset:])
+                if suffix:
+                    result[base_name + ".sequence"].append(suffix)
 
         return {name: ','.join(vals) for name, vals in result.iteritems()}
 

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -545,14 +545,44 @@ class TrapTask(BaseTask, CaptureReplay):
             netsnmp.lib.snmp_free_pdu(reply)
         sess.close()
 
-    def _add_varbind_detail(self, result, oid, value):
-        detail_name = self.oid2name(oid, exactMatch=False, strip=False)
-        result[detail_name].append(str(value))
+    def _process_varbinds(self, varbinds):
+        # varbinds: Sequence[Tuple(str, Any)]
 
-        detail_name_stripped = self.oid2name(oid, exactMatch=False, strip=True)
-        if detail_name_stripped != detail_name:
-            remainder = detail_name[len(detail_name_stripped)+1:]
-            result[detail_name_stripped + ".sequence"].append(remainder)
+        result = defaultdict(list)
+        groups = defaultdict(list)
+        original_ids = set()
+
+        # Group varbinds having the same MIB Object name together
+        for key, value in varbinds:
+            original_ids.add(key)
+            base_name = self.oid2name(key, exactMatch=False, strip=True)
+            full_name = self.oid2name(key, exactMatch=False, strip=False)
+            groups[base_name].append((full_name, str(value)))
+
+        # Process each MIB object by name
+        for base_name, data in groups.items():
+            offset = len(base_name) + 1
+
+            # One instance of the object is normal data
+            if len(data) == 1:
+                full_name, value = data[0]
+                result[base_name].append(value)
+
+                # if the base name ('var') and full_name ('var.0') do
+                # not match, add an extra ".ifIndex" detail to record the
+                # "0" value.
+                if full_name not in original_ids and base_name != full_name:
+                    result[base_name + ".ifIndex"].append(full_name[offset:])
+                continue
+
+            for full_name, value in data:
+                result[full_name].append(value)
+                # For multiple instances of the same base name,
+                # record their suffixes into a ".sequence" detail.
+                if full_name not in original_ids:
+                    result[base_name + ".sequence"].append(full_name[offset:])
+
+        return {name: ','.join(vals) for name, vals in result.iteritems()}
 
     def decodeSnmpv1(self, addr, pdu):
 
@@ -602,7 +632,7 @@ class TrapTask(BaseTask, CaptureReplay):
 
         # Decode all variable bindings. Allow partial matches and strip
         # off any index values.
-        vb_result = defaultdict(list)
+        varbinds = []
         for vb_oid, vb_value in variables:
             vb_value = decode_snmp_value(vb_value)
             vb_oid = '.'.join(map(str, vb_oid))
@@ -611,11 +641,9 @@ class TrapTask(BaseTask, CaptureReplay):
                     "[decodeSnmpv1] enterprise %s, varbind-oid %s, "
                     "varbind-value %s", enterprise, vb_oid, vb_value
                 )
-            self._add_varbind_detail(vb_result, vb_oid, vb_value)
+            varbinds.append((vb_oid, vb_value))
 
-        result.update(
-            {name: ','.join(vals) for name, vals in vb_result.iteritems()}
-        )
+        result.update(self._process_varbinds(varbinds))
 
         return eventType, result
 
@@ -624,7 +652,7 @@ class TrapTask(BaseTask, CaptureReplay):
         result = {"snmpVersion": "2", "oid": "", "device": addr[0]}
         variables = self.getResult(pdu)
 
-        vb_result = defaultdict(list)
+        varbinds = []
         for vb_oid, vb_value in variables:
             vb_value = decode_snmp_value(vb_value)
             vb_oid = '.'.join(map(str, vb_oid))
@@ -646,11 +674,9 @@ class TrapTask(BaseTask, CaptureReplay):
                 result['snmpTrapAddress'] = vb_value
                 result['device'] = vb_value
             else:
-                self._add_varbind_detail(vb_result, vb_oid, vb_value)
+                varbinds.append((vb_oid, vb_value))
 
-        result.update(
-            {name: ','.join(vals) for name, vals in vb_result.iteritems()}
-        )
+        result.update(self._process_varbinds(varbinds))
 
         if eventType in ["linkUp", "linkDown"]:
             eventType = "snmp_" + eventType

--- a/Products/ZenEvents/zentrap.py
+++ b/Products/ZenEvents/zentrap.py
@@ -567,11 +567,12 @@ class TrapTask(BaseTask, CaptureReplay):
             # the varbind to the event details using pre Zenoss 6.2.0 rules.
             if len(data) == 1:
                 full_name, value = data[0]
+                result[base_name].append(value)
+                
                 suffix = full_name[offset:]
-                if base_name != full_name:
-                    result[base_name].append(value)
                 if suffix:
                     result[base_name + ".ifIndex"].append(suffix)
+                continue
 
             # Record the varbind instance(s) in their 'raw' form.
             for full_name, value in data:


### PR DESCRIPTION
SNMP notification varbinds that occur only once in a packet are recorded into events as they were in pre 6.2.0 systems.  Varbinds that have multiple occurrences will continue to use the post 6.2.0 behavior.

Fixes ZEN-32255.