### PR TITLE
Adding user/group/role methods to the Zuul user router

### DIFF
--- a/Products/Zuul/facades/tests/test_userfacade.py
+++ b/Products/Zuul/facades/tests/test_userfacade.py
@@ -1,0 +1,96 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+import unittest
+from zope.interface.verify import verifyClass
+from Products.ZenModel.IpService import IpService
+from Products import Zuul
+from Products.Zuul.tests.base import ZuulFacadeTestCase
+from Products.ZenModel.Service import Service
+from Products.Zuul.interfaces import IComponent
+from Products.PluggableAuthService import plugins
+
+class UserFacadeTest(ZuulFacadeTestCase):
+
+    def afterSetUp(self):
+        super(UserFacadeTest, self).afterSetUp()
+        self.facade = Zuul.getFacade('user', self.dmd)
+
+        # verify that groupManager is enabled
+        acl = self.facade._root.acl_users
+        if not hasattr(acl, 'groupManager'):
+            plugins.ZODBGroupManager.addZODBGroupManager(acl, 'groupManager')
+        acl.groupManager.manage_activateInterfaces(['IGroupsPlugin', ])
+
+    def test_interfaces(self):
+        verifyClass(IComponent, Service)
+
+    def test_addUsers(self):
+        u1 = self.facade.addUser("heman",  "MotU",  "heman@master.universe", ("ZenUser", "ZenManager", "Manager"))
+        u2 = self.facade.addUser("shera",  "MotU",  "shera@master.universe", ("ZenUser",))
+        u3 = self.facade.addUser("duncan", "MotU", "duncan@master.universe", ("ZenUser",))
+        self.assertEqual(u1.id, 'heman')
+        self.assertEqual(u2.id, 'shera')
+        self.assertEqual(u3.id, 'duncan')
+        users = self.facade._root.getAllUserSettingsNames()
+        self.assertTrue('heman' in users)
+        self.assertTrue('orco' not in users)
+
+    def test_deleteUsers(self):
+        if 'duncan' not in self.facade._root.getAllUserSettingsNames():
+            # User needs to be in users list before removal
+            u = self.facade.addUser("duncan", "MotU", "duncan@master.universe", ("ZenUser",))
+            self.assertTrue('duncan' in self.facade._root.getAllUserSettingsNames())
+
+        self.facade.removeUsers("duncan")
+        self.assertTrue('duncan' not in self.facade._root.getAllUserSettingsNames())
+
+    def test_createGroups(self):
+        g1 = self.facade.createGroup("Universe Masters")
+        g2 = self.facade.createGroup("Man at Arms")
+        groups = self.facade._root.getAllGroupSettingsNames()
+        self.assertTrue(g1.id in groups)
+        self.assertTrue(g2.id in groups)
+
+    def test_deleteGroups(self):
+        groupName = "Man at Arms"
+        if groupName not in self.facade._root.getAllGroupSettingsNames():
+            # need to add the groups list before removal
+            g = self.facade.createGroup(groupName)
+            self.assertTrue(groupName, self.facade._root.getAllGroupSettingsNames())
+
+        self.facade.removeGroups(groupName)
+        self.assertTrue(groupName not in self.facade._root.getAllGroupSettingsNames())
+
+    def test_assignAdminRoles(self):
+        userName = 'shera'
+        if userName not in self.facade._root.getAllUserSettingsNames():
+            # User needs to be in users list before removal
+            u = self.facade.addUser(userName, "MotU", "shera@master.universe", ("ZenUser",))
+            self.assertTrue(userName in self.facade._root.getAllUserSettingsNames())
+
+        # test assignment of admin
+        roles = self.facade._root.getUser(userName).getRoles()
+        self.assertTrue("Manager" not in roles)
+        self.facade.assignAdminRolesToUsers(userName)
+        roles = self.facade._root.getUser(userName).getRoles()
+        self.assertTrue("Manager" in roles)
+
+        # test removal of admin
+        self.facade.removeAdminRolesFromUsers(userName)
+        roles = self.facade._root.getUser(userName).getRoles()
+        self.assertTrue("Manager" not in roles)
+
+def test_suite():
+    return unittest.TestSuite((unittest.makeSuite(UserFacadeTest),))
+
+
+if __name__=="__main__":
+    unittest.main(defaultTest='test_suite')

--- a/Products/Zuul/facades/userfacade.py
+++ b/Products/Zuul/facades/userfacade.py
@@ -47,3 +47,36 @@ class UserFacade(ZuulFacade):
         user = self._root.getUserSettings(propertiedUser.getId())
         user.email = email
         return IInfo(user)
+
+    def getGroups(self, start=0, limit=50, sort='id', dir='ASC', name=None):
+        groups = map(IInfo, self._dmd.ZenUsers.getAllGroupSettings())
+        sortedGroups = sorted(groups, key=lambda u: getattr(u, sort))
+        if dir == "DESC":
+            sortedGroups.reverse()
+        total = len(sortedGroups)
+        return SearchResults(iter(sortedGroups[start:limit]), total, total, areBrains=False)
+
+    def createGroup(self, groupName):
+        self._root.manage_addGroup(groupName)
+        group = self._root.getGroupSettings(groupName)
+        return IInfo(group)
+
+    def removeGroups(self, groupIds):
+        ids = groupIds
+        if isinstance(ids, basestring):
+            groupIds = [ids]
+        return self._root.manage_deleteGroups(groupIds)
+
+    def addUsersToGroups(self, userIds, groupIds):
+        # can pass string or list of strings
+        return self._root.manage_addUsersToGroups(userIds, groupIds)
+
+    def removeUsersFromGroups(self, userIds, groupIds):
+        # can pass string or list of strings
+        return self._root.manage_removeUsersFromGroups(userIds, groupIds)
+
+    def assignAdminRolesToUsers(self, userIds):
+        return self._root.manage_assignAdminRolesToUsers(userIds)
+
+    def removeAdminRolesFromUsers(self, userIds):
+        return self._root.manage_removeAdminRolesFromUsers(userIds)

