### PR TITLE
Removing traceback from error_formatted

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -431,7 +431,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
             return
 
         from traceback import format_exception
-        error_formatted = ''.join(format_exception(error_type, error_value, error_traceback))
+        error_formatted = ''.join(format_exception(error_type, error_value))
         return self.zenoss_feedback_error_message(error_type=error_type,
                                         error_value=error_value,
                                         error_traceback=error_traceback,


### PR DESCRIPTION
fix for ZEN-32234
Removing traceback from error_formatted will prevent the call-stack from being printed to the Console