### PR TITLE
Add support for multiple instances of collector daemons, using a rendezvous hashing algorithm

### DIFF
--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -805,7 +805,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
         """
         def errback(error):
             if isinstance(error, Failure):
-                self.log.critical( "Invalid monitor: %s" % self.options.monitor)
+                self.log.critical( "Invalid monitor: %s : %s" % (self.options.monitor, error))
                 reactor.stop()
                 return defer.fail(RemoteBadMonitor(
                            "Invalid monitor: %s" % self.options.monitor, ''))

--- a/Products/ZenPackAdapter/configdispatch.py
+++ b/Products/ZenPackAdapter/configdispatch.py
@@ -1,0 +1,145 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+import logging
+from collections import defaultdict
+from functools import partial
+import mmh3
+import math
+
+import zope.component
+from zope.interface import implements
+
+from Products.ZenCollector.interfaces import (
+    IConfigurationDispatchingFilter,
+    ICollectorPreferences
+)
+
+LOG = logging.getLogger("zen.configdispatch")
+
+_WPOOL = None
+def getWorkerDispatchPool():
+    global _WPOOL
+
+    if _WPOOL is None:
+        _WPOOL = WorkerPool()
+    return _WPOOL
+
+def type_and_id(options):
+    collectorType = options.get('zpaCollectorType', 'None')
+    collectorId = options.get('zpaCollectorId', 1)
+
+    return collectorType, collectorId
+
+def int_to_float(value):
+    fifty_three_ones = (0xFFFFFFFFFFFFFFFF >> (64-53))
+    fifty_three_zeros = float(1 << 53)
+    return (value & fifty_three_ones) / fifty_three_zeros
+
+class WRHBucket(object):
+    bucketId = None
+    weight = None
+
+    def __init__(self, bucketId, weight):
+        self.bucketId, self.weight = bucketId, weight
+
+    def compute_weighted_score(self, key):
+        hash1, hash2 = mmh3.hash64(str(self.bucketId + "/" + key))
+        score = 1.0 / -math.log(int_to_float(hash2))
+        return self.weight * score
+
+class WRH(object):
+    buckets = None
+
+    def __init__(self, buckets=None):
+        if buckets is None:
+            buckets = []
+
+        self.buckets = {}
+
+        for bucket in buckets:
+            self.buckets[bucket.bucketId] = bucket
+
+    def add_bucket(self, bucketId, weight=1.0):
+        self.buckets[bucketId] = WRHBucket(bucketId, weight)
+
+    def remove_bucket(self, bucketId):
+        if bucketId in self.buckets:
+            del self.buckets[bucketId]
+
+    def determine_responsible_bucket(self, key):
+        champion, highest_score = None, -1
+        for bucket in self.buckets.values():
+            score = bucket.compute_weighted_score(key)
+            if score > highest_score:
+                champion, highest_score = bucket, score
+
+        return champion
+
+
+class WorkerPool(object):
+    workers = None
+
+    def __init__(self):
+        self.workers = defaultdict(WRH)
+
+    def add_worker(self, options):
+        collectorType, collectorId = type_and_id(options)
+        self.workers[collectorType].add_bucket(collectorId)
+        LOG.info("Added new %s worker: %s", collectorType, collectorId)
+
+    def remove_worker(self, options):
+        collectorType, collectorId = type_and_id(options)
+        self.workers[collectorType].remove_bucket(collectorId)
+        LOG.info("Removed %s worker: %s", collectorType, collectorId)
+
+    def get_workers(self, collectorType):
+        return [x for x in self.workers[collectorType].buckets]
+
+    def collectorId_for_deviceId(self, deviceId, options):
+        collectorType, _ = type_and_id(options)
+
+        wrh = self.workers[collectorType]
+        bucket = wrh.determine_responsible_bucket(deviceId)
+
+        return bucket.bucketId
+
+
+
+# IMPORTANT NOTE: One of the concepts behind the rendezvous hash
+# is that it can produce the same results across multiple
+# instances, as long as they have the same members.
+#
+# There is one instance of the IConfigurationDispatchingFilter utility used
+# used for config dispatching in zminihub (one per
+# service, technically), but there can also be one in each collector daemon.
+#
+# I had intended to do this by using a setPropertyItems remote
+# call to push the list of pool members down whenever it changes.
+#
+# I decided that this wasn't necessary, though, because that
+# collector-daemon side filtering wasn't really required.  As
+# long as zminihub is pushing the right configs to the right
+# daemons, they don't really need to double-check it.  So the collector
+# daemons do not have dispatch filtering turned on.
+
+class RendezvousHashDispatchingFilter(object):
+    implements(IConfigurationDispatchingFilter)
+
+    def getFilter(self, options):
+        collectorType, collectorId = type_and_id(options)
+        pool = getWorkerDispatchPool()
+
+        def _filter(collectorType, collectorId, device):
+            deviceId = getattr(device, 'id', '')
+            return collectorId == pool.collectorId_for_deviceId(deviceId, options)
+
+        return partial(_filter, collectorType, collectorId)
+

--- a/Products/ZenPackAdapter/configure.zcml
+++ b/Products/ZenPackAdapter/configure.zcml
@@ -1,0 +1,5 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:zcml="http://namespaces.zope.org/zcml">
+
+</configure>
+

--- a/Products/ZenPackAdapter/db.py
+++ b/Products/ZenPackAdapter/db.py
@@ -11,6 +11,7 @@
 # In-memory database holding all devices, device classes, and monitoring
 # templates.
 
+from contextlib import contextmanager
 import datetime
 import logging
 import os
@@ -53,6 +54,17 @@ def get_db():
     if _DB is None:
         _DB = DB()
     return _DB
+
+@contextmanager
+def snapshot_to_file(filename):
+    if '/' in filename:
+        raise ValueError("Invalid snapshot_file filename: %s" % filename)
+
+    file = open("%s/%s" % (SNAPSHOT_DIR, filename), 'w')
+    try:
+        yield file
+    finally:
+        file.close()
 
 
 class DB(object):

--- a/Products/ZenPackAdapter/monkey.py
+++ b/Products/ZenPackAdapter/monkey.py
@@ -13,6 +13,8 @@
 #
 # This file is loaded by Products.ZenUtils (__init__.py)
 
+import socket
+import sys
 import time
 import os.path
 import logging
@@ -66,6 +68,17 @@ def buildOptions(self):
                        default=None,
                        help='Source tag data sent to Zenoss Cloud')
 
+    self.parser.add_option('--collector-type',
+                       dest='zpaCollectorType',
+                       type='string',
+                       default=os.path.basename(sys.argv[0]),
+                       help='Type of collector process (process name, generally)')
+
+    self.parser.add_option('--collector-instance-id',
+                       dest='zpaCollectorId',
+                       type='string',
+                       default=socket.gethostname(),
+                       help='Unique Identifier for this collector process/container')
 @monkeypatch(CmdBase)
 def parseOptions(self):
     from Products.ZenPackAdapter.yamlconfig import load_config_yaml, CONFIG_YAML

--- a/Products/ZenPackAdapter/overrides.zcml
+++ b/Products/ZenPackAdapter/overrides.zcml
@@ -16,4 +16,9 @@
         factory=".guid.GUIDManager"
         />
 
+    <utility factory=".configdispatch.RendezvousHashDispatchingFilter"
+             provides="Products.ZenCollector.interfaces.IConfigurationDispatchingFilter"
+             name="rendezvous"
+             />
+
 </configure>

--- a/Products/ZenPackAdapter/tests/test_configdispatch.py
+++ b/Products/ZenPackAdapter/tests/test_configdispatch.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2021, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import time
+import Globals
+from collections import Counter
+
+from Products.ZenUtils.Utils import unused
+from Testing import ZopeTestCase
+
+from Products.ZenPackAdapter.configdispatch import WorkerPool
+
+unused(Globals)
+
+
+def makeoptions(type_, id_):
+    return {
+        "zpaCollectorType": type_,
+        "zpaCollectorId": id_
+    }
+
+zenpython = makeoptions("zenpython", None)
+
+# just 50 random words to use as device IDs in tests
+wordlist = [
+    "soothe", "astonishing", "religion", "swift", "scissors", "parsimonious",
+    "robust", "visitor", "humdrum", "boil", "grouchy", "lumber", "stare",
+    "nasty", "malicious", "puncture", "change", "disturbed", "hobbies",
+    "educate", "imagine", "able", "sail", "long-term", "familiar", "annoy",
+    "assorted", "arch", "screeching", "stale", "selection", "energetic",
+    "self", "crabby", "past", "invite", "wander", "legal", "cherries",
+    "doubt", "literate", "stimulating", "smell", "short", "next", "salty",
+    "magnificent", "flower", "billowy", "plucky"
+]
+
+class TestConfigDispatch(ZopeTestCase.ZopeTestCase):
+
+    def setUp(self):
+        self.pool = WorkerPool()
+
+    def test_add_workers(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12346"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12347"))
+        self.pool.add_worker(makeoptions("zenmodeler", "c12348"))
+
+        self.assertEqual(len(self.pool.get_workers("zenpython")), 3)
+        self.assertEqual(len(self.pool.get_workers("zenmodeler")), 1)
+
+        #  duplicate, so should not add anything
+        self.pool.add_worker(makeoptions("zenmodeler", "c12348"))
+        self.assertEqual(len(self.pool.get_workers("zenpython")), 3)
+
+    def test_remove_workers(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+        self.assertEqual(len(self.pool.get_workers("zenpython")), 1)
+        self.pool.remove_worker(makeoptions("zenpython",  "c12345"))
+        self.assertEqual(len(self.pool.get_workers("zenpython")), 0)
+        self.pool.remove_worker(makeoptions("zenpython",  "c12345"))
+        self.assertEqual(len(self.pool.get_workers("zenpython")), 0)
+
+    def test_device_singlecollector(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+        collectorA = self.pool.collectorId_for_deviceId("deviceA", zenpython)
+        self.assertEqual(collectorA, "c12345")
+
+    def test_device_multicollector(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12341"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12342"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12343"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12344"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+        count = Counter()
+        collectorA = self.pool.collectorId_for_deviceId("deviceA", zenpython)
+        self.assertIsNotNone(collectorA)
+        count[collectorA] += 1
+        collectorB = self.pool.collectorId_for_deviceId("deviceB", zenpython)
+        self.assertIsNotNone(collectorB)
+        count[collectorB] += 1
+        collectorC = self.pool.collectorId_for_deviceId("deviceC", zenpython)
+        self.assertIsNotNone(collectorC)
+        count[collectorC] += 1
+        collectorD = self.pool.collectorId_for_deviceId("deviceD", zenpython)
+        self.assertIsNotNone(collectorD)
+        count[collectorD] += 1
+
+        # devices were assigned to more than one collector.  If they
+        # all got put on one, either we're hashing really poorly, or
+        # there is a bug.
+        self.assertTrue(len(count) > 1)
+
+
+    def test_scaleup(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12341"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12342"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12343"))
+
+        collectors = {}
+        for d in wordlist:
+            collectors[d] = self.pool.collectorId_for_deviceId(d, zenpython)
+
+        self.pool.add_worker(makeoptions("zenpython",  "c12344"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+        collectors2 = {}
+        moves = 0
+        for d in wordlist:
+            collectors2[d] = self.pool.collectorId_for_deviceId(d, zenpython)
+            if collectors2[d] != collectors[d]:
+                moves += 1
+
+        # Some rebalancing is fine, but it shouldn't be excessive.
+        self.assertTrue(moves < len(wordlist) / (2.0/5.0))
+
+    def test_scaledown(self):
+        self.pool.add_worker(makeoptions("zenpython",  "c12341"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12342"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12343"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12344"))
+        self.pool.add_worker(makeoptions("zenpython",  "c12345"))
+
+        collectors = {}
+        for d in wordlist:
+            collectors[d] = self.pool.collectorId_for_deviceId(d, zenpython)
+
+        self.pool.remove_worker(makeoptions("zenpython",  "c12344"))
+        self.pool.remove_worker(makeoptions("zenpython",  "c12345"))
+
+        collectors2 = {}
+        for d in wordlist:
+            collectors2[d] = self.pool.collectorId_for_deviceId(d, zenpython)
+            if collectors2[d] != collectors[d]:
+                # Only devices previously on the collectors we removed
+                # should be remapped to another.
+                self.assertIn(collectors[d], ["c12344", "c12345"])
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestConfigDispatch))
+    return suite
+
+
+if __name__ == "__main__":
+    from zope.testrunner.runner import Runner
+    runner = Runner(found_suites=[test_suite()])
+    runner.run()
+
+

--- a/Products/ZenPackAdapter/zobject.py
+++ b/Products/ZenPackAdapter/zobject.py
@@ -615,6 +615,12 @@ class ZDeviceOrComponent(ZObject):
 
         return False
 
+    def getLastChange(self):
+        return DateTime(float(self._device._lastChange))
+
+    def getLastChangeString(self):
+        return Time.LocalDateTimeSecsResolution(float(self._device._lastChange))
+
 
 class ZDevice(ZDeviceOrComponent):
     def device(self):
@@ -645,11 +651,6 @@ class ZDevice(ZDeviceOrComponent):
                 result.append(template)
         return result
 
-    def getLastChange(self):
-        return DateTime(float(self._device._lastChange))
-
-    def getLastChangeString(self):
-        return Time.LocalDateTimeSecsResolution(float(self._device._lastChange))
 
 class ZDeviceComponent(ZDeviceOrComponent):
     def device(self):


### PR DESCRIPTION
The traditional hashing we did in RM was based on a sequential instance number, which
wasn't really practical in the more dynamic scenario we had in mind with collectors being
scaled up and down in k8s.

Now the hashing is done based on container ID, and the rendezvous algorithm gives consistent
results as long as the same list of IDs is used.

This requires us to keep track of collector listener connections as they come and go,
and making sure that a consistent collector list is used by any process that needs
to perform the hash.

In addition we take extra care to push config changes whenever the responsible collector
changes for a given device, as will happen as they are added and removed.