### PR TITLE
ZEN-33520 'Time Zone' field is blank after upgrade if time zone wasn't default

### DIFF
--- a/Products/ZenUtils/Time.py
+++ b/Products/ZenUtils/Time.py
@@ -151,5 +151,11 @@ def getLocalTimezone():
     """
     Return a string representing local time zone.
     """
-    return time.strftime("%Z")
+    # try to read serviced variable
+    timezone = os.getenv("TZ", None)
+
+    if not timezone:
+        timezone = time.strftime("%Z")
+
+    return timezone
     


### PR DESCRIPTION
After migration, existing MWs should have the timezone from serviced config