--- a/Products/Zuul/infos/group.py
+++ b/Products/Zuul/infos/group.py
@@ -1,0 +1,26 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from zope.interface import implements
+from Products.Zuul.interfaces import IInfo
+from Products.Zuul.infos import InfoBase, ProxyProperty
+
+class GroupInfo(InfoBase):
+    """
+    Takes a zep event and maps it to the format that the UI expects
+    """
+    implements(IInfo)
+
+    @property
+    def members(self):
+        pfnMembers = None
+        if getattr(self, "_obj"):
+            pfnMembers = getattr(self._obj, "getMemberUserIds", None)
+        if pfnMembers:
+            return pfnMembers()

--- a/Products/Zuul/routers/users.py
+++ b/Products/Zuul/routers/users.py
@@ -101,3 +101,105 @@ class UsersRouter(DirectRouter):
         newUser = facade.addUser(id, password, email, roles)
         audit('UI.Users.Add', id, email=email, roles=roles)
         return DirectResponse.succeed(data=Zuul.marshal(newUser))
+
+    def getGroups(self, keys=None, start=0, limit=50, page=0, sort='name', dir='ASC', name=None):
+        """
+        Retrieves a list of groups. This method supports pagination.
+        @type  start: integer
+        @param start: (optional) Offset to return the results from; used in
+                      pagination (default: 0)
+        @type  name: string
+        @param name: (optional) filter to be applied to groups returned (default: None)
+        @type  limit: integer
+        @param limit: (optional) Number of items to return; used in pagination
+                      (default: 50)
+        @type  sort: string
+        @param sort: (optional) Key on which to sort the return results (default:
+                     'name')
+        @type  dir: string
+        @param dir: (optional) Sort order; can be either 'ASC' or 'DESC'
+                    (default: 'ASC')
+        @rtype:   DirectResponse
+        @return:  B{Properties}:
+             - data: (list) Dictionaries of group properties
+             - totalCount: (integer) Number of devices returned
+        """
+        facade = self._getFacade()
+        groups = facade.getGroups(start=start, limit=limit, sort=sort, dir=dir, name=name)
+        total = groups.total
+        data = Zuul.marshal(groups, keys)
+        return DirectResponse.succeed(data=data, totalCount=total)
+        pass
+
+    def createGroup(self, groupName):
+        """
+        Adds a new group to the system.
+        @type  groupName: string
+        @param groupName: The unique name of the group
+        @rtype:   DirectResponse
+        @return:  B{Properties}:
+             - data: properties of the new users
+        """
+        facade = self._getFacade()
+        newGroup = facade.createGroup(groupName)
+        audit('UI.Users.CreateGroup', groupName)
+        return DirectResponse.succeed(data=Zuul.marshal(newGroup))
+
+    def deleteGroups(self, groupIds):
+        """
+        Removes all the users from the given group then deletes the group.
+        @type  groupId: List of Strings
+        @param groupId: (optional) group ids to remove.
+        """
+        facade = self._getFacade()
+        facade.removeGroups(groupIds)
+        audit('UI.Users.RemoveGroups', groupIds=groupIds)
+        return DirectResponse.succeed()
+
+    def addUsersToGroup(self, userIds, groupIds):
+        """
+        Adds listed users to the given group.
+        @type  userIds: List of Strings
+        @param userIds: (optional) user ids to add to groups.
+        @type  groupIds: List of Strings
+        @param groupIds: (optional) group ids users will be added to.
+        """
+        facade = self._getFacade()
+        facade.addUsersToGroups(userIds, groupIds)
+        audit('UI.Users.AddUsersToGroups', userIds=userIds, groupIds=groupIds)
+        return DirectResponse.succeed()
+
+    def removeUsersFromGroup(self, userIds, groupIds):
+        """
+        Removes listed users from the given group.
+        @type  userIds: List of Strings
+        @param userIds: (optional) user ids to add to groups.
+        @type  groupIds: List of Strings
+        @param groupIds: (optional) group ids users will be removed from.
+        """
+        facade = self._getFacade()
+        facade.removeUsersFromGroups(userIds, groupIds)
+        audit('UI.Users.RemoveUsersFromGroups', userIds=userIds, groupIds=groupIds)
+        return DirectResponse.succeed()
+
+    def assignAdminRolesToUsers(self, userIds):
+        """
+        Assign the listed roles to the given users.
+        @type  userIds: List of Strings
+        @param userIds: (optional) user ids to assign admin roles to.
+        """
+        facade = self._getFacade()
+        facade.assignAdminRolesToUsers(userIds, roles)
+        audit('UI.Users.AssignAdminRolesToUsers', userIds=userIds, roles=roles)
+        return DirectResponse.succeed()
+
+    def removeAdminRolesFromUsers(self, userIds):
+        """
+        Removes the listed roles from the given users.
+        @type  userIds: List of Strings
+        @param userIds: (optional) user ids to remove admin roles from.
+        """
+        facade = self._getFacade()
+        facade.removeAdminRolesFromUsers(userIds, roles)
+        audit('UI.Users.RemoveAdminRolesFromUsers', userIds=userIds, roles=roles)
+        return DirectResponse.succeed()


### PR DESCRIPTION
This adds management methods to edit user, group, and role methods to the Zuul user_router
Includes unit test
https://jira.zenoss.com/browse/ZING-15272