### PR TITLE
Check for unstarted jobs when job ends.

### DIFF
--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -457,8 +457,12 @@ def job_end(log, task_id, task=None, **ignored):
         return
     jobstore = getUtility(IJobStore, "redis")
     finished = jobstore.getfield(task_id, "finished")
-    if finished is not None:
-        started = jobstore.getfield(task_id, "started")
+    if finished is None:
+        return
+    started = jobstore.getfield(task_id, "started")
+    if started is None:
+        log.info("Job never started")
+    else:
         log.info("Job total duration is %0.3f seconds", finished - started)
 
 


### PR DESCRIPTION
When a finished job has no start time, log a message that the job was never started.

Fixes ZEN-33124.