### PR TITLE
ZEN-33261 Moving a device to a class with a different zPythonClass will orphan the IpAddress associated with the manageIp

### DIFF
--- a/Products/ZenModel/DeviceClass.py
+++ b/Products/ZenModel/DeviceClass.py
@@ -263,8 +263,8 @@ class DeviceClass(DeviceOrganizer, ZenPackable, TemplateContainer):
                             root.removeChild(obj)
 
                     elif obj.tagName == 'toone' and \
-                         name in ('perfServer', 'location'):
-                        pass # Preserve collector name and location
+                         name in ('perfServer', 'location', 'ipaddress'):
+                        pass # Preserve collector name, location, and ipaddress
 
                     elif obj.tagName == 'tomany' and \
                          name in ('systems', 'groups'):


### PR DESCRIPTION
Backport of https://github.com/zenoss/zenoss-prodbin/pull/3988