### PR TITLE
Fix UI tracebacks messages for event transforms

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/Security.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Security.js
@@ -9,90 +9,92 @@
 
 
 /* package level */
-(function() {
-     // NOTE: All permissions are handled on the server, this is just to
-     // enhance the user experience
-     Ext.ns('Zenoss.Security');
+(function () {
+    // NOTE: All permissions are handled on the server, this is just to
+    // enhance the user experience
+    Ext.ns('Zenoss.Security');
 
-     // Defined in ZenUI3/security/security.py this is a dictionary of all the
-     // permissions the current user has on the current context.
-     var all_permissions = _global_permissions(),
-         callbacks = [];
+    // Defined in ZenUI3/security/security.py this is a dictionary of all the
+    // permissions the current user has on the current context.
+    var all_permissions = _global_permissions(),
+        callbacks = [];
 
-     /**
-      * The main method for ACL on the front end. It asks
-      * if the current user has this permission.
-      * The permissions are defined in Zope
-      *
-      * NOTE: The permissions are not case-sensitive here
-      * @returns True/False if the user has permission or not
-      **/
-     Zenoss.Security.hasPermission = function(permission) {
-         // uses all_permissions as a closure
-         return all_permissions[permission.toLowerCase()];
-     };
+    /**
+     * The main method for ACL on the front end. It asks
+     * if the current user has this permission.
+     * The permissions are defined in Zope
+     *
+     * NOTE: The permissions are not case-sensitive here
+     * @returns True/False if the user has permission or not
+     **/
+    Zenoss.Security.hasPermission = function (permission) {
+        // uses all_permissions as a closure
+        return all_permissions[permission.toLowerCase()];
+    };
 
-     /**
-      * Asks if the current user has this permission in the
-      * global context.
-      * @returns True/False if the user has the permission or not
-      **/
-     Zenoss.Security.hasGlobalPermission = function(permission) {
-         return _global_permissions()[permission.toLowerCase()];
-     };
+    /**
+     * Asks if the current user has this permission in the
+     * global context.
+     * @returns True/False if the user has the permission or not
+     **/
+    Zenoss.Security.hasGlobalPermission = function (permission) {
+        return _global_permissions()[permission.toLowerCase()];
+    };
 
-     /**
-      * Convenience method, it makes the Hide and Disable properties
-      * easier to read.
-      * For instance:
-      *      config {
-      *           hidden: Zenoss.Security.doesNotHavePermission('Manage DMD');
-      *      };
-      * @returns True if the user does NOT have permission
-      **/
-     Zenoss.Security.doesNotHavePermission = function(permission) {
-         return (!this.hasPermission(permission));
-     };
+    /**
+     * Convenience method, it makes the Hide and Disable properties
+     * easier to read.
+     * For instance:
+     *      config {
+     *           hidden: Zenoss.Security.doesNotHavePermission('Manage DMD');
+     *      };
+     * @returns True if the user does NOT have permission
+     **/
+    Zenoss.Security.doesNotHavePermission = function (permission) {
+        return (!this.hasPermission(permission));
+    };
 
-     /**
-      * Add an callback to be executed every time the permissions
-      * are changed, usually this is done by changing context.
-      * Example Usage:
-      *     Zenoss.Security.onPermissionChange(function() {
-      *         Ext.getCmp('foo').setDisabled(Zenoss.Security.doesNotHavePermission('Manage DMD'));
-      * });
-      *@param callback: function to execute
-      *@param scope[Optional]: scope of the callback
-      **/
-     Zenoss.Security.onPermissionsChange = function(callback, scope) {
-         if (scope) {
-             callbacks.push(Ext.bind(callback, scope));
-         }else {
-             callbacks.push(callback);
-         }
-     };
+    /**
+     * Add an callback to be executed every time the permissions
+     * are changed, usually this is done by changing context.
+     * Example Usage:
+     *     Zenoss.Security.onPermissionChange(function() {
+     *         Ext.getCmp('foo').setDisabled(Zenoss.Security.doesNotHavePermission('Manage DMD'));
+     * });
+     *@param callback: function to execute
+     *@param scope[Optional]: scope of the callback
+     **/
+    Zenoss.Security.onPermissionsChange = function (callback, scope) {
+        if (scope) {
+            callbacks.push(Ext.bind(callback, scope));
+        } else {
+            callbacks.push(callback);
+        }
+    };
 
-     /**
-      * If the context you are working on changes call this
-      * method to update the security permissions for that new context
-      **/
-     Zenoss.Security.setContext = function(uid) {
-         var params = {
-             uid:uid || 'zport/dmd/Events'
-         };
-         function callback(response) {
-             var i;
-             if (response.success) {
-                 all_permissions = response.data;
-                 if (callbacks) {
-                     for (i = 0; i < callbacks.length; i += 1) {
-                         callbacks[i]();
-                     }
-                 }
-             }
-         }
-         Zenoss.remote.DetailNavRouter.getSecurityPermissions(params, callback);
+    /**
+     * If the context you are working on changes call this
+     * method to update the security permissions for that new context
+     **/
+    Zenoss.Security.setContext = function (uid) {
+        var params = {
+            uid: uid
+        };
 
-     };
+        function callback(response) {
+            var i;
+            if (response.success) {
+                all_permissions = response.data;
+                if (callbacks) {
+                    for (i = 0; i < callbacks.length; i += 1) {
+                        callbacks[i]();
+                    }
+                }
+            }
+        }
+
+        Zenoss.remote.DetailNavRouter.getSecurityPermissions(params, callback);
+
+    };
 
 }());

--- a/Products/ZenUI3/browser/resources/js/zenoss/Security.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Security.js
@@ -1,10 +1,10 @@
 /*****************************************************************************
- * 
+ *
  * Copyright (C) Zenoss, Inc. 2010, all rights reserved.
- * 
+ *
  * This content is made available according to terms specified in
  * License.zenoss under the directory where your Zenoss product is installed.
- * 
+ *
  ****************************************************************************/
 
 
@@ -78,7 +78,7 @@
       **/
      Zenoss.Security.setContext = function(uid) {
          var params = {
-             uid:uid
+             uid:uid || 'zport/dmd/Events'
          };
          function callback(response) {
              var i;

--- a/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassConsole.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassConsole.js
@@ -155,7 +155,7 @@ Ext.onReady(function(){
                         Ext.getCmp('footer_bar').setContext(uid);
                         Zenoss.env.contextUid = uid;
                         // explicitly set the new security context (to update permissions)
-                        Zenoss.Security.setContext(uid);
+                        Zenoss.Security.setContext(uid || 'zport/dmd/Events');
                     }
                 }
             }
@@ -212,7 +212,7 @@ Ext.onReady(function(){
                         // set the context for the active item:
                         var contentPanel = classtree.getContentPanel();
                         contentPanel.setContext(Zenoss.env.contextUid);
-                        Zenoss.Security.setContext(Zenoss.env.contextUid);
+                        Zenoss.Security.setContext(Zenoss.env.contextUid || 'zport/dmd/Events');
                     }
                 },
                 store:  Ext.create('Ext.data.ArrayStore', {

--- a/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
@@ -403,7 +403,7 @@ Ext.onReady(function(){
                                         autoScroll: false,
                                         listeners: {
                                             beforerender: function(g){
-                                                g.setContext(data.uid);
+                                                g.setContext(data.uid || 'zport/dmd/Events');
                                             }
                                         }
                                     }
@@ -781,8 +781,7 @@ Ext.onReady(function(){
         },
         setContext: function(uid){
             var me = this;
-
-            Zenoss.remote.EventClassesRouter.getTransformTree({'uid':uid}, function(response){
+            Zenoss.remote.EventClassesRouter.getTransformTree({'uid':uid || 'zport/dmd/Events'}, function(response){
                 if(response.success){
                     var data = response.data;
                     me.removeAll(true);
@@ -826,7 +825,7 @@ Ext.onReady(function(){
                         listeners : {
                             beforerender: function(el) {
                                 if(Zenoss.Security.doesNotHavePermission('Manage DMD') === false) {
-                                    Zenoss.remote.EventClassesRouter.isTransformEnabled({'uid':uid}, function(response){
+                                    Zenoss.remote.EventClassesRouter.isTransformEnabled({'uid':uid || 'zport/dmd/Events'}, function(response){
                                         if(response.success){
                                             if(response.data === false){
                                                 el.setVisible(true);

--- a/Products/ZenUtils/extdirect/router.py
+++ b/Products/ZenUtils/extdirect/router.py
@@ -178,13 +178,6 @@ class DirectRouter(object):
         if isinstance(data, (int, basestring)):
             data = {'id': data}
 
-        # Set default value for event class for transform getting without chosen event class
-        if not data:
-            if action == 'EventClassesRouter' and (method == 'getTransformTree' or method == 'isTransformEnabled'):
-                data = {'uid': 'zport/dmd/Events'}
-            elif action == 'DetailNavRouter' and method == 'getSecurityPermissions':
-                data = {'uid': 'zport/dmd/Events'}
-
         # Cast all keys as strings, in case of encoding or other wrinkles
         data = dict((str(k), v) for k, v in data.iteritems())
         self._data = data


### PR DESCRIPTION
Fixes ZEN-32905.

To fix type errors related to getSecurityPermissions() and
getTransformTree() which were observable for the customer through the
UI, the default value for event class was set. After changes when the
customer opens Events -> Even Classes and chose Transforms in the
drop-down menu before selecting an event class, no errors will occur,
instead of them the transforms for Events will be shown.