### PR TITLE
Alternative config data structure.

### DIFF
--- a/Products/ZenHub/server/config.py
+++ b/Products/ZenHub/server/config.py
@@ -9,6 +9,8 @@
 
 from __future__ import absolute_import
 
+import json
+
 from Products.ZenHub import XML_RPC_PORT, PB_PORT
 from zope.interface import implementer
 
@@ -57,6 +59,34 @@ class ModuleObjectConfig(object):
     @property
     def xmlrpcport(self):
         return self.__config.xmlrpcport
+
+
+class ZenHubServiceCallConfig(object):
+    """ load and store configuration from file """
+    
+    def __init__(self, config):
+
+        self.__config = {}
+
+        try:
+            with open(config, 'r') as f:
+                self.__config = json.load(f)
+        except Exception as e:
+            import logging
+            log = logging.getLogger("zen.%s" %  __name__)
+            log.error("Couldn't load configuration from %s, using default configuration instead, ERROR: %s", config, e)
+
+    @property
+    def pools(self):
+        return {i['poolid']:i['executorid'] for i in self.__config.get('pools', {})}
+
+    @property
+    def executors(self):
+        return {i['executorid']:i['spec'] for i in self.__config.get('executors', {})}
+
+    @property
+    def routes(self):     
+        return {i['servicecall']:i['executorid'] for i in self.__config.get('routes', {})}
 
 
 ##############################################################################

--- a/Products/ZenHub/server/tests/zenhub-server.yaml
+++ b/Products/ZenHub/server/tests/zenhub-server.yaml
@@ -1,0 +1,18 @@
+default:
+    spec: "Products.ZenHub.server.executors:WorkerPoolExecutor"
+    routes:
+      - "*:*"
+
+event:
+    spec: "Products.ZenHub.server.executors:SendEventExecutor"
+    routes:
+      - "EventService:sendEvent"
+      - "EventService:sendEvents"
+
+adm:
+    spec: "Products.ZenHub.server.executors:WorkerPoolExecutor"
+    routes:
+      - "*:applyDataMaps"
+
+user:
+    spec: "Products.ZenHub.server.executors:WorkerPoolExecutor"

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -353,7 +353,10 @@ class ZenHub(ZCmdBase):
             type='int', default=server_config.defaults.modeling_pause_timeout,
             help='Maximum number of seconds to pause modeling during ZenPack'
                  ' install/upgrade/removal (default: %default)')
-
+        self.parser.add_option(
+            '--servicecall-router-conf', dest='servicecallConf',
+            type='string', default='/opt/zenoss/etc/zenhubservicecall.json',
+            help='Configuration file to customize routes to zenhubworkers')
         notify(ParserReadyForOptionsEvent(self.parser))
 
     def parseOptions(self):
@@ -364,6 +367,11 @@ class ZenHub(ZCmdBase):
             int(self.options.modeling_pause_timeout)
         server_config.xmlrpcport = int(self.options.xmlrpcport)
         server_config.pbport = int(self.options.pbport)
+        if self.options.servicecallConf:
+            service_config = server_config.ZenHubServiceCallConfig(self.options.servicecallConf)
+            server_config.routes.update(service_config.routes)
+            server_config.executors.update(service_config.executors)
+            server_config.pools.update(service_config.pools)
         config_util = server_config.ModuleObjectConfig(server_config)
         provideUtility(config_util, IHubServerConfig)
 

--- a/Products/ZenHub/zenhub.py
+++ b/Products/ZenHub/zenhub.py
@@ -64,6 +64,7 @@ from Products.ZenHub.server import (
     XmlRpcManager,
     ZenHubStatusReporter,
 )
+from Products.ZenHub.server.config import ServerConfig
 
 
 def _load_modules():
@@ -354,8 +355,8 @@ class ZenHub(ZCmdBase):
             help='Maximum number of seconds to pause modeling during ZenPack'
                  ' install/upgrade/removal (default: %default)')
         self.parser.add_option(
-            '--servicecall-router-conf', dest='servicecallConf',
-            type='string', default='/opt/zenoss/etc/zenhubservicecall.json',
+            '--server-config', dest='serverconfig',
+            type='string', default='/opt/zenoss/etc/zenhub-server.yaml',
             help='Configuration file to customize routes to zenhubworkers')
         notify(ParserReadyForOptionsEvent(self.parser))
 
@@ -367,11 +368,11 @@ class ZenHub(ZCmdBase):
             int(self.options.modeling_pause_timeout)
         server_config.xmlrpcport = int(self.options.xmlrpcport)
         server_config.pbport = int(self.options.pbport)
-        if self.options.servicecallConf:
-            service_config = server_config.ZenHubServiceCallConfig(self.options.servicecallConf)
-            server_config.routes.update(service_config.routes)
-            server_config.executors.update(service_config.executors)
-            server_config.pools.update(service_config.pools)
+        if self.options.serverconfig:
+            cfg = ServerConfig.from_file(self.options.serverconfig)
+            server_config.routes.update(cfg.routes)
+            server_config.executors.update(cfg.executors)
+            server_config.pools.update(cfg.pools)
         config_util = server_config.ModuleObjectConfig(server_config)
         provideUtility(config_util, IHubServerConfig)
 


### PR DESCRIPTION
YAML is not required.  The equivalent JSON of the example zenhub-server.yaml file is:
```
{
    "default": {
        "spec": "Products.ZenHub.server.executors:WorkerPoolExecutor",
        "routes": ["*:*"]
    },
    "event": {
        "spec": "Products.ZenHub.server.executors:SendEventExecutor",
        "routes": [
            "EventService:sendEvent",
            "EventService:sendEvents"
        ]
    },
    "adm": {
        "spec": "Products.ZenHub.server.executors:WorkerPoolExecutor",
        "routes": [
            "*:applyDataMaps"
        ]
    },
    "user": {
        "spec": "Products.ZenHub.server.executors:WorkerPoolExecutor",
    }
}
```
YAML takes up less space.  And YAML supports comments.