### PR TITLE
ZEN-29799 Maintenance Window Localization Doesn't Handle DST

### DIFF
--- a/Products/ZenModel/MaintenanceWindow.py
+++ b/Products/ZenModel/MaintenanceWindow.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2007, 2009, 2014 all rights reserved.
+# Copyright (C) Zenoss, Inc. 2007, 2009, 2014, 2021 all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -19,10 +19,14 @@ WEEK_SECONDS = 7*DAY_SECONDS
 
 import re
 import time
+import dateutil.tz as tz
 import calendar
 import logging
 log = logging.getLogger("zen.MaintenanceWindows")
 
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 from AccessControl import ClassSecurityInfo
 from zope.interface import implements
@@ -43,35 +47,28 @@ from ZODB.transact import transact
 from ZODB.POSException import ConflictError, POSKeyError, ReadConflictError
 
 
-def lastDayPreviousMonth(seconds):
-    parts = list(time.localtime(seconds))
-    # use day 1 of this month
-    parts[2] = 1
-    # and go back DAY_SECONDS
-    return time.mktime(parts) - DAY_SECONDS
+def addMonth(secs, dayOfMonthHint=0, tzInstance=tz.tzutc()):
+    dateTime = datetime.fromtimestamp(secs, tzInstance)
+    newYear = dateTime.year
+    newMonth = dateTime.month + 1
 
-def addMonth(secs, dayOfMonthHint=0):
-    base = list(time.localtime(secs))
-    # add a month
-    base[1] += 1
-    # year wrap
-    if base[1] == 13:
-        base[0] += 1
-        base[1] = 1
-    # Check for the case Jan 31 becomes March 3
-    # in that case, force it back to Feb 28
+    if newMonth > 12:
+        newYear += 1
+        newMonth = 1
 
-    # first, remember the month
-    month = base[1]
-    if dayOfMonthHint:
-        base[2] = dayOfMonthHint
-    # normalize
-    base = list(time.localtime(time.mktime(base)))
-    # if the month changed, walk back to the end of the previous month
-    if base[1] != month:
-        return lastDayPreviousMonth(time.mktime(base))
-    return time.mktime(base)
+    lastDayOfMonth = calendar.monthrange(newYear, newMonth)[1]
+    newDay = min(dayOfMonthHint, lastDayOfMonth)
+    newDateTime = datetime(
+        year=newYear, 
+        month=newMonth, 
+        day=newDay, 
+        hour=dateTime.hour, 
+        minute=dateTime.minute, 
+        second=dateTime.second,
+        tzinfo=tzInstance
+    )
 
+    return Time.awareDatetimeToTimestamp(newDateTime)
 
 RETURN_TO_ORIG_PROD_STATE = -99
 
@@ -93,6 +90,8 @@ class MaintenanceWindow(ZenModelRM):
     stopProductionState = RETURN_TO_ORIG_PROD_STATE
     enabled = True
     skip = 1
+    timezone = 'UTC'
+    tzInstance = tz.tzutc()
 
     _properties = (
         {'id':'name', 'type':'string', 'mode':'w'},
@@ -103,6 +102,7 @@ class MaintenanceWindow(ZenModelRM):
         {'id':'days', 'type':'string', 'mode':'w'},
         {'id':'occurrence', 'type':'string', 'mode':'w'},
         {'id':'skip', 'type':'int', 'mode':'w'},
+        {'id': 'timezone', 'type':'string', 'mode':'w'},
         )
 
     factory_type_information = (
@@ -135,13 +135,15 @@ class MaintenanceWindow(ZenModelRM):
         self.start = time.time()
         self.enabled = False
 
-    def set(self, start, duration, repeat, days='Sunday', occurrence='1st', enabled=True):
+    def set(self, start, duration, repeat, days='Sunday', occurrence='1st', enabled=True, timezone='UTC'):
         self.start = start
         self.duration = duration
         self.repeat = repeat
         self.enabled = enabled
         self.days = days
         self.occurrence = occurrence
+        self.timezone = timezone
+        self.tzInstance = tz.gettz(timezone)
 
     def displayName(self):
         if self.name is not None: return self.name
@@ -174,7 +176,7 @@ class MaintenanceWindow(ZenModelRM):
 
     def niceStartDateTime(self):
         "Return start time as a string with nice sort qualities"
-        return "%s %s" % (Time.LocalDateTime(self.start), Time.getLocalTimezone())
+        return "%s %s" % (Time.convertTimestampToTimeZone(self.start, self.timezone), self.timezone)
 
     def niceStartProductionState(self):
         "Return a string version of the startProductionState"
@@ -185,10 +187,10 @@ class MaintenanceWindow(ZenModelRM):
         return 'Original'
 
     def niceStartHour(self):
-        return time.localtime(self.start)[3]
+        return datetime.fromtimestamp(self.start, self.tzInstance).hour
 
     def niceStartMinute(self):
-        return time.localtime(self.start)[4]
+        return datetime.fromtimestamp(self.start, self.tzInstance).minute
 
     def niceRepeat(self):
         if self.repeat == self.REPEAT[-1]:
@@ -212,7 +214,8 @@ class MaintenanceWindow(ZenModelRM):
                                      enabled=True,
                                      skip=1,
                                      REQUEST=None,
-                                     startDateTime=None):
+                                     startDateTime=None,
+                                     timezone=None):
         "Update the maintenance window from GUI elements"
         def makeInt(v, fieldName, minv=None, maxv=None, acceptBlanks=True):
             if acceptBlanks:
