### PR TITLE
Improve timeout handling on unstable networks.

### DIFF
--- a/Products/ZenRRD/runner.py
+++ b/Products/ZenRRD/runner.py
@@ -323,7 +323,12 @@ class SshRunner(object):
                 # Last task is using connection so can be closed
                 self.connection.clientFinished()
                 self.cleanUpPool(close=True)
+                log.debug(
+                    "Connection closed  connection=%s", self.connection,
+                )
             self.connection = None
+        else:
+            log.debug("No connection to close")
 
     def cleanUpPool(self, connection=None, close=False):
         """
@@ -332,6 +337,12 @@ class SshRunner(object):
         connection = connection or self.connection
 
         if self._poolkey in self._pool:
+            # Cancel the deferreds from other tasks waiting on a connection.
+            content = self._pool.get(self._poolkey)
+            if isinstance(content, list):
+                for d in content:
+                    if not d.called:
+                        d.cancel()
             del self._pool[self._poolkey]
             log.debug(
                 "Deleted connection from pool  device=%s connection=%s",
@@ -345,6 +356,10 @@ class SshRunner(object):
         Deliver ourselves to the starter with the proper attributes
         """
         if isinstance(result, Failure):
+            log.debug(
+                "Command failed  device=%s failure=%r",
+                self.deviceId, result,
+            )
             return result
 
         self.output, self.exitCode, self.stderr = result

--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -451,7 +451,10 @@ class SshPerformanceCollectionTask(BaseTask):
         @return: Deferred actions to run against a device configuration
         @rtype: Twisted deferred object
         """
-        log.debug("Starting collection task  device=%s", self._devId)
+        log.debug(
+            "Starting collection task  device=%s interval=%s",
+            self._devId, self.interval,
+        )
         self._doTask_start = datetime.now()
         self.state = SshPerformanceCollectionTask.STATE_CONNECTING
         try:
@@ -491,11 +494,14 @@ class SshPerformanceCollectionTask(BaseTask):
 
         except Exception as e:
             self.state = TaskStates.STATE_PAUSED
-            err_msg = "Task paused  name=%s device-id=%s ip=%s message=%s" % (
-                self.name,
-                self._devId,
-                self._manageIp,
-                e.message)
+            err_msg = (
+                "Task paused  device=%s ip=%s interval=%s message=%s" % (
+                    self._devId,
+                    self._manageIp,
+                    self.interval,
+                    e.message,
+                )
+            )
             if log.isEnabledFor(logging.DEBUG):
                 log.exception(err_msg)
             else:
@@ -507,6 +513,9 @@ class SshPerformanceCollectionTask(BaseTask):
                 component=COLLECTOR_NAME,
                 severity=Error,
             )
+            # Re-raise the exception to the scheduler, which will increment
+            # the failed task counter.
+            raise
         else:
             self._returnToNormalSchedule()
 
@@ -533,8 +542,11 @@ class SshPerformanceCollectionTask(BaseTask):
         d = self._runner(self._connector.connection).send(datasource)
         if self._showfullcommand:
             log.info(
-                "Datasource added  name=%s command=%r",
-                datasource.name, datasource.command,
+                "Datasource added  device=%s interval=%s name=%s command=%r",
+                self._devId,
+                self.interval,
+                datasource.name,
+                datasource.command,
             )
         datasource.lastStart = time.time()
         d.addBoth(datasource.processCompleted)
@@ -547,13 +559,17 @@ class SshPerformanceCollectionTask(BaseTask):
         Sends commands to run the monitored device then waits for and
         processes the results.
         """
-        log.debug("Fetching data  device=%s", self._devId)
+        log.debug(
+            "Fetching data  device=%s interval=%s",
+            self._devId, self.interval,
+        )
         self.state = SshPerformanceCollectionTask.STATE_FETCH_DATA
 
         try:
             # Collect the Deferred objects into this list.
             pending = []
 
+            label = "{}/{}".format(self.interval, self._devId)
             # Submit the commands to the executor.
             for command, datasources in self._commandMap.items():
                 first_ds = datasources[0]
