### PR TITLE
Fix adding new user to group without permissions

### DIFF
--- a/Products/ZenModel/skins/zenmodel/dialog_addUserToAGroup.pt
+++ b/Products/ZenModel/skins/zenmodel/dialog_addUserToAGroup.pt
@@ -11,7 +11,7 @@
     </select>
 </p><br><br>
 
-<p>
+<p tal:condition="python: here.has_permission('Manage Users', here)">
     Create a new user to add to this group<br>
     <input type="text" id="add_new_user_to_group">
     <input type="submit" value="Add New User" onclick="

--- a/Products/ZenModel/skins/zenmodel/dialog_addUserToGroup.pt
+++ b/Products/ZenModel/skins/zenmodel/dialog_addUserToGroup.pt
@@ -11,7 +11,7 @@
     </select>
 </p><br><br>
 
-<p>
+<p tal:condition="python: here.has_permission('Manage Users', here)">
     Create a new user to add to this group<br>
     <input type="text" id="add_new_user_to_group">
     <input type="submit" value="Add New User" onclick="


### PR DESCRIPTION
This way of adding a previously non-existent user to a group can result
in breaking things in a CZ. Only users with the CZAdmin role, and
therefore the "Manage Users" permission should be allowed to add new
users to a group. Users with the ZenManager role will still be allowed
to add existing users to groups.

Fixes ZING-14314.
