### PR TITLE
Make notification and trigger forms more readable

### DIFF
--- a/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
+++ b/Products/ZenUI3/browser/resources/css/xtheme-zenoss.css
@@ -776,7 +776,9 @@ table.x-container:before, tbody.x-container:before, tr.x-container:before {
   display: block; }
 
 .x-item-disabled, .x-item-disabled * {
-  cursor: default; }
+  cursor: default;
+  background: none;
+}
 
 .x-cycle-fixed-width .x-btn-inner {
   text-align: inherit; }

--- a/Products/ZenUI3/browser/resources/js/zenoss/triggers.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/triggers.js
@@ -161,6 +161,9 @@ Ext.onReady(function () {
         tab.cascade(function() {
             if (Ext.isFunction(this.enable)) {
                 this.enable();
+                if (this.xtype === 'panel') {
+                    this.addCls('x-item-disabled');
+                }
             }
         });
         tab.setDisabled(false);


### PR DESCRIPTION
Fixes ZEN-33838.

The issue appeared because the "Everyone can view" style for triggers
and notification forms were the same as for other elements (etc.
windows). To fix the problem triggers and notification forms were
extended by adding the new CSS class, which implements a specific
"Everyone can view" style for forms.