### PR TITLE
Refactor code for building prodbin artifact.

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,26 +5,21 @@ BRANCH       ?= support/6.x
 ARTIFACT_TAG ?= $(shell echo $(BRANCH) | sed 's/\//-/g')
 ARTIFACT     := prodbin-$(VERSION)-$(ARTIFACT_TAG).tar.gz
 
-# Define the name, version and tag name for the docker build image
-# Note that build-tools is derived from zenoss-centos-base which contains JSBuilder
-BUILD_IMAGE = build-tools
-BUILD_VERSION = 0.0.11
-BUILD_IMAGE_TAG = zenoss/$(BUILD_IMAGE):$(BUILD_VERSION)
+IMAGE = zenoss/zenoss-centos-base:1.3.4.devtools
 
 USER_ID := $(shell id -u)
 GROUP_ID := $(shell id -g)
 
-DOCKER_RUN := docker run --rm \
-	-v $(PWD):/mnt \
-	--user $(USER_ID):$(GROUP_ID) \
-	$(BUILD_IMAGE_TAG) \
-	/bin/bash -c
+DOCKER = $(shell which docker)
+
+DOCKER_RUN = $(DOCKER) run --rm -v $(PWD):/mnt -w /mnt --user $(USER_ID):$(GROUP_ID) $(IMAGE) /bin/bash -c
 
 .PHONY: all clean build
 
 all: build
 
 include javascript.mk
+include migration.mk
 include zenoss-version.mk
 
 #
@@ -33,11 +28,16 @@ include zenoss-version.mk
 #     - compile & minify the javascript, which is saved in the Products directory tree
 #     - build the zenoss-version wheel, which is copied into dist
 
-EXCLUSIONS=--exclude Products/ZenModel/ZMigrateVersion.py.in
-INCLUSIONS=Products bin dist etc share legacy/sitecustomize.py
+EXCLUSIONS = *.pyc $(MIGRATE_VERSION).in Products/ZenModel/migrate/tests Products/ZenUITests
 
-build: build-javascript build-zenoss-version Products/ZenModel/ZMigrateVersion.py
-	tar cvfz $(ARTIFACT) $(EXCLUSIONS) $(INCLUSIONS)
+ARCHIVE_EXCLUSIONS = $(foreach item,$(EXCLUSIONS),--exclude=$(item))
+ARCHIVE_INCLUSIONS = Products bin dist etc share legacy/sitecustomize.py
+ARCHIVE_TRANSFORMS = --transform="s/legacy\/sitecustomize.py/lib\/python2.7\/sitecustomize.py/"
 
-clean: clean-javascript clean-zenoss-version
+build: $(ARTIFACT)
+
+clean: clean-javascript clean-migration clean-zenoss-version
 	rm -f $(ARTIFACT)
+
+$(ARTIFACT): $(JSB_TARGETS) $(MIGRATE_VERSION) dist/$(ZENOSS_VERSION_WHEEL)
+	tar cvfz $@ $(ARCHIVE_EXCLUSIONS) $(ARCHIVE_TRANSFORMS) $(ARCHIVE_INCLUSIONS)

