### PR TITLE
ZEN-30634 Traceback Generated When Manually Modelling Devices

### DIFF
--- a/Products/ZenHub/services/ModelerService.py
+++ b/Products/ZenHub/services/ModelerService.py
@@ -145,8 +145,8 @@ class ModelerService(PerformanceConfig):
     def post_adm_process(self, map, device, preadmdata):
         pass
 
-    @transact
     @translateError
+    @transact
     def remote_applyDataMaps(self, device, maps, devclass=None, setLastCollection=False):
         from Products.DataCollector.ApplyDataMap import ApplyDataMap
         device = self.getPerformanceMonitor().findDeviceByIdExact(device)
@@ -219,8 +219,8 @@ class ModelerService(PerformanceConfig):
                 log.info(msg)
 
 
-    @transact
     @translateError
+    @transact
     def remote_setSnmpConnectionInfo(self, device, version, port, community):
         device = self.getPerformanceMonitor().findDeviceByIdExact(device)
         device.updateDevice(zSnmpVer=version,


### PR DESCRIPTION
- Fix the problem when we see the following error instead of actual traceback:
`2018-07-11 14:24:15,559 ERROR zen.ZenModeler: exceptions must be old-style classes or derived from BaseException, not str
Traceback (most recent call last):
  File "/opt/zenoss/Products/DataCollector/zenmodeler.py", line 716, in processClient
    if driver.next():
  File "/opt/zenoss/Products/ZenUtils/Driver.py", line 63, in result
    raise ex
TypeError: exceptions must be old-style classes or derived from BaseException, not str`

Because of a wrong order of @translateError decorator, remote exceptions in transact decorator are handled incorrectly. This commit sets the correct order of decorators