@@ -243,6 +246,15 @@ class MaintenanceWindow(ZenModelRM):
         prodStates = dict((key, value) for (key,value) in self.dmd.getProdStateConversions())
         msgs = []
         self.enabled = bool(enabled)
+
+        if not timezone:
+            # Use container timezone
+            timezone = time.strftime('%Z')
+        try:
+            tzInstance = tz.gettz(timezone)
+        except:
+            msgs.append("'timezone' has wrong value")
+    
         if startDateTime:
             t = int(startDateTime)
         else:
@@ -257,8 +269,8 @@ class MaintenanceWindow(ZenModelRM):
             month = int(month)
             year = int(year)
             if not msgs:
-                t = time.mktime((year, month, day, startHours, startMinutes,
-                             0, 0, 0, -1))
+                startDateTime = datetime(year, month, day, startHours, startMinutes, tzinfo=tzInstance)
+                t = Time.awareDatetimeToTimestamp(startDateTime)
         if repeat not in self.REPEAT:
             msgs.append('\'repeat\' has wrong value.')
         if not isinstance(enabled, bool):
@@ -300,6 +312,8 @@ class MaintenanceWindow(ZenModelRM):
             self.startProductionState = startProductionState
             self.stopProductionState = stopProductionState
             self.skip = skip
+            self.timezone = timezone
+            self.tzInstance = tzInstance
             now = time.time()
             if self.started:
                 if ((t + duration * 60) < now) or (t > now) or (not self.enabled):
@@ -329,10 +343,10 @@ class MaintenanceWindow(ZenModelRM):
     def nextEvent(self, now):
         "Return the time of the next begin() or end()"
         if self.started:
-            return self.adjustDST(self.started + self.duration * 60 - 1)
+            return self.started + self.duration * 60 - 1
         # ok, so maybe "now" is a little late: start anything that
         # should have been started by now
-        return self.next(self.padDST(now) - self.duration * 60 + 1)
+        return self.next(now - self.duration * 60 + 1)
 
 
     security.declareProtected(ZEN_VIEW, 'breadCrumbs')
@@ -346,13 +360,13 @@ class MaintenanceWindow(ZenModelRM):
 
 
     def occurDay(self, start, now, skip=1, day=6, occur=0):
