### PR TITLE
Only notify with successful transaction.

### DIFF
--- a/Products/ZenMessaging/queuemessaging/publisher.py
+++ b/Products/ZenMessaging/queuemessaging/publisher.py
@@ -332,8 +332,9 @@ class PublishSynchronizer(object):
                     self._queuePublisher.close()
                 except Exception:
                     log.exception("Error closing queue publisher")
-            if self._postPublishingEventArgs:
-                notify(MessagePostPublishingEvent(*self._postPublishingEventArgs))
+            if status:
+                if self._postPublishingEventArgs:
+                    notify(MessagePostPublishingEvent(*self._postPublishingEventArgs))
         finally:
             self._queuePublisher=None
             self._postPublishingEventArgs=()


### PR DESCRIPTION
Send a MessagePostPublishingEvent only if the transaction comitted successfully.

Fixes ZEN-32890.