### PR TITLE
Make no attempt to load empty parser names.

### DIFF
--- a/Products/DataCollector/Plugins.py
+++ b/Products/DataCollector/Plugins.py
@@ -38,7 +38,6 @@ Note that modPath uses a different convention for core versus zenpack plugins.
 from Products.ZenUtils.Utils import importClass, zenPath
 import sys
 import os
-import re
 import exceptions
 import imp
 from twisted.spread import pb
@@ -250,6 +249,8 @@ class PluginManager(object):
         packs - list of installed zenpacks (ZenPack instances)
         modPath - the module path of the plugin
         """
+        if not modPath:
+            return None
         if modPath not in self.pluginLoaders:
             self.getPluginLoaders(packs)
         if modPath in self.pluginLoaders:
@@ -264,9 +265,10 @@ class PluginManager(object):
         """
         try:
             for pack in packs:
-                if pack.moduleName() not in self.loadedZenpacks:
-                    self.loadedZenpacks.append(pack.moduleName())
-                    modPathPrefix = '.'.join((pack.moduleName(),) +
+                modname = pack.moduleName()
+                if modname not in self.loadedZenpacks:
+                    self.loadedZenpacks.append(modname)
+                    modPathPrefix = '.'.join((modname,) +
                             self.packPath + (self.lastModName,))
                     factory = PackLoaderFactory(OsWalker(), modPathPrefix)
                     package = pack.path(*self.packPath + (self.lastModName,))


### PR DESCRIPTION
Also cache a ZenPack's module name locally rather than repeatedly calling the method.

Fixes ZEN-33761.