-        date = time.localtime(start)
-        time_for_mktime = (date.tm_hour, date.tm_min, date.tm_sec, 0, 0, -1)
-        log.debug('start date: %s; day: %d; occur: %d; skip: %d', str(date), day,
+        startDateTime = datetime.fromtimestamp(start, self.tzInstance)
+        timeDelta = relativedelta(hours=startDateTime.hour, minutes=startDateTime.minute, seconds=startDateTime.second)
+        log.debug('start date: %s; day: %d; occur: %d; skip: %d', str(startDateTime), day,
                   occur, skip)
         # get a list of (mday, wday) tuples for current month
         c = calendar.Calendar(firstweekday=0)
-        flatter = sum(c.monthdays2calendar(date.tm_year, date.tm_mon), [])
+        flatter = sum(c.monthdays2calendar(startDateTime.year, startDateTime.month), [])
         if occur == 5:
             flatter = reversed(flatter)
             tmp_occur = 0
@@ -364,26 +378,28 @@ class MaintenanceWindow(ZenModelRM):
             if wday == day and mday > 0:
                 count += 1
                 log.debug('found wday %d, mday %d, count %d', wday, mday, count)
-                if count == tmp_occur + 1 and mday >= date.tm_mday:
+                if count == tmp_occur + 1 and mday >= startDateTime.day:
                     log.debug('count matched, mday %d', mday)
-                    startTime = time.mktime(
-                        (date.tm_year, date.tm_mon, mday) + time_for_mktime)
+                    startDateTime = datetime(startDateTime.year, startDateTime.month, mday, tzinfo=self.tzInstance) + timeDelta
+                    startTimestamp = Time.awareDatetimeToTimestamp(startDateTime)
                     # do we need to skip this day?
                     if skip > 1:
                         log.debug('skipping this occurrence. skip = %d', skip)
-                        return self.occurDay(startTime + DAY_SECONDS, now, skip - 1,
+                        return self.occurDay(startTimestamp + DAY_SECONDS, now, skip - 1,
                                              day, tmp_occur)
-                    elif startTime >= now:
+                    elif startTimestamp >= now:
                         log.debug('Window will start on: %s',
-                                  str(time.localtime(startTime)))
-                        return startTime
-                        # couldn't find start day in current month, switching to 1st day of the next month
-        if date.tm_mon == 12:
-            date = (date.tm_year + 1, 1, 1)
+                                  str(datetime.fromtimestamp(startTimestamp, self.tzInstance)))
+                        return startTimestamp
+        
+        # couldn't find start day in current month, switching to 1st day of the next month
+        if startDateTime.month == 12:
+            startDateTime = datetime(startDateTime.year + 1, 1, 1, tzinfo=self.tzInstance)
         else:
-            date = (date.tm_year, date.tm_mon + 1, 1)
-        date += time_for_mktime
-        return self.occurDay(time.mktime(date), now, skip, day, occur)
+            startDateTime = datetime(startDateTime.year, startDateTime.month + 1, 1, tzinfo=self.tzInstance)
+        startDateTime += timeDelta
+
+        return self.occurDay(Time.awareDatetimeToTimestamp(startDateTime), now, skip, day, occur)
 
 
     def next(self, now=None):
@@ -392,7 +408,7 @@ class MaintenanceWindow(ZenModelRM):
         for the window to start, or None
         This adjusts for DST changes.
         """
-        return self.adjustDST(self._next(now))
+        return self._next(now)
 
 
     def _next(self, now):
@@ -413,42 +429,42 @@ class MaintenanceWindow(ZenModelRM):
                 return None
             return self.start
 
-        elif self.repeat == self.DAILY:
-            skip = (DAY_SECONDS * self.skip)
-            last = self.start + ((now - self.start) // skip * skip)
-            return last + skip
+        elif self.repeat == self.DAILY:   
+            daysSince = (now - self.start) // DAY_SECONDS
+            dateTime = datetime.fromtimestamp(self.start, self.tzInstance) + relativedelta(days=daysSince + self.skip)
+            return Time.awareDatetimeToTimestamp(dateTime)
 
         elif self.repeat == self.EVERY_WEEKDAY:
             weeksSince = (now - self.start) // WEEK_SECONDS
             weekdaysSince = weeksSince * 5
             # start at the most recent week-even point from the start
-            base = self.start + weeksSince * DAY_SECONDS * 7
+            baseDateTime = datetime.fromtimestamp(self.start, self.tzInstance) + relativedelta(weeks=weeksSince)
+            nowDateTime = datetime.fromtimestamp(now, self.tzInstance)
             while 1:
-                dow = time.localtime(base).tm_wday
+                dow = baseDateTime.weekday()
                 if dow not in (5,6):
-                    if base > now and weekdaysSince % self.skip == 0:
+                    if baseDateTime > nowDateTime and weekdaysSince % self.skip == 0:
                         break
                     weekdaysSince += 1
-                base += DAY_SECONDS
-            assert base >= now
-            return base
+                baseDateTime += relativedelta(days=1)
+            assert baseDateTime >= nowDateTime
+            return Time.awareDatetimeToTimestamp(baseDateTime)
 
         elif self.repeat == self.WEEKLY:
-            skip = (WEEK_SECONDS * self.skip)
-            last = self.start + ((now - self.start) // skip * skip)
-            return last + skip
+            weeksSince = (now - self.start) // WEEK_SECONDS
+            dateTime = datetime.fromtimestamp(self.start, self.tzInstance) + relativedelta(weeks=weeksSince + self.skip)
+            return Time.awareDatetimeToTimestamp(dateTime)
 
         elif self.repeat == self.MONTHLY:
             months = 0
             m = self.start
-            dayOfMonthHint = time.localtime(self.start).tm_mday
+            dayOfMonthHint = datetime.fromtimestamp(self.start, self.tzInstance).day
             while m < now or months % self.skip:
-                m = addMonth(m, dayOfMonthHint)
+                m = addMonth(m, dayOfMonthHint, self.tzInstance)
                 months += 1
             return m
 
         elif self.repeat == self.NTHWDAY:
-            #return self.occurDay(self.start, now, self.skip)
             return self.occurDay(
                                  self.start,
                                  now,
@@ -721,34 +737,6 @@ class MaintenanceWindow(ZenModelRM):
         else:
             self.begin(now, batchSize, inTransaction)
 
-    def adjustDST(self, result):
-        if result is None:
-            return None
-        if self.started:
-            startTime = time.localtime(self.started)
-        else:
-            startTime = time.localtime(self.start)
-        resultTime = time.localtime(result)
-        if startTime.tm_isdst == resultTime.tm_isdst:
-            return result
-        if startTime.tm_isdst:
-            return result + 60*60
-        return result - 60*60
-
-
-    def padDST(self, now):
-        """
-        When incrementing or decrementing timestamps within a DST switch we
-        need to add or subtract the DST offset accordingly.
-        """
-        startTime = time.localtime(self.start)
-        nowTime = time.localtime(now)
-        if startTime.tm_isdst == nowTime.tm_isdst:
-            return now
-        elif startTime.tm_isdst:
-            return now - 60 * 60
-        else:
-            return now + 60 * 60
 
     def getAuditData(self):
         return {

--- a/Products/ZenModel/migrate/addTzToMaintWindows.py
+++ b/Products/ZenModel/migrate/addTzToMaintWindows.py
@@ -1,0 +1,40 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+import dateutil.tz as tz
+
+__doc__ = '''
+This migration script add and sets the timezone field for existing maintenance windows.
+It takes the timezone of container
+'''
+
+import Migrate
+
+from Products.ZenUtils import Time
+from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION
+
+log = logging.getLogger("zen.migrate")
+
+
+class AddTzToMaintWindows(Migrate.Step):
+    version = Migrate.Version(SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA_REVISION)
+
+    def cutover(self, dmd):
+        container_tz = Time.getLocalTimezone()
+        tzInstance = tz.gettz(container_tz)
+        for brain in dmd.maintenanceWindowSearch():
+            try:
+                m = brain.getObject()
+            except Exception:
+                continue
+            m.timezone = container_tz
+            m.tzInstance = tzInstance
+
+AddTzToMaintWindows()

--- a/Products/ZenModel/tests/testMaintenanceWindow.py
+++ b/Products/ZenModel/tests/testMaintenanceWindow.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2008, 2009, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2008, 2009, 2021 all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -8,12 +8,17 @@
 ##############################################################################
 
 
+import dateutil.tz as tz
+
 from time import mktime, time
+from datetime import datetime, timedelta
+from dateutil.relativedelta import relativedelta
 
 from ZODB.POSException import ConflictError
 
 from ZenModelBaseTest import ZenModelBaseTest
 from Products.ZenModel.MaintenanceWindow import MaintenanceWindow, DAY_SECONDS
+from Products.ZenUtils import Time
 # Note: The new messaging code inteferes with FakeRequest operations,
 #      as the adapter machinery doesn't load
 #from Products.ZenUtils.FakeRequest import FakeRequest
@@ -37,57 +42,63 @@ stateNames = {
 
 class TestMaintenanceWindows(ZenModelBaseTest):
 
-    def testMaintenanceWindows(self):
+    def testUTCMaintenanceWindows(self):
         m = MaintenanceWindow('tester')
         m.dmd = self.dmd
-        t = mktime( (2006, 1, 29, 10, 45, 12, 6, 29, 0) )
+        tzInstance = tz.tzutc()
+
+        def getLocalizedTimestamp(year, month, day, hour, minutes, seconds):
+            localizedExpectedDateTime = datetime(year, month, day, hour, minutes, seconds, tzinfo=tzInstance)
+            return Time.awareDatetimeToTimestamp(localizedExpectedDateTime)
+
+        t = getLocalizedTimestamp(2006, 1, 29, 10, 45, 12)
         P = 60*60*2
         # set(start, duration, repeat, enabled=True)
         m.set(t, P, m.NEVER)
         self.assert_(m.next() == None)
         m.set(t, P, m.DAILY)
-        c = mktime( (2006, 1, 30, 10, 45, 12, 6, 29, 0) )
+        c = getLocalizedTimestamp(2006, 1, 30, 10, 45, 12)
         self.assert_(m.next(t + P + 1) == c)
         m.set(t, P, m.WEEKLY)
-        c = mktime( (2006, 2, 5, 10, 45, 12, 6, 36, 0) )
+        c = getLocalizedTimestamp(2006, 2, 5, 10, 45, 12)
         self.assert_(m.next(t + 1) == c)
         m.set(t - DAY_SECONDS, P, m.EVERY_WEEKDAY)
-        c = mktime( (2006, 1, 30, 10, 45, 12, 7, 30, 0) )
+        c = getLocalizedTimestamp(2006, 1, 30, 10, 45, 12)
         self.assert_(m.next(t) == c)
         m.set(t, P, m.MONTHLY)
-        c = mktime( (2006, 2, 28, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 2, 28, 10, 45, 12)
         self.assert_(m.next(t+1) == c)
-        t2 = mktime( (2005, 12, 31, 10, 45, 12, 0, 0, 0) )
+        t2 = getLocalizedTimestamp(2005, 12, 31, 10, 45, 12)
         m.set(t2, P, m.MONTHLY)
-        c = mktime( (2006, 1, 31, 10, 45, 12, 0, 0, 0) )
-        c2 = mktime( (2006, 2, 28, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 1, 31, 10, 45, 12)
+        c2 = getLocalizedTimestamp(2006, 2, 28, 10, 45, 12)
         self.assert_(m.next(t2+1) == c)
         self.assert_(m.next(c+1) == c2)
-        c = mktime( (2006, 2, 5, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 2, 5, 10, 45, 12)
         m.set(t, P, m.NTHWDAY)
         self.assert_(m.next(t+1) == c)
-        c = mktime( (2006, 1, 31, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 1, 31, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Tuesday', 'Last')
         self.assert_(m.next(t+1) == c)
-        c = mktime( (2006, 2, 19, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 2, 19, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Sunday', '3rd')
         self.assert_(m.next(t+1) == c)
-        c = mktime( (2006, 2, 22, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 2, 22, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Wednesday', 'Last')
         self.assert_(m.next(t+1) == c)
 
-        c = mktime( (2006, 3, 13, 10, 45, 12, 0, 0, 0) )
-        n = mktime( (2006, 3, 6, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 3, 13, 10, 45, 12)
+        n = getLocalizedTimestamp(2006, 3, 6, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Monday', '2nd')
         self.assert_(m.next(n) == c)
 
-        c = mktime( (2006, 3, 29, 10, 45, 12, 0, 0, 0) )
-        n = mktime( (2006, 3, 6, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 3, 29, 10, 45, 12)
+        n = getLocalizedTimestamp(2006, 3, 6, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Wednesday', 'Last')
         self.assert_(m.next(n) == c)
 
-        c = mktime( (2007, 1, 8, 10, 45, 12, 0, 0, 0) )
-        n = mktime( (2007, 1, 2, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2007, 1, 8, 10, 45, 12)
+        n = getLocalizedTimestamp(2007, 1, 2, 10, 45, 12)
         m.set(t, P, m.NTHWDAY, 'Monday', '2nd')
         self.assert_(m.next(n) == c)
 
@@ -95,61 +106,62 @@ class TestMaintenanceWindows(ZenModelBaseTest):
         # DST
         FSOTM_Map = {
             # DST day      following first sunday of the month
-            (2008, 3, 9):  (2008, 4, 6),
-            (2008, 11, 2): (2008, 12, 7),
+            (2008, 3, 9):  datetime(2008, 4, 6),
+            (2008, 11, 2): datetime(2008, 12, 7),
             }
         for (yy, mm, dd), sunday in FSOTM_Map.items():
             duration = 3*60
-            tt = mktime( (yy, mm, dd, 12, 10, 9, 0, 0, -1) )
+            tt = getLocalizedTimestamp(yy, mm, dd, 12, 10, 9)
             m.set(tt, duration, m.DAILY)
-            c = mktime( (yy, mm, dd + 1, 12, 10, 9, 0, 0, -1) )
+            c = getLocalizedTimestamp(yy, mm, dd + 1, 12, 10, 9)
             self.assert_(m.next(tt + duration) == c)
 
             m.set(tt, duration, m.WEEKLY)
-            c = mktime( (yy, mm, dd + 7, 12, 10, 9, 0, 0, -1) )
+            c = getLocalizedTimestamp(yy, mm, dd + 7, 12, 10, 9)
             self.assert_(m.next(tt + duration) == c)
 
             m.set(tt, duration, m.EVERY_WEEKDAY)
-            c = mktime( (yy, mm, dd + 1, 12, 10, 9, 0, 0, -1) )
+            c = getLocalizedTimestamp(yy, mm, dd + 1, 12, 10, 9)
             self.assert_(m.next(tt + duration) == c)
 
             m.set(tt, duration, m.NTHWDAY)
-            c = mktime( sunday + (12, 10, 9, 0, 0, -1) )
+            date = sunday + timedelta(hours=12, minutes=10, seconds=9)
+            c = getLocalizedTimestamp(date.year, date.month, date.day, date.hour, date.minute, date.second)
             self.assert_(m.next(tt + duration) == c)
 
             # DST: check that a 3-hour range ends at the proper time
-            tt = mktime( (yy, mm, dd, 0, 10, 9, 0, 0, -1) )
+            tt = getLocalizedTimestamp(yy, mm, dd, 0, 10, 9)
             m.set(tt, duration, m.DAILY)
             m.started = tt
-            c = mktime( (yy, mm, dd, 3, 10, 8, 0, 0, -1) )
+            c = getLocalizedTimestamp(yy, mm, dd, 3, 10, 8)
             self.assert_(m.nextEvent(tt) == c)
             m.started = None
 
         # skips
         m.skip = 2
         m.set(t, P, m.DAILY)
-        c = mktime( (2006, 1, 31, 10, 45, 12, 6, 29, 0) )
+        c = getLocalizedTimestamp(2006, 1, 31, 10, 45, 12)
         self.assert_(m.next(t + 1) == c)
 
         m.set(t, P, m.WEEKLY)
-        c = mktime( (2006, 2, 12, 10, 45, 12, 6, 36, 0) )
+        c = getLocalizedTimestamp(2006, 2, 12, 10, 45, 12)
         self.assert_(m.next(t + 1) == c)
 
         m.set(t, P, m.MONTHLY)
-        c = mktime( (2006, 3, 29, 10, 45, 12, 6, 36, 0) )
+        c = getLocalizedTimestamp(2006, 3, 29, 10, 45, 12)
         self.assert_(m.next(t + 1) == c)
 
         m.set(t - DAY_SECONDS * 2, P, m.EVERY_WEEKDAY)
-        c = mktime( (2006, 1, 31, 10, 45, 12, 7, 30, 0) )
+        c = getLocalizedTimestamp(2006, 1, 31, 10, 45, 12)
         self.assert_(m.next(t + 1) == c)
 
-        c = mktime( (2006, 3, 5, 10, 45, 12, 0, 0, 0) )
+        c = getLocalizedTimestamp(2006, 3, 5, 10, 45, 12)
         m.set(t, P, m.NTHWDAY)
         self.assert_(m.next(t+1) == c)
 
         m1 = MaintenanceWindow('t1')
         m2 = MaintenanceWindow('t2')
-        t = mktime( (2006, 1, 29, 10, 45, 12, 6, 29, 0) )
+        t = getLocalizedTimestamp(2006, 1, 29, 10, 45, 12)
         duration = 1
         m1.set(t, duration, m.NEVER)
         m2.set(t + duration * 60, duration, m.NEVER)
@@ -179,6 +191,132 @@ class TestMaintenanceWindows(ZenModelBaseTest):
         self.assert_(m.duration == 24*60+61)
         self.assert_(m.repeat == 'Weekly')
         self.assert_(m.startProductionState == state_Maintenance)
+    
+    def testTimezonedWindows(self):
+        m = MaintenanceWindow('tester')
+        m.dmd = self.dmd
+        tzName = 'Europe/Kiev'
+        tzInstance = tz.gettz(tzName)
+
+        def getLocalizedTimestamp(year, month, day, hour, minutes):
+            localizedExpectedDateTime = datetime(year, month, day, hour, minutes, tzinfo=tzInstance)
+            return Time.awareDatetimeToTimestamp(localizedExpectedDateTime)
+
+        startTime = getLocalizedTimestamp(2021, 2, 19, 15, 0)
+        duration = 60*60*2
+
+        m.set(startTime, duration, m.NEVER, timezone=tzName)
+        self.assertEqual(m.next(), None)
+
+        m.set(startTime, duration, m.DAILY, timezone=tzName)
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 20, 15, 0)
+        self.assertEqual(m.next(startTime + duration + 1), expectedTimestamp)
+
+        m.set(startTime, duration, m.WEEKLY, timezone=tzName)
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 26, 15, 0)
+        self.assertEqual(m.next(startTime + 1), expectedTimestamp)
+
+        m.set(startTime, duration, m.EVERY_WEEKDAY)
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 22, 15, 0)
+        self.assertEqual(m.next(startTime), expectedTimestamp)
+
+        m.set(startTime, duration, m.MONTHLY, timezone=tzName)
+        expectedTimestamp = getLocalizedTimestamp(2021, 3, 19, 15, 0)
+        self.assertEqual(m.next(startTime+1), expectedTimestamp)
+
+        t2 = getLocalizedTimestamp(2020, 12, 31, 15, 0)
+        m.set(t2, duration, m.MONTHLY, timezone=tzName)
+        expectedTimestamp_1 = getLocalizedTimestamp(2021, 1, 31, 15, 0)
+        expectedTimestamp_2 = getLocalizedTimestamp(2021, 2, 28, 15, 0)
+        self.assertEqual(m.next(t2+1), expectedTimestamp_1)
+        self.assertEqual(m.next(expectedTimestamp_1+1), expectedTimestamp_2)
+
+        expectedTimestamp = getLocalizedTimestamp(2021, 3, 7, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, timezone=tzName)
+        self.assertEqual(m.next(startTime+1), expectedTimestamp)
+
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 26, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Friday', 'Last', timezone=tzName)
+        self.assertEqual(m.next(startTime+1), expectedTimestamp)
+
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 21, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Sunday', '3rd', timezone=tzName)
+        self.assertEqual(m.next(startTime+1), expectedTimestamp)
+
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 24, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Wednesday', 'Last', timezone=tzName)
+        self.assertEqual(m.next(startTime+1), expectedTimestamp)
+
+        expectedTimestamp = getLocalizedTimestamp(2021, 3, 19, 15, 0)
+        m.set(startTime, duration, m.MONTHLY, timezone=tzName)
+        self.assertEqual(m.next(startTime + 1), expectedTimestamp)
+
+        nowTimestamp = getLocalizedTimestamp(2021, 3, 1, 15, 0)
+        expectedTimestamp = getLocalizedTimestamp(2021, 3, 8, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Monday', '2nd', timezone=tzName)
+        self.assertEqual(m.nextEvent(nowTimestamp), expectedTimestamp)
+
+        nowTimestamp = getLocalizedTimestamp(2021, 3, 1, 15, 0)
+        expectedTimestamp = getLocalizedTimestamp(2021, 3, 31, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Wednesday', 'Last', timezone=tzName)
+        self.assertEqual(m.nextEvent(nowTimestamp), expectedTimestamp)
+
+        nowTimestamp = getLocalizedTimestamp(2022, 3, 8, 15, 0)
+        expectedTimestamp = getLocalizedTimestamp(2022, 3, 14, 15, 0)
+        m.set(startTime, duration, m.NTHWDAY, 'Monday', '2nd', timezone=tzName)
+        self.assertEqual(m.nextEvent(nowTimestamp), expectedTimestamp)
+
+        # skips
+        m.skip = 2
+        m.set(startTime, duration, m.DAILY, timezone=tzName)
+        expectedTimestamp = getLocalizedTimestamp(2021, 2, 21, 15, 0)
+        self.assertEqual(m.next(startTime + 1), expectedTimestamp)
+
+    def testTimezonedWindowsWithDST(self):
+        m = MaintenanceWindow('tester')
+        m.dmd = self.dmd
+        tzName = 'Europe/Kiev'
+        tzInstance = tz.gettz(tzName)
+        duration = 3*60
+
+        def getLocalizedTimestamp(dateTime):
+            localized_expected_time = dateTime.replace(tzinfo=tzInstance)
+            return Time.awareDatetimeToTimestamp(localized_expected_time)
+
+        FSOTM_Map = {
+            # day before DST changing (Europe/Kiev) and first sunday of the month
+            # Saturday      Sunday
+            (2021, 3, 27):  datetime(2021, 4, 4),
+            (2021, 10, 30): datetime(2021, 11, 7),
+        }
+
+        for (yy, mm, dd), sunday in FSOTM_Map.items():
+            startTime = getLocalizedTimestamp(datetime(yy, mm, dd, 12, 0))
+            nowTime = getLocalizedTimestamp(datetime(yy, mm, dd, 15, 0))
+
+            m.set(startTime, duration, m.DAILY, timezone=tzName)
+            expected_timestamp = getLocalizedTimestamp(datetime(yy, mm, dd, 12, 0) + relativedelta(days=1))
+            self.assertEqual(m.nextEvent(nowTime), expected_timestamp)
+
+            m.set(startTime, duration, m.WEEKLY, timezone=tzName)
+            expected_timestamp = getLocalizedTimestamp(datetime(yy, mm, dd, 12, 0) + relativedelta(days=7))
+            self.assertEqual(m.nextEvent(nowTime), expected_timestamp)
+
+            m.set(startTime, duration, m.EVERY_WEEKDAY, timezone=tzName)
+            expected_timestamp = getLocalizedTimestamp(datetime(yy, mm, dd, 12, 0) + relativedelta(days=2))
+            self.assertEqual(m.nextEvent(nowTime), expected_timestamp)
+
+            m.set(startTime, duration, m.NTHWDAY, 'Sunday', '1st', timezone=tzName)
+            expected_timestamp = getLocalizedTimestamp(sunday + relativedelta(hours=12))
+            self.assertEqual(m.nextEvent(nowTime), expected_timestamp)
+
+            # DST: check that a mw takes the proper amount of time
+            tt = getLocalizedTimestamp(datetime(yy, mm, dd, 0, 10, 9))
+            m.set(tt, duration, m.DAILY, timezone=tzName)
+            m.started = tt
+            self.assertEqual(m.nextEvent(tt)-tt, duration*60-1)
+            m.started = None
+
 
     def setupWindows(self, windowsDefs, maxWindows=10):
         """

--- a/Products/ZenUtils/Time.py
+++ b/Products/ZenUtils/Time.py
@@ -21,6 +21,7 @@ __version__ = "$$"[11:-2]
 import time
 import os
 import pytz
+import dateutil.tz as tz
 import re
 from datetime import datetime
 from hashlib import sha224
@@ -133,6 +134,12 @@ def isoToTimestamp(value):
     timeTuple = time.strptime(timeStr, '%Y-%m-%d %H:%M:%S')
     timestamp = time.mktime(timeTuple)
     return timestamp
+
+def awareDatetimeToTimestamp(awareDatetime):
+    """
+    converts a datetime that contains a timezone to a timestamp in seconds since 1970
+    """
+    return (awareDatetime.astimezone(tz.tzutc()) - datetime(1970, 1, 1, tzinfo=tz.tzutc())).total_seconds()
 
 def getYear():
     """

--- a/Products/Zuul/infos/devicemanagement.py
+++ b/Products/Zuul/infos/devicemanagement.py
@@ -20,6 +20,7 @@ class MaintenanceWindowInfo(InfoBase):
     days = ProxyProperty('days')
     occurrence = ProxyProperty('occurrence')
     startState = ProxyProperty('startProductionState')
+    timezone = ProxyProperty('timezone')
 
     @property
     def startProdState(self):
@@ -50,7 +51,8 @@ class MaintenanceWindowInfo(InfoBase):
                                      days=p.get('days', 'Sunday'),
                                      occurrence=p.get('occurrence', '1st'),
                                      startProductionState=p['startProductionState'],
-                                     enabled=p['enabled']
+                                     enabled=p['enabled'],
+                                     timezone=p.get('timezone', None),
                                 )
 
 class UserCommandManagementInfo(InfoBase):


### PR DESCRIPTION
- Now every MW has its own timezone. MWs are independent of the server timezone
- Use timezoned datetime for time calculations (for proper DST calculations)
- Add timezone field in UI (when editing MW)
- Add unit tests to check DST calculations