### PR TITLE
ZEN-33256 Handle case with lost connection to MySQL

### DIFF
--- a/Products/ZenHub/tests/test_zenhubworker.py
+++ b/Products/ZenHub/tests/test_zenhubworker.py
@@ -52,6 +52,7 @@ class ZenHubWorkerTest(TestCase):
             'dmd': patch.object(ZenHubWorker, 'dmd', create=True),
             'log': patch.object(ZenHubWorker, 'log', create=True),
             'options': patch.object(ZenHubWorker, 'options', create=True),
+            'connection': patch.object(ZenHubWorker, 'connection', create=True),
         }
         for name, patcher in t.zcmdbase_patchers.items():
             setattr(t, name, patcher.start())

--- a/Products/ZenHub/zenhubworker.py
+++ b/Products/ZenHub/zenhubworker.py
@@ -257,6 +257,7 @@ class ZenHubWorker(ZCmdBase, pb.Referenceable):
         @param monitor {str} Name of the collection monitor
         """
         try:
+            self.syncdb()
             return self.__manager.getService(name, monitor)
         except RemoteBadMonitor:
             # Catch and rethrow this Exception derived exception.


### PR DESCRIPTION
Add additional database sync when we get remote Service
to restore db connection.

Backport of https://github.com/zenoss/zenoss-prodbin/pull/3949