--- a/migration.mk
+++ b/migration.mk
@@ -1,0 +1,60 @@
+MIGRATE_VERSION = Products/ZenModel/ZMigrateVersion.py
+
+# The SCHEMA_* values define the DB schema version used for upgrades.
+# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
+# for more information about setting these values.
+
+pick_version_part = $(word $(1),$(subst ., ,$(2)))
+
+SCHEMA_VERSION  = $(shell cat SCHEMA_VERSION)
+SCHEMA_MAJOR    = $(call pick_version_part,1,$(SCHEMA_VERSION))
+SCHEMA_MINOR    = $(call pick_version_part,2,$(SCHEMA_VERSION))
+SCHEMA_REVISION = $(call pick_version_part,3,$(SCHEMA_VERSION))
+
+.PHONY: clean-migration generate-zversion generate-zmigrateversion
+
+clean-migration:
+	rm -f $(MIGRATE_VERSION)
+
+# Exists for backward compatibility
+generate-zversion: generate-zmigrateversion
+
+# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
+# for more information about setting the SCHEMA_* values.
+generate-zmigrateversion: $(MIGRATE_VERSION)
+
+$(MIGRATE_VERSION): $(MIGRATE_VERSION).in SCHEMA_VERSION
+	@echo "Generating ZMigrateVersion.py"
+	@sed \
+	    -e "s/%SCHEMA_MAJOR%/$(SCHEMA_MAJOR)/g;s/%SCHEMA_MINOR%/$(SCHEMA_MINOR)/g;s/%SCHEMA_REVISION%/$(SCHEMA_REVISION)/g" \
+	    $< > $@
+
+# The target replace-zmigrationversion should be used just prior to release to lock
+# down the schema versions for a particular release
+replace-zmigrateversion:
+	@echo Replacing SCHEMA_MAJOR with $(SCHEMA_MAJOR)
+	@echo Replacing SCHEMA_MINOR with $(SCHEMA_MINOR)
+	@echo Replacing SCHEMA_REVISION with $(SCHEMA_REVISION)
+	@cd Products/ZenModel/migrate; \
+	    for file in `grep -l ZMigrateVersion *.py`; do \
+	        sed \
+	            -i \
+	            -e "/ZMigrateVersion/d" \
+	            -e "s/SCHEMA_MAJOR/$(SCHEMA_MAJOR)/g;s/SCHEMA_MINOR/$(SCHEMA_MINOR)/g;s/SCHEMA_REVISION/$(SCHEMA_REVISION)/g" \
+	            $$file; \
+	    done
+
+SCHEMA_FOUND = $(shell grep Migrate.Version Products/ZenModel/migrate/*.py  | grep SCHEMA_ | cut -f1 -d':')
+
+# The target verify-explicit-zmigrateversion should be invoked as a first step in all release
+# builds to verify that all of the SCHEMA_* variables were replaced with an actual numeric value.
+verify-explicit-zmigrateversion:
+ifeq ($(SCHEMA_FOUND),)
+	@echo "Good - no SCHEMA_* variables found: $(SCHEMA_FOUND)"
+else
+	$(info Some SCHEMA_* variables found in Products/ZenModel/migrate/*.py:)
+	$(info )
+	$(foreach item,$(SCHEMA_FOUND),$(info $(item)))
+	$(info )
+	$(error At least one of the SCHEMA_* variables found)
+endif

--- a/zenoss-version.mk
+++ b/zenoss-version.mk
@@ -2,16 +2,15 @@
 # Makefile for zenoss-version
 #
 
+.PHONY: clean-zenoss-version build-zenoss-version
+
 ZENOSS_VERSION_ROOT = legacy/zenoss-version
 ZENOSS_VERSION_WHEEL = Zenoss-$(VERSION)-py2-none-any.whl
-
-.PHONY: clean-zenoss-version build-zenoss-version generate-zmigrateversion
 
 clean-zenoss-version:
 	rm -f $(ZENOSS_VERSION_ROOT)/setup.py
 	rm -rf $(ZENOSS_VERSION_ROOT)/src/Zenoss.egg-info
 	rm -rf $(ZENOSS_VERSION_ROOT)/build dist
-	rm -f Products/ZenModel/ZMigrateVersion.py
 
 build-zenoss-version: dist/$(ZENOSS_VERSION_WHEEL)
 
@@ -24,57 +23,3 @@ $(ZENOSS_VERSION_ROOT)/setup.py: $(ZENOSS_VERSION_ROOT)/setup.py.in
 
 dist:
 	@mkdir -p $@
-
-
-# The SCHEMA_* values define the DB schema version used for upgrades.
-# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
-# for more information about setting these values.
-
-pick_version_part = $(word $(1),$(subst ., ,$(2)))
-
-SCHEMA_VERSION  = $(shell cat SCHEMA_VERSION)
-SCHEMA_MAJOR    = $(call pick_version_part,1,$(SCHEMA_VERSION))
-SCHEMA_MINOR    = $(call pick_version_part,2,$(SCHEMA_VERSION))
-SCHEMA_REVISION = $(call pick_version_part,3,$(SCHEMA_VERSION))
-
-# Exists for backward compatibility
-generate-zversion: generate-zmigrateversion
-
-# See the topic "Managing Migrate.Version" in Products/ZenModel/migrate/README.md
-# for more information about setting the SCHEMA_* values.
-generate-zmigrateversion: Products/ZenModel/ZMigrateVersion.py
-
-Products/ZenModel/ZMigrateVersion.py: Products/ZenModel/ZMigrateVersion.py.in SCHEMA_VERSION
-	sed \
-	    -e "s/%SCHEMA_MAJOR%/$(SCHEMA_MAJOR)/g;s/%SCHEMA_MINOR%/$(SCHEMA_MINOR)/g;s/%SCHEMA_REVISION%/$(SCHEMA_REVISION)/g" \
-	    $< > $@
-
-# The target replace-zmigrationversion should be used just prior to release to lock
-# down the schema versions for a particular release
-replace-zmigrateversion:
-	@echo Replacing SCHEMA_MAJOR with $(SCHEMA_MAJOR)
-	@echo Replacing SCHEMA_MINOR with $(SCHEMA_MINOR)
-	@echo Replacing SCHEMA_REVISION with $(SCHEMA_REVISION)
-	@cd Products/ZenModel/migrate; \
-	    for file in `grep -l ZMigrateVersion *.py`; do \
-	        sed \
-	            -i \
-	            -e "/ZMigrateVersion/d" \
-	            -e "s/SCHEMA_MAJOR/$(SCHEMA_MAJOR)/g;s/SCHEMA_MINOR/$(SCHEMA_MINOR)/g;s/SCHEMA_REVISION/$(SCHEMA_REVISION)/g" \
-	            $$file; \
-	    done
-
-SCHEMA_FOUND = $(shell grep Migrate.Version Products/ZenModel/migrate/*.py  | grep SCHEMA_ | cut -f1 -d':')
-
-# The target verify-explicit-zmigrateversion should be invoked as a first step in all release
-# builds to verify that all of the SCHEMA_* variables were replaced with an actual numeric value.
-verify-explicit-zmigrateversion:
-ifeq ($(SCHEMA_FOUND),)
-	@echo "Good - no SCHEMA_* variables found: $(SCHEMA_FOUND)"
-else
-	$(info Some SCHEMA_* variables found in Products/ZenModel/migrate/*.py:)
-	$(info )
-	$(foreach item,$(SCHEMA_FOUND),$(info $(item)))
-	$(info )
-	$(error At least one of the SCHEMA_* variables found)
-endif


### PR DESCRIPTION
* Separate ZMigrateVersion.py build from zenoss-version package.
* Update makefile phony targets depend on real targets.
* Exclude the ZenUITests and migrate tests from the artifact.
* Move sitecustomize.py to its final location in artifact.