@@ -561,7 +577,9 @@ class SshPerformanceCollectionTask(BaseTask):
                 # Note: 'd' is not the same deferred object returned from
                 # the _fetchFromDatasource method.
                 d = self._executor.submit(
-                    call, timeout=self._device.zCommandCommandTimeout,
+                    call,
+                    timeout=self._device.zCommandCommandTimeout,
+                    label=label,
                 )
                 d.addCallback(self._handle_completion, command)
                 d.addErrback(self._handle_error, command)
@@ -587,6 +605,14 @@ class SshPerformanceCollectionTask(BaseTask):
         return (True, (command, response))
 
     def _handle_error(self, failure, command):
+        log.debug(
+            "Datasource command failed  "
+            "device=%s interval=%s command=%r failure=%r",
+            self._devId,
+            self.interval,
+            command,
+            failure,
+        )
         # This callback method is called for any error resulting from the
         # command being unable to complete, e.g. timeouts.
         return (False, (command, failure))
@@ -628,7 +654,10 @@ class SshPerformanceCollectionTask(BaseTask):
         @parameter resultList: results of running the commands
         @type resultList: array of (boolean, (str, IRunner|Failure))
         """
-        log.debug("Parsing fetched data  device=%s", self._devId)
+        log.debug(
+            "Parsing fetched data  device=%s interval=%s",
+            self._devId, self.interval,
+        )
         self.state = SshPerformanceCollectionTask.STATE_PARSE_DATA
 
         parsed_results = []
@@ -648,8 +677,9 @@ class SshPerformanceCollectionTask(BaseTask):
             self._connector.connection.timed_out = True
         log.warn(
             "Command timed out.  Connection flagged for closure  "
-            "device=%s datasources=%s",
+            "device=%s interval=%s datasources=%s",
             self._devId,
+            self.interval,
             ",".join(ds.name for ds in datasources),
         )
         return self._timeout_error_result
@@ -668,8 +698,13 @@ class SshPerformanceCollectionTask(BaseTask):
 
     def _handle_failure_error(self, datasources, failure):
         log.error(
-            "Command failed  device=%s datasource=%s error=%s reason=%s",
-            self._devId, datasources[0].name, failure.type, failure.value,
+            "Command failed  "
+            "device=%s interval=%s datasource=%s error=%s reason=%s",
+            self._devId,
+            self.interval,
+            datasources[0].name,
+            failure.type,
+            failure.value,
         )
         return partial(self._failure_error_result, failure)
 
@@ -691,8 +726,9 @@ class SshPerformanceCollectionTask(BaseTask):
     def _handle_unexpected_error(self, datasources, response):
         log.error(
             "Command failed with unexpected result  "
-            "device=%s datasources=%s result=%s",
+            "device=%s interval=%s datasources=%s result=%s",
             self._devId,
+            self.interval,
             ",".join(ds.name for ds in datasources),
             response,
         )
@@ -712,8 +748,10 @@ class SshPerformanceCollectionTask(BaseTask):
     def _parse_result(self, datasources, response):
         ds = datasources[0]
         log.debug(
-            "Command succeeded  device=%s datasource=%s elapsed-seconds=%.2f",
+            "Command succeeded  "
+            "device=%s interval=%s datasource=%s elapsed-seconds=%.2f",
             self._devId,
+            self.interval,
             ",".join(ds.name for ds in datasources),
             ds.lastStop - ds.lastStart,
         )
@@ -837,7 +875,10 @@ class SshPerformanceCollectionTask(BaseTask):
         @type resultList: array of tuples which have the following layout:
            (Cmd object, ParsedResults object)
         """
-        log.debug("Store parsed data  device=%s", self._devId)
+        log.debug(
+            "Store parsed data  device=%s interval=%s",
+            self._devId, self.interval,
+        )
         self.state = SshPerformanceCollectionTask.STATE_STORE_PERF
 
         try:
@@ -845,9 +886,19 @@ class SshPerformanceCollectionTask(BaseTask):
             #   'datasource' is a Cmd object.
             #   'results' is a ParsedResults object.
             for datasource, results in resultList:
-                log.debug("Store values  datasource=%s", datasource.name)
+                log.debug(
+                    "Store values  device=%s interval=%s datasource=%s",
+                    self._devId, self.interval, datasource.name,
+                )
                 for dp, value in results.values:
-                    log.debug("Store datapoint  datapoint=%s", dp.dpName)
+                    log.debug(
+                        "Store datapoint  "
+                        "device=%s interval=%s datasource=%s datapoint=%s",
+                        self._devId,
+                        self.interval,
+                        datasource.name,
+                        dp.dpName,
+                    )
                     threshData = {
                         "eventKey": datasource.getEventKey(dp),
                         "component": dp.component,
@@ -873,7 +924,12 @@ class SshPerformanceCollectionTask(BaseTask):
                     except Exception as e:
                         log.exception(
                             "Failed to write to metric service  "
+                            "device=%s interval=%s datasource=%s datapoint=%s "
                             "metadata=%s type=%s message=%s",
+                            self._devId,
+                            self.interval,
+                            datasource.name,
+                            dp.dpName,
                             dp.metadata, e.__class__.__name__, e,
                         )
 

--- a/Products/ZenUtils/Executor.py
+++ b/Products/ZenUtils/Executor.py
@@ -133,7 +133,7 @@ class AsyncExecutor(object):
     def queued(self):
         return len(self._queue.pending)
 
-    def submit(self, call, timeout=None, label=None):
+    def submit(self, call, timeout=None, label=""):
         """Submit a callable to run asynchronously.
 
         @param call: A callable to be executed
@@ -266,12 +266,12 @@ class ExecutorTask(object):
     @ivar call: The callable called when the task is invoked.
     """
 
-    def __init__(self, deferred, call, timeout, log, label=None):
+    def __init__(self, deferred, call, timeout, log, label=""):
         self.id = "%x" % uuid.uuid4().time
         self.deferred = deferred
         self.timeout = timeout
         self.call = call
-        self.label = label if label is not None else ""
+        self.label = label
         self._log = log
         self._ontimeout = None
 

--- a/Products/ZenUtils/Executor.py
+++ b/Products/ZenUtils/Executor.py
@@ -10,7 +10,9 @@
 import logging
 import uuid
 
-from twisted.internet import defer, reactor
+from functools import partial
+
+from twisted.internet import defer, error, reactor
 from twisted.internet.task import LoopingCall
 
 log = logging.getLogger("zen.executor")
@@ -131,7 +133,7 @@ class AsyncExecutor(object):
     def queued(self):
         return len(self._queue.pending)
 
-    def submit(self, call, timeout=None):
+    def submit(self, call, timeout=None, label=None):
         """Submit a callable to run asynchronously.
 
         @param call: A callable to be executed
@@ -142,9 +144,10 @@ class AsyncExecutor(object):
             exception, the Deferred returns the exception.
         """
         d = defer.Deferred()
-        task = ExecutorTask(d, call, timeout, self._log)
+        task = ExecutorTask(d, call, timeout, self._log, label)
         self._log.debug(
-            "Received task  executor=%s task-id=%s", self._id, task.id,
+            "Received task  executor=%s task-id=%s label=%s",
+            self._id, task.id, task.label,
         )
         self._queue.put(task)
         return d
@@ -169,8 +172,8 @@ class AsyncExecutor(object):
 
             # Schedule the task to run at the next available moment.
             self._log.debug(
-                "Scheduled task to run  executor=%s task-id=%s",
-                self._id, task.id,
+                "Scheduled task to run  executor=%s task-id=%s label=%s",
+                self._id, task.id, task.label,
             )
             self._reactor.callLater(0, self.execute, task)
         except Exception:
@@ -181,7 +184,8 @@ class AsyncExecutor(object):
     @defer.inlineCallbacks
     def execute(self, task):
         self._log.debug(
-            "Running task  executor=%s task-id=%s", self._id, task.id,
+            "Running task  executor=%s task-id=%s label=%s",
+            self._id, task.id, task.label,
         )
         try:
             # Wait for the task to complete.
@@ -189,8 +193,25 @@ class AsyncExecutor(object):
             task.finished(result)
         except _ShutdownException:
             self._log.debug("Executor has stopped  executor=%s", self._id)
+        except (error.TimeoutError, defer.TimeoutError) as ex:
+            self._log.error(
+                "Task timed out  executor={} task-id={} label={}",
+                self._id, task.id, task.label,
+            )
+            task.error(ex)
+        except defer.CancelledError as ex:
+            self._log.debug(
+                "Task cancelled (probably due to a connection timeout)  "
+                "executor={} task-id={} label={}",
+                self._id, task.id, task.label,
+            )
+            task.error(ex)
         except Exception as ex:
-            message = "Bad task  executor={} task-id={}".format(self._id, task.id)
+            message = (
+                "Bad task  executor={} task-id={} label={}".format(
+                    self._id, task.id, task.label,
+                )
+            )
             if self._log.isEnabledFor(logging.DEBUG):
                 self._log.exception(message)
             else:
@@ -201,8 +222,8 @@ class AsyncExecutor(object):
             self._tasks_running -= 1
             self._tokens.release()
             self._log.debug(
-                "Finished running task  executor=%s task-id=%s",
-                self._id, task.id,
+                "Finished running task  executor=%s task-id=%s label=%s",
+                self._id, task.id, task.label,
             )
 
 
@@ -245,11 +266,12 @@ class ExecutorTask(object):
     @ivar call: The callable called when the task is invoked.
     """
 
-    def __init__(self, deferred, call, timeout, log):
+    def __init__(self, deferred, call, timeout, log, label=None):
         self.id = "%x" % uuid.uuid4().time
         self.deferred = deferred
         self.timeout = timeout
         self.call = call
+        self.label = label if label is not None else ""
         self._log = log
         self._ontimeout = None
 
@@ -257,26 +279,34 @@ class ExecutorTask(object):
         d = defer.maybeDeferred(self.call)
         if self.timeout:
             self._log.debug(
-                "Setting timeout  task-id=%s duration=%s",
-                self.id, self.timeout,
+                "Setting timeout  task-id=%s label=%s duration=%s",
+                self.id, self.label, self.timeout,
             )
             self._ontimeout = defer.Deferred()
-            self._ontimeout.addTimeout(self.timeout, reactor, self._timeout)
+            timeout_handler = partial(self._timeout, d)
+            self._ontimeout.addTimeout(self.timeout, reactor, timeout_handler)
             # Add a do-nothing errback handler for when the deferred is
             # cancelled before time has elapsed.
             self._ontimeout.addErrback(lambda x: None)
         else:
-            self._log.debug("No timeout set  task-id=%s", self.id)
+            self._log.debug(
+                "No timeout set  task-id=%s label=%s", self.id, self.label,
+            )
         return d
 
     def finished(self, result):
         if self._ontimeout:
             self._ontimeout.cancel()
         if not self.deferred.called:
+            self._log.debug(
+                "Setting callback  task-id=%s label=%s result=%r",
+                self.id, self.label, result,
+            )
             self.deferred.callback(result)
         else:
             self._log.debug(
-                "Result ignored  task-id=%s reason=timeout", self.id,
+                "Result ignored  task-id=%s label=%s reason=timeout",
+                self.id, self.label,
             )
 
     def error(self, ex):
@@ -288,18 +318,24 @@ class ExecutorTask(object):
             self.deferred.errback(ex)
         else:
             self._log.debug(
-                "Failure ignored  task-id=%s reason=timeout", self.id,
+                "Failure ignored  task-id=%s label=%s reason=timeout",
+                self.id, self.label,
             )
 
-    def _timeout(self, failure, timeout):
-        self._log.debug("Task timed out  task-id=%s", self.id)
-        self.deferred.errback(defer.TimeoutError("timeout"))
+    def _timeout(self, calld, failure, timeout):
+        # calld is the deferred returned by __call__.
+        self._log.debug(
+            "Task timed out  task-id=%s label=%s", self.id, self.label,
+        )
+        error = defer.TimeoutError("timeout")
+        calld.errback(error)
+        self.deferred.errback(error)
         self._ontimeout = None
 
     def __repr__(self):
         return (
-            "<{0.__module__}.{0.__name__} id={1}>"
-        ).format(type(self), self.id)
+            "<{0.__module__}.{0.__name__} id={1} label={2}>"
+        ).format(type(self), self.id, self.label)
 
 
 class _ShutdownException(Exception):


### PR DESCRIPTION
No new timeouts were added.  Instead, existing timeouts were handled differently to ensure that tasks will exit when a timeout occurrs.

Fixes ZEN-33565.