### PR TITLE
Fix UI representation of graph point legend

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/form/graphPanel.js
@@ -42,7 +42,7 @@
         var first = true;
         var componentName = "";
         pts.forEach(function(pt){
-            var cname = pt.legend.substr(0,pt.legend.indexOf(" "));
+            var cname = pt.legend.substr(0,pt.legend.indexOf(""));
             allTheSame = allTheSame && ( componentName === cname || first );
             componentName = cname;
             first = false;


### PR DESCRIPTION
Fixes ZEN-33971.

Graph point legend was represented on the UI side with the cutting of
the first word if the legend is long. The issue appeared because of the
wrong legend rendering on the UI.