### PR TITLE
Pass the job ID back to the browser.

### DIFF
--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -129,7 +129,7 @@ class JobRecord(object):
             or self.started is None
         ):
             return None
-        if self.complete:
+        if self.complete and self.finished is not None:
             return self.finished - self.started
         return time.time() - self.started
 

--- a/Products/Jobber/task/abortable.py
+++ b/Products/Jobber/task/abortable.py
@@ -14,6 +14,7 @@ import signal
 import sys
 import thread
 import threading
+import time
 
 from celery import states
 from celery.app import push_current_task, pop_current_task
@@ -38,7 +39,7 @@ class AbortableResult(AbortableAsyncResult):
     def abort(self):
         """Abort the job."""
         jobstore = getUtility(IJobStore, "redis")
-        jobstore.update(self.id, status=ABORTED)
+        jobstore.update(self.id, status=ABORTED, finished=time.time())
         return super(AbortableResult, self).abort()
 
 

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/model/Discovery.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/model/Discovery.js
@@ -26,7 +26,10 @@
     });
 
     Ext.define('Zenoss.quickstart.Wizard.model.Discovery', {
-        extend: 'Zenoss.quickstart.Wizard.model.JobRecord'
+        extend: 'Zenoss.quickstart.Wizard.model.JobRecord',
+        fields: [
+            {name: 'duration', type: 'int'}
+        ]
     });
 
     Ext.define('Zenoss.quickstart.Wizard.model.AddDeviceJobRecord', {

--- a/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AutoDiscoveryView.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/quickstart/view/AutoDiscoveryView.js
@@ -87,6 +87,7 @@
                           case "STARTED":
                             return Ext.String.format("<img src='{0}' alt='{1}' />", "/++resource++zenui/img/ext4/icon/circle_arrows_ani.gif", status);
                           case "PENDING":
+                          case "RETRY":
                             return Ext.String.format("<img class='x-grid-icon-pending' src='{0}' alt='{1}' />", "/++resource++zenui/img/ext4/icon/circle_arrows_still.png", status);
                           case "ABORTED":
                             return "<span class=\"tree-severity-icon-small-warning\" style=\"padding-left:18px;padding-top:2px;\">Aborted</span>";

--- a/Products/Zuul/routers/jobs.py
+++ b/Products/Zuul/routers/jobs.py
@@ -34,6 +34,7 @@ JOBKEYS = [
     "scheduled",
     "started",
     "finished",
+    "duration",
     "status",
     "user",
     "logfile",

--- a/Products/Zuul/routers/network.py
+++ b/Products/Zuul/routers/network.py
@@ -32,6 +32,17 @@ from . import TreeRouter
 log = logging.getLogger("zen.NetworkRouter")
 
 
+JOBKEYS = [
+    "uuid",
+    "status",
+    "started",
+    "scheduled",
+    "finished",
+    "duration",
+    "logfile",
+]
+
+
 class NetworkRouter(TreeRouter):
     """A JSON/ExtDirect interface to operations on networks.
     """
@@ -250,7 +261,7 @@ class NetworkRouter(TreeRouter):
             networks=networks, zProperties=zProperties, collector=collector
         )
         audit("UI.Discovery.Add", networks=networks, collector=collector)
-        return DirectResponse.succeed(data=Zuul.marshal(jobs))
+        return DirectResponse.succeed(data=Zuul.marshal(jobs, keys=JOBKEYS))
 
 
 class Network6Router(NetworkRouter):


### PR DESCRIPTION
Also pass the job's duration so that field is updated on the Add Multiple Devices screen.

Fixes ZEN-33110.