### PR TITLE
ZEN-33272 Tracebacks 'Bad task  executor 'in zencommand log for all linux devices

### DIFF
--- a/Products/ZenRRD/runner.py
+++ b/Products/ZenRRD/runner.py
@@ -272,11 +272,9 @@ class SshRunner(object):
         try:
             connection = yield connection.run()
         except Exception as e:
-            deferredList = self._pool.get(self._poolkey, [])
             self.cleanUpPool(connection)
-            for d in deferredList:
-                d.errback(e)
             log.error("Failed to set up connection  error=%s", e)
+            raise e
         else:
             deferredList = self._pool.get(self._poolkey, [])
             self._pool[self._poolkey] = connection

--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -492,13 +492,15 @@ class SshPerformanceCollectionTask(BaseTask):
 
         except Exception as e:
             self.state = TaskStates.STATE_PAUSED
-            log.exception(
-                "Task paused  name=%s device-id=%s ip=%s message=%s",
+            err_msg = "Task paused  name=%s device-id=%s ip=%s message=%s" % (
                 self.name,
                 self._devId,
                 self._manageIp,
-                e.message,
-            )
+                e.message)
+            if log.isEnabledFor(logging.DEBUG):
+                log.exception(err_msg)
+            else:
+                log.error(err_msg)
             self._eventService.sendEvent(
                 STATUS_EVENT,
                 device=self._devId,
@@ -506,7 +508,6 @@ class SshPerformanceCollectionTask(BaseTask):
                 component=COLLECTOR_NAME,
                 severity=Error,
             )
-            raise
         else:
             self._returnToNormalSchedule()
 


### PR DESCRIPTION
Backport of https://github.com/zenoss/zenoss-prodbin/pull/3958/files