### PR TITLE
Generate ZMigrateVersion.py for prodbin build.

### DIFF
--- a/Products/ZenModel/ZVersion.py
+++ b/Products/ZenModel/ZVersion.py
@@ -8,11 +8,6 @@
 ##############################################################################
 
 import os
-import pkg_resources
 
-try:
-    VERSION = pkg_resources.get_distribution("Zenoss").version
-except Exception:
-    VERSION = "unknown"
-
+VERSION = os.environ.get("ZENOSS_VERSION", "DEV")
 BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "DEV")

--- a/makefile
+++ b/makefile
@@ -32,9 +32,12 @@ include zenoss-version.mk
 #     - create the 'dist' subdirectory
 #     - compile & minify the javascript, which is saved in the Products directory tree
 #     - build the zenoss-version wheel, which is copied into dist
-#
-build: build-javascript build-zenoss-version
-	tar cvfz $(ARTIFACT) Products bin dist etc share legacy/sitecustomize.py
+
+EXCLUSIONS=--exclude Products/ZenModel/ZMigrateVersion.py.in
+INCLUSIONS=Products bin dist etc share legacy/sitecustomize.py
+
+build: build-javascript build-zenoss-version Products/ZenModel/ZMigrateVersion.py
+	tar cvfz $(ARTIFACT) $(EXCLUSIONS) $(INCLUSIONS)
 
 clean: clean-javascript clean-zenoss-version
 	rm -f $(ARTIFACT)


### PR DESCRIPTION
Modify ZVersion.py to read from os.environ instead of Zenoss package.  The value of ZVersion.VERSION should reflect the version number specified in product-assembly, not prodbin.

Fixes ZEN-33350.