### PR TITLE
ZEN-33017: fix sending of org details to zing

### DIFF
--- a/Products/ZenModel/Location.py
+++ b/Products/ZenModel/Location.py
@@ -28,6 +28,7 @@ from ZenPackable import ZenPackable
 from zExceptions import NotFound
 from Products.ZenUtils.jsonutils import json
 from Products.ZenUtils.Utils import extractPostContent
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
 
 def manage_addLocation(context, id, description = "",
                        address="", REQUEST = None):
@@ -196,6 +197,8 @@ class Location(DeviceOrganizer, ZenPackable):
                 loc = self.unrestrictedTraverse(str(uid))
                 if loc.latlong != geo['latlong']:
                     loc.latlong = geo['latlong']
+                    # ensure new latlong gets to the catalog and cloud
+                    IModelCatalogTool(loc).update(loc)
             except (KeyError, NotFound):
                 # the location might have been removed or renamed
                 # and the client still had the cache.

--- a/Products/ZenModel/Organizer.py
+++ b/Products/ZenModel/Organizer.py
@@ -168,7 +168,7 @@ class Organizer(ZenModelRM, EventView):
 
 
     security.declareProtected(ZEN_ADD, 'manage_addOrganizer')
-    def manage_addOrganizer(self, newPath, factory=None, REQUEST=None):
+    def manage_addOrganizer(self, newPath, factory=None, properties=None, REQUEST=None):
         """
         Adds a new organizer under this organizer. if given a fully qualified
         path it will create an organizer at that path
@@ -178,7 +178,6 @@ class Organizer(ZenModelRM, EventView):
         @raise: ZentinelException
         @permission: ZEN_ADD
 
-        >>> dmd.Devices.manage_addOrganizer('/Devices/DocTest')
         """
         if factory is None:
             factory = self.__class__
@@ -186,6 +185,7 @@ class Organizer(ZenModelRM, EventView):
         try:
             if newPath.startswith("/"):
                 org = self.createOrganizer(newPath)
+                name = org.titleOrId()
             else:
                 # Strip out invalid characters from the newPath
                 name = newPath
@@ -194,7 +194,15 @@ class Organizer(ZenModelRM, EventView):
                 self._setObject(org.id, org)
                 # Set the display name to the original string
                 org = self._getOb(newPath)
-                org.setTitle(name)
+
+            # Allow adding additional properties to the organizer.
+            # All organizers use this to set description.
+            # Locations use this to set address.
+            if properties:
+                for k, v in properties.items():
+                    setattr(org, k, v)
+
+            org.setTitle(name)
         except ZentinelException as e:
             if REQUEST:
                 messaging.IMessageSender(self).sendToBrowser(

--- a/Products/ZenModel/migrate/SendOrganizersToZing.py
+++ b/Products/ZenModel/migrate/SendOrganizersToZing.py
@@ -1,0 +1,44 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2020, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+
+from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION  # noqa: E501
+from Products.Zuul.catalog.interfaces import IModelCatalogTool
+
+import Migrate
+
+log = logging.getLogger("zen.migrate")
+
+
+class SendOrganizersToZing(Migrate.Step):
+    """Update all organizers' catalog entries so they can be sent to Zing."""
+
+    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+
+    def cutover(self, dmd):
+        try:
+            orgs = \
+                dmd.Devices.getSubOrganizers() + \
+                dmd.Groups.getSubOrganizers() + \
+                dmd.Systems.getSubOrganizers() + \
+                dmd.Locations.getSubOrganizers() + \
+                dmd.ComponentGroups.getSubOrganizers()
+        except Exception as e:
+            logging.error("error getting list of organizers: %s", e)
+            return
+
+        for org in orgs:
+            try:
+                IModelCatalogTool(org).update(org)
+            except Exception as e:
+                logging.error("error updating catalog for organizers: %s", org.getOrganizerName())
+
+
+SendOrganizersToZing()

--- a/Products/Zuul/facades/__init__.py
+++ b/Products/Zuul/facades/__init__.py
@@ -243,16 +243,20 @@ class TreeFacade(ZuulFacade):
         # convert to info objects
         return SearchResults(imap(IInfo, objs), brains.total, brains.hash_)
 
-    def addOrganizer(self, contextUid, id, description=''):
+    def addOrganizer(self, contextUid, id, description='', properties=None):
+        if not properties:
+            properties = {}
+
+        properties["description"] = description
+
         context = self._getObject(contextUid)
-        context.manage_addOrganizer(id)
+        context.manage_addOrganizer(id, properties=properties)
         if id.startswith("/"):
             organizer = context.getOrganizer(id)
         else:
             # call prepId for each segment.
             id = '/'.join(context.prepId(s) for s in id.split('/'))
             organizer = context._getOb(id)
-        organizer.description = description
         return IOrganizerInfo(organizer)
 
     def addClass(self, contextUid, id):

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -849,9 +849,11 @@ class DeviceFacade(TreeFacade):
                     pass
 
     def addLocationOrganizer(self, contextUid, id, description = '', address=''):
-        org = super(DeviceFacade, self).addOrganizer(contextUid, id, description)
-        org.address = address
-        return org
+        properties = {}
+        if address:
+            properties["address"] = address
+
+        return super(DeviceFacade, self).addOrganizer(contextUid, id, description, properties=properties)
 
     def addDeviceClass(self, contextUid, id, description = '', connectionInfo=None):
         org = super(DeviceFacade, self).addOrganizer(contextUid, id, description)


### PR DESCRIPTION
When initially being created locations would have their name sent to
zing-connector, then set their address. This resulted in their address
never making it to zing. Now we are setting all properties before the
fact goes to zing-connector instead.
