### PR TITLE
ZING-16621: Update product help link

### DIFF
--- a/Products/ZenModel/DataRoot.py
+++ b/Products/ZenModel/DataRoot.py
@@ -785,7 +785,7 @@ class DataRoot(ZenModelRM, OrderedFolder, Commandable, ZenMenuable):
         """
         Return a URL to docs for the Zenoss product that is installed.
         """
-        return "https://help.zenoss.com/docs/collection-zone"
+        return "https://docs.zenoss.io/"
 
     def getDocFilesInfo(self):
         docDir = os.path.join(zenPath("Products"), 'ZenUI3', 'docs')


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZING-16621

This should change the link on the infrastructure page to connect to the new docs page.
The docs will not be ready until end of October 2021, so this should not be merged until they are ready.