### PR TITLE
Change update_config API in CyberArk integration

### DIFF
--- a/Products/DataCollector/zenmodeler.py
+++ b/Products/DataCollector/zenmodeler.py
@@ -897,7 +897,7 @@ class ZenModeler(PBDaemon):
                         self.log.info(d.skipModelMsg)
                     else:
                         if self.cyberark:
-                            yield self.cyberark.update_config(d)
+                            yield self.cyberark.update_config(d.id, d)
                             driver.next()
                             self.log.info('config updated')
                         self.collectDevice(d)

--- a/Products/ZenCollector/tests/test_cyberark.py
+++ b/Products/ZenCollector/tests/test_cyberark.py
@@ -135,7 +135,7 @@ class TestCyberArk(TestCase):
         vault = CyberArk(query, t.manager)
         conf = t.Conf(query)
 
-        vault.update_config(conf)
+        vault.update_config(conf.configId, conf)
 
         t.assertTrue(getattr(conf, _cyberark_flag, None))
         t.assertEqual(conf.zProp2, "")
@@ -158,7 +158,7 @@ class TestCyberArk(TestCase):
         result = """{"Content": "stuff"}"""
         t.client.request.return_value = (status, result)
 
-        vault.update_config(conf)
+        vault.update_config(conf.configId, conf)
 
         t.assertTrue(getattr(conf, _cyberark_flag, None))
         t.assertEqual(conf.zProp2, "stuff")
@@ -178,7 +178,7 @@ class TestCyberArk(TestCase):
         conf = t.Conf(query)
         conf.zProp2 = "value2"
 
-        vault.update_config(conf)
+        vault.update_config(conf.configId, conf)
 
         t.assertFalse(None)
         t.assertFalse(getattr(conf, _cyberark_flag, None))

--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -455,7 +455,8 @@ class SshPerformanceCollectionTask(BaseTask):
             old_pass = self._device.zCommandPassword
             old_name = self._device.zCommandUsername
             yield self._scheduler.cyberark.update_config(
-                self._device, self)
+                self._devId, self._device,
+            )
             if (old_pass != self._device.zCommandPassword or old_name != self._device.zCommandUsername):
                 self._connector.close()
                 self.__init__(self.name, self.configId, self.interval, self._device)

--- a/Products/ZenRRD/zenperfsnmp.py
+++ b/Products/ZenRRD/zenperfsnmp.py
@@ -560,7 +560,10 @@ class SnmpPerformanceCollectionTask(BaseTask):
         # See if we need to connect first before doing any collection
         if self._scheduler.cyberark:
             d = defer.maybeDeferred(
-                self._scheduler.cyberark.update_config, self._snmpConnInfo, self)
+                self._scheduler.cyberark.update_config,
+                self._devId,
+                self._snmpConnInfo,
+            )
             d.addCallback(self._connect)
         else:
             d = defer.maybeDeferred(self._connect)


### PR DESCRIPTION
Removes guesswork in identifying the device associated with the given device config.