### PR TITLE
Reveal remote exceptions

### DIFF
--- a/Products/ZenHub/services/ModelerService.py
+++ b/Products/ZenHub/services/ModelerService.py
@@ -146,8 +146,8 @@ class ModelerService(PerformanceConfig):
     def post_adm_process(self, map, device, preadmdata):
         pass
 
-    @transact
     @translateError
+    @transact
     def remote_applyDataMaps(self, device, maps, devclass=None, setLastCollection=False):
         from Products.DataCollector.ApplyDataMap import ApplyDataMap
         device = self.getPerformanceMonitor().findDeviceByIdExact(device)
@@ -223,8 +223,8 @@ class ModelerService(PerformanceConfig):
                 log.info(msg)
 
 
-    @transact
     @translateError
+    @transact
     def remote_setSnmpConnectionInfo(self, device, version, port, community):
         device = self.getPerformanceMonitor().findDeviceByIdExact(device)
         device.updateDevice(zSnmpVer=version,


### PR DESCRIPTION
Because of a wrong order of @translateError decorator, remote exceptions
are handled incorrectly. This commit sets the correct order of decorators

ZEN-33220