### PR TITLE
Remove sitecustomize.py from prodbin.

### DIFF
--- a/legacy/sitecustomize.py
+++ b/legacy/sitecustomize.py
@@ -1,6 +1,0 @@
-import sys, os, site
-sys.setdefaultencoding('utf-8')
-site.addsitedir(os.path.join(os.getenv('ZENHOME'), 'ZenPacks'))
-site.addsitedir('/var/zenoss/ZenPacks')
-import warnings
-warnings.filterwarnings('ignore', '.*', DeprecationWarning)

--- a/makefile
+++ b/makefile
@@ -31,8 +31,7 @@ include zenoss-version.mk
 EXCLUSIONS = *.pyc $(MIGRATE_VERSION).in Products/ZenModel/migrate/tests Products/ZenUITests
 
 ARCHIVE_EXCLUSIONS = $(foreach item,$(EXCLUSIONS),--exclude=$(item))
-ARCHIVE_INCLUSIONS = Products bin dist etc share legacy/sitecustomize.py
-ARCHIVE_TRANSFORMS = --transform='s:legacy/sitecustomize.py:lib/python2.7/sitecustomize.py:'
+ARCHIVE_INCLUSIONS = Products bin dist etc share
 
 build: $(ARTIFACT)
 
@@ -40,4 +39,4 @@ clean: clean-javascript clean-migration clean-zenoss-version
 	rm -f $(ARTIFACT)
 
 $(ARTIFACT): $(JSB_TARGETS) $(MIGRATE_VERSION) dist/$(ZENOSS_VERSION_WHEEL)
-	tar cvfz $@ $(ARCHIVE_EXCLUSIONS) $(ARCHIVE_TRANSFORMS) $(ARCHIVE_INCLUSIONS)
+	tar cvfz $@ $(ARCHIVE_EXCLUSIONS) $(ARCHIVE_INCLUSIONS)


### PR DESCRIPTION
The sitecustomize.py file is installed by product-assembly as sitecustomize.py is about more than just the contents of prodbin.

Fixes ZEN-33400.