### PR TITLE
Process and log the UnicodeDecodeError

### DIFF
--- a/Products/DataCollector/ApplyDataMap/tests/test_datamaputils.py
+++ b/Products/DataCollector/ApplyDataMap/tests/test_datamaputils.py
@@ -91,7 +91,7 @@ class GetSetObject():
         return self.Attr
 
 
-class Test_check_the_locks(TestCase):
+class TestCheckTheLocks(TestCase):
 
     def setUp(t):
         t.datamap = Mock(name='datamap')
@@ -142,7 +142,7 @@ class Test_check_the_locks(TestCase):
         t.assertEqual(t.datamap._directive, 'delete_locked')
 
 
-class Test__locked_from_updates(TestCase):
+class TestLockedFromUpdates(TestCase):
 
     def test_locked(t):
         obj = Mock(spec=['isLockedFromUpdates'])
@@ -164,7 +164,7 @@ class Test__locked_from_updates(TestCase):
         t.assertEqual(ret, False)
 
 
-class Test__locked_from_deletion(TestCase):
+class TestLockedFromDeletion(TestCase):
 
     def test_locked(t):
         obj = Mock(spec=['isLockedFromDeletion'])
@@ -186,7 +186,7 @@ class Test__locked_from_deletion(TestCase):
         t.assertEqual(ret, False)
 
 
-class Test__evaluate_legacy_directive(TestCase):
+class TestEvaluateLegacyDirective(TestCase):
 
     def setUp(t):
         t.object_map = ObjectMap()
@@ -228,7 +228,7 @@ class Test__evaluate_legacy_directive(TestCase):
         t.assertEqual(t.object_map._directive, 'nochange')
 
 
-class Test_objectmap_to_device_diff(TestCase):
+class TestObjectMapToDeviceDiff(TestCase):
 
     def test_no_change(t):
         '''Unchanged objects return an empty dict
@@ -338,7 +338,7 @@ class Test_objectmap_to_device_diff(TestCase):
                 t.assertEqual(val, getattr(objectmap, key).decode(enc))
 
 
-class Test_attribute_diff(TestCase):
+class TestAttributeDiff(TestCase):
 
     def test_changed(t):
         obj = Mock(name='object')
@@ -379,7 +379,7 @@ class Test_attribute_diff(TestCase):
         t.assertEqual(ret, None)
 
 
-class Test_get_attr_value(TestCase):
+class TestGetAttrValue(TestCase):
 
     def test_set_methods(t):
         '''given an attribute that starts with 'set'
@@ -416,7 +416,7 @@ class Test_get_attr_value(TestCase):
         t.assertEqual(ret, MISSINGNO)
 
 
-class Test_sanitize_value(TestCase):
+class TestSanitizeValue(TestCase):
 
     def test_handles_strings(t):
         value = 'some_string'
@@ -427,10 +427,20 @@ class Test_sanitize_value(TestCase):
         original_str = 'some_string'
         value = b64encode(original_str)
         obj = Mock(zCollectorDecoding='base64')
-
         ret = _sanitize_value(value, obj)
-
         t.assertEqual(ret, original_str)
+
+    def test_decodes_strings_with_no_decoder(t):
+        original_str = 'some_string'
+        obj = Mock(zCollectorDecoding='')
+        ret = _sanitize_value(original_str, obj)
+        t.assertEqual(ret, original_str.encode('utf-8'))
+
+    def test_decodes_strings_with_non_unicode(t):
+        original_str = 'David Mu\xf1oz'
+        obj = Mock(zCollectorDecoding='utf-8')
+        ret = _sanitize_value(original_str, obj)
+        t.assertEqual(ret, 'David Muoz'.encode('utf-8'))
 
     def test_handles_MultiArgs(t):
         args = (sentinel.a, 'some_string', {'a': 1})
@@ -446,7 +456,7 @@ class Test_sanitize_value(TestCase):
             _sanitize_value(value, sentinel.obj)
 
 
-class Test_decode_value(TestCase):
+class TestDecodeValue(TestCase):
 
     def test_decodes_strings(t):
         original_str = 'some_string'
@@ -458,7 +468,7 @@ class Test_decode_value(TestCase):
         t.assertEqual(ret, original_str)
 
 
-class Test_update_object(TestCase):
+class TestUpdateObject(TestCase):
 
     def test_update(t):
         obj = Device('deviceid')
@@ -503,7 +513,7 @@ class Test_update_object(TestCase):
         t.assertTrue(ret)
 
 
-class Test_update_callable_attribute(TestCase):
+class TestUpdateCallableAttribute(TestCase):
 
     def test_uses_set_method_to_update(t):
         obj = Mock(name='object', spec_set=['setAttr'])


### PR DESCRIPTION
Fixes ZEN-33839.

To handle the issue with UnicodeDecodeError the decoding procedure was
modified by adding an additional check. The procedure tries to decode
values using zCollectorDecoding if it is defined, otherwise, it tries to
apply the default encoding (usually utf-8). If decoding of the value in
strict mode causes errors, then it will be done in ignore mode,
therefore non-Unicode symbols will be ignored and the corresponding
record will be added to the log.