### PR TITLE
Add NullZingClient component.

### DIFF
--- a/Products/Zing/README.md
+++ b/Products/Zing/README.md
@@ -25,3 +25,11 @@ zing_connector = IZingConnectorProxy(context)
 if zing_connector.ping():
     zing_connector.send_facts(FACTS)
 ```
+
+
+## Development
+
+There is an alternative to the ZingConnectorClient that can be used when developing solely within the CZ.  It allows all the normal Zing fact generation to run but makes no attempt to send the facts via the zing-connector.  To enable this alternate client:
+
+ 1. Set "zing-connector-client NullZingClient" in globals.conf
+ 2. Restart the services.

--- a/Products/Zing/configure.zcml
+++ b/Products/Zing/configure.zcml
@@ -1,31 +1,38 @@
 <?xml version="1.0"?>
 <configure
-    xmlns="http://namespaces.zope.org/zope"
-    xmlns:five="http://namespaces.zope.org/five"
-    xmlns:browser="http://namespaces.zope.org/browser"
-    xmlns:meta="http://namespaces.zope.org/meta">
+   xmlns="http://namespaces.zope.org/zope"
+   xmlns:five="http://namespaces.zope.org/five"
+   xmlns:browser="http://namespaces.zope.org/browser"
+   xmlns:meta="http://namespaces.zope.org/meta">
 
-    <subscriber handler=".datamaps.zing_add_datamap" />
+   <subscriber
+      handler=".datamaps.zing_add_datamap"
+      />
 
-    <adapter
-        provides=".interfaces.IZingConnectorProxy"
-        for="*"
-        factory=".zing_connector.ZingConnectorProxy"
-        />
+   <adapter
+      provides=".interfaces.IZingConnectorProxy"
+      for="*"
+      factory=".zing_connector.ZingConnectorProxy"
+      />
 
-    <utility
-        component=".zing_connector.CLIENT_FACTORY"
-        name="ZingConnectorClient"
-        />
+   <utility
+      component=".zing_connector.CLIENT_FACTORY"
+      name="ZingConnectorClient"
+      />
 
-    <utility
-        component=".datamaps.DATAMAP_HANDLER_FACTORY"
-        name="ZingDatamapHandler"
-        />
+   <utility
+      component=".zing_connector.NULL_CLIENT_FACTORY"
+      name="NullZingClient"
+      />
 
-    <utility
-        component=".model_updates.OBJECT_UPDATE_HANDLER_FACTORY"
-        name="ZingObjectUpdateHandler"
-        />
+   <utility
+      component=".datamaps.DATAMAP_HANDLER_FACTORY"
+      name="ZingDatamapHandler"
+      />
+
+   <utility
+      component=".model_updates.OBJECT_UPDATE_HANDLER_FACTORY"
+      name="ZingObjectUpdateHandler"
+      />
 
 </configure>

--- a/Products/Zing/tx_state.py
+++ b/Products/Zing/tx_state.py
@@ -65,12 +65,12 @@ class ZingTxState(object):
 
     def is_there_object_updates(self):
         return any(
-            (
-                len(self.need_organizers_fact) > 0,
-                len(self.need_device_info_fact) > 0,
-                len(self.need_device_organizer_info_fact) > 0,
-                len(self.need_component_group_info_fact) > 0,
-                len(self.need_deletion_fact) > 0,
+            len(facts) > 0 for facts in (
+                self.need_organizers_fact,
+                self.need_device_info_fact,
+                self.need_device_organizer_info_fact,
+                self.need_component_group_info_fact,
+                self.need_deletion_fact,
             )
         )
 
@@ -96,7 +96,7 @@ class ZingTxStateManager(object):
             zing_tx_state = ZingTxState()
             setattr(current_tx, self.TX_DATA_FIELD_NAME, zing_tx_state)
             current_tx.addAfterCommitHook(
-                self.process_facts, args=(zing_tx_state, context)
+                self.process_facts, args=(zing_tx_state, context),
             )
             log.debug(
                 "ZingTxStateManager AfterCommitHook added. "


### PR DESCRIPTION
The NullZingClient is an IZingConnectorClient implementation that performs no I/O with the zing-connector service.

Fixes ZEN-33186.