### PR TITLE
ZEN-33345 Remove possibility to move the device to organizer root

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -974,6 +974,14 @@ Ext.onReady(function () {
                 devids,
                 me = this,
                 isOrganizer = true;
+            
+            var rootOrganizers = [
+                "/zport/dmd/Devices",
+                "/zport/dmd/Locations",
+                "/zport/dmd/Groups",
+                "/zport/dmd/Systems",
+            ]
+
             if (e.records) {
                 // the tree drag and drop wraps the model in a node interface so we
                 // need to look at the uid to figure out what they are dropping
@@ -981,6 +989,10 @@ Ext.onReady(function () {
             }
 
             if (!isOrganizer) {
+                // we can't move device under the organizer root
+                if (rootOrganizers.includes(targetnode.data.uid)) {
+                    return false;
+                }
                 // move devices to the target node
                 devids = Ext.Array.pluck(Ext.pluck(e.records, 'data'), 'uid');
                 // show the confirmation about devices

--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -967,7 +967,7 @@ Ext.onReady(function () {
 
     // page level variables
     var originalMessage,
-        errorMessage = "You can't move devices to organizer root";
+        errorMessage = "You cannot move devices to a top-level organizer";
     function initializeTreeDrop(tree) {
         var rootOrganizers = [
             "/zport/dmd/Devices",


### PR DESCRIPTION
Now users can't move the device under /Devices, /Groups, /Systems and /Locations.
Users can move devices only to nested organizers

Fixes ZEN-33345