### PR TITLE
Fix issues with ADM's 'add' directive.

### DIFF
--- a/Products/DataCollector/ApplyDataMap/applydatamap.py
+++ b/Products/DataCollector/ApplyDataMap/applydatamap.py
@@ -102,9 +102,9 @@ class ApplyDataMap(object):
 
         # apply the changes
         if commit:
-            result = transact(adm_method)(datamap, device)
+            transact(adm_method)(datamap, device)
         else:
-            result = adm_method(datamap, device)
+            adm_method(datamap, device)
 
         # report the changes made
         result = self._report_changes(datamap, device)

--- a/Products/DataCollector/ApplyDataMap/datamaputils.py
+++ b/Products/DataCollector/ApplyDataMap/datamaputils.py
@@ -78,12 +78,26 @@ def _locked_from_deletion(obj):
 def _evaluate_legacy_directive(datamap):
     """Translate legacy directives"""
     for attr, directive in directive_map.items():
-        if hasattr(datamap, attr):
-            if getattr(datamap, attr):
-                datamap._directive = directive
-            else:
-                datamap._directive = "nochange"
-            delattr(datamap, attr)
+        flag = getattr(datamap, attr, None)
+        if flag is None:
+            continue
+
+        # .-----------------------------------------------.
+        # |  _add  | Device Exists | Device Doesn't Exist |
+        # |--------+---------------+----------------------|
+        # | True   | Update device | Add device           |
+        # | False  | Update device | Ignore datamap       |
+        # `-----------------------------------------------'
+        # Note: if there are no differences between the device
+        # and the datamap, then applyDataMap should return False
+        # to indicate no changes.
+
+        if directive == "add" and flag is False:
+            datamap._directive = "update"
+        else:
+            datamap._directive = directive if flag else "nochange"
+
+        delattr(datamap, attr)
 
     return datamap
 
@@ -203,15 +217,46 @@ def _update_object(obj, diff):
     """
     log.debug("_update_object: obj=%s, diff=%s", obj, diff)
 
+    if not diff:
+        return False
+
+    changed = False
+
     for attrname, value in diff.items():
         attr = getattr(obj, attrname, MISSINGNO)
         if attr is MISSINGNO:
             continue
         elif callable(attr):
-            _update_callable_attribute(attr, value)
+            changed = _update_callable_attribute(attr, value)
         else:
-            setattr(obj, attrname, value)
+            if attr != value:
+                setattr(obj, attrname, value)
+                changed = True
 
+    return changed
+
+
+def _update_callable_attribute(attr, value):
+    try:
+        try:
+            attr(*value) if isinstance(value, tuple) else attr(value)
+        except (TypeError, ValueError):
+            # This is to handle legacy zenpacks that use the signature
+            # pattern:
+            #     def func(*args): (arg1, arg2, ...) = args[0]
+            attr(*(value,))
+        return True
+    except Exception:
+        log.exception(
+            "Error in _update_callable_attribute. failed to set %s.%s%s",
+            attr.__module__,
+            attr.__name__,
+            value,
+        )
+        return False
+
+
+def _object_changed(obj):
     try:
         obj.index_object()
     except AttributeError:
@@ -220,23 +265,3 @@ def _update_object(obj, diff):
     notify(IndexingEvent(obj))
 
     obj.setLastChange()
-
-    return True
-
-
-def _update_callable_attribute(attr, value):
-    try:
-        try:
-            attr(*value) if isinstance(value, tuple) else attr(value)
-        except (TypeError, ValueError):
-            """This is to handle legacy zenpacks that use the signature pattern
-            def func(*args): (arg1, arg2, ...) = args[0]
-            """
-            attr(*(value,))
-    except Exception:
-        log.exception(
-            "Error in _update_callable_attribute. failed to set %s.%s%s",
-            attr.__module__,
-            attr.__name__,
-            value,
-        )

--- a/Products/DataCollector/ApplyDataMap/incrementalupdate.py
+++ b/Products/DataCollector/ApplyDataMap/incrementalupdate.py
@@ -26,6 +26,7 @@ from Products.ZenUtils.Utils import NotFound
 from .datamaputils import (
     _check_the_locks,
     _evaluate_legacy_directive,
+    _object_changed,
     _objectmap_to_device_diff,
     _update_object,
 )
@@ -274,22 +275,45 @@ class IncrementalDataMap(object):
 
     def _add(self):
         """Add the target device to the parent relationship"""
-        self._create_target()
-        self._add_target_to_relationship()
-        self.target = self.relationship._getOb(self._target_id)
-        self._update()
+        changed = False
+        self._target = next(
+            (
+                obj
+                for objId, obj in self.relationship.objectItemsAll()
+                if objId == self._target_id
+            ),
+            _NOTSET
+        )
+        if self._target is _NOTSET:
+            changed = True
+            self._create_target()
+            self._add_target_to_relationship()
+            self._target = self.relationship._getOb(self._target_id)
+
+        changed |= _update_object(self._target, self._diff)
+
+        if changed:
+            _object_changed(self._target)
+            notify(
+                DatamapUpdateEvent(
+                    self._base.dmd, self.__original_object_map, self._target
+                )
+            )
+        self.changed = changed
 
     def _update(self):
         """Update the target object using diff"""
-        _update_object(self.target, self._diff)
+        changed = _update_object(self.target, self._diff)
 
-        notify(
-            DatamapUpdateEvent(
-                self._base.dmd, self.__original_object_map, self.target
+        if changed:
+            _object_changed(self.target)
+            notify(
+                DatamapUpdateEvent(
+                    self._base.dmd, self.__original_object_map, self.target
+                )
             )
-        )
 
-        self.changed = True
+        self.changed = changed
 
     def _remove(self):
         """Remove the target object from the relationship"""
@@ -307,11 +331,11 @@ class IncrementalDataMap(object):
         """create a new zodb object from the object map we were given"""
         mod = import_module(self.modname)
         constructor = getattr(mod, self.classname)
-        self.target = constructor(self._target_id)
+        self._target = constructor(self._target_id)
 
     def _add_target_to_relationship(self):
         if self.relationship.hasobject(self.target):
-            return True
+            return
 
         log.debug(
             "%s add related object: "  # pragma: no mutate
@@ -337,8 +361,6 @@ class IncrementalDataMap(object):
                     self.id,
                 )
             )
-
-        return True
 
     def _rebuild(self):
         log.debug(

--- a/Products/DataCollector/ApplyDataMap/tests/test_add_directive.py
+++ b/Products/DataCollector/ApplyDataMap/tests/test_add_directive.py
@@ -1,0 +1,217 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2022, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import copy
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+from ..applydatamap import ApplyDataMap, ObjectMap
+
+PATH = {'src': 'Products.DataCollector.ApplyDataMap.applydatamap'}
+
+
+class TestImplicitAdd(BaseTestCase):
+    """Test ApplyDataMap directives.
+    """
+
+    def afterSetUp(t):
+        super(TestImplicitAdd, t).afterSetUp()
+        t.om = ObjectMap(
+            plugin_name="my-plugin",
+            modname="Products.ZenModel.IpInterface",
+            data={
+                "compname": "os",
+                "relname": "interfaces",
+                "id": "eth0",
+                "speed": 1e3,
+            },
+        )
+        t.adm = ApplyDataMap(t)
+        t.device = t.dmd.Devices.createInstance("test-device")
+
+    def afterTearDown(t):
+        t.dmd.Devices.removeDevices(("test-device",))
+        del t.device
+        del t.adm
+        super(TestImplicitAdd, t).afterTearDown()
+
+    def test_implicit_update(t):
+        result = t.device.applyDataMap(t.om)
+        t.assertTrue(result)
+
+    def test_implicit_update_twice_with_same_data(t):
+        t.device.applyDataMap(t.om)
+        result = t.device.applyDataMap(t.om)
+        t.assertFalse(result)
+
+
+class TestExplicitAdd(BaseTestCase):
+
+    def afterSetUp(t):
+        super(TestExplicitAdd, t).afterSetUp()
+        t.om1 = ObjectMap(
+            plugin_name="my-plugin",
+            modname="Products.ZenModel.IpInterface",
+            data={
+                "compname": "os",
+                "relname": "interfaces",
+                "id": "eth0",
+                "speed": 1e3,
+            },
+        )
+        t.om2 = copy.copy(t.om1)
+        t.adm = ApplyDataMap(t)
+        t.device = t.dmd.Devices.createInstance("test-device")
+        t.device.applyDataMap(t.om1)
+
+    def afterTearDown(t):
+        t.dmd.Devices.removeDevices(("test-device",))
+        del t.device
+        del t.adm
+        del t.om2
+        del t.om1
+        super(TestExplicitAdd, t).afterTearDown()
+
+    def test_implicit_update_with_actual_change(t):
+        t.om2.speed = 2e3
+        result = t.device.applyDataMap(t.om2)
+        t.assertTrue(result)
+
+    def test_explicit_add_true_with_existing_device_no_changes(t):
+        t.om2._add = True
+        result = t.device.applyDataMap(t.om2)
+        t.assertFalse(result)
+
+    def test_explicit_add_false_with_existing_device_no_changes(t):
+        t.device.applyDataMap(t.om1)
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "speed": 1e3,
+                    "_add": False,
+                },
+            )
+        )
+        t.assertFalse(result)
+
+    def test_explicit_add_false_with_existing_device_with_changes(t):
+        t.device.applyDataMap(t.om1)
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "interfaceName": "xyz",
+                    "speed": 2e3,
+                    "_add": False,
+                },
+            )
+        )
+        t.assertTrue(result)
+
+
+class TestAddSequence(BaseTestCase):
+    """Test ApplyDataMap directives.
+    """
+
+    def afterSetUp(t):
+        super(TestAddSequence, t).afterSetUp()
+        t.adm = ApplyDataMap(t)
+        t.device = t.dmd.Devices.createInstance("test-device")
+
+    def afterTearDown(t):
+        t.dmd.Devices.removeDevices(("test-device",))
+        del t.device
+        del t.adm
+        super(TestAddSequence, t).afterTearDown()
+
+    def test_sequence(t):
+        om1 = ObjectMap(
+            plugin_name="my-plugin",
+            modname="Products.ZenModel.IpInterface",
+            data={
+                "compname": "os",
+                "relname": "interfaces",
+                "id": "eth0",
+                "speed": 1e3,
+            },
+        )
+
+        result = t.device.applyDataMap(om1)
+        t.assertTrue(result)
+
+        result = t.device.applyDataMap(om1)
+        t.assertFalse(result)
+
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "speed": 2e3,
+                },
+            )
+        )
+        t.assertTrue(result)
+
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "speed": 2e3,
+                    "_add": True,
+                },
+            )
+        )
+        t.assertFalse(result)
+
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "speed": 2e3,
+                    "_add": False,
+                },
+            )
+        )
+        t.assertFalse(result)
+
+        result = t.device.applyDataMap(
+            ObjectMap(
+                plugin_name="my-plugin",
+                modname="Products.ZenModel.IpInterface",
+                data={
+                    "compname": "os",
+                    "relname": "interfaces",
+                    "id": "eth0",
+                    "speed": 3e3,
+                    "_add": False,
+                },
+            )
+        )
+        t.assertTrue(result)

--- a/Products/DataCollector/ApplyDataMap/tests/test_applydatamap.py
+++ b/Products/DataCollector/ApplyDataMap/tests/test_applydatamap.py
@@ -7,7 +7,6 @@
 #
 ##############################################################################
 
-from unittest import TestCase
 from mock import Mock, create_autospec, patch, sentinel, MagicMock, call
 
 from Products.ZenModel.Device import Device
@@ -16,7 +15,6 @@ from ..applydatamap import (
     ApplyDataMap,
     CLASSIFIER_CLASS,
     IncrementalDataMap,
-    log,
     NotFound,
     ObjectMap,
     RelationshipMap,
@@ -33,14 +31,15 @@ from ..applydatamap import (
     _validate_datamap,
     _validate_device_class,
 )
-
-log.setLevel("DEBUG")
+from .utils import BaseTestCase
 
 PATH = {"src": "Products.DataCollector.ApplyDataMap.applydatamap"}
 
 
-class ApplyDataMapTests(TestCase):
+class ApplyDataMapTests(BaseTestCase):
     def setUp(t):
+        super(ApplyDataMapTests, t).setUp()
+
         patches = [
             "notify",
             "_get_relmap_target",
@@ -524,7 +523,7 @@ class ApplyDataMapTests(TestCase):
 ##############################################################################
 
 
-class Test_get_relmap_target(TestCase):
+class Test_get_relmap_target(BaseTestCase):
     def test__get_relmap_target(t):
         device = Mock(name="device", id=sentinel.pid)
         datamap = Mock(name="datamap", parentId=None, compname=None)
@@ -577,7 +576,7 @@ class Test_get_relmap_target(TestCase):
         t.assertIs(None, ret)
 
 
-class Test_validate_device_class(TestCase):
+class Test_validate_device_class(BaseTestCase):
     def test__validate_device_class(t):
         device = Mock(name="device", deviceClass=lambda: "some class")
         ret = _validate_device_class(device)
@@ -607,7 +606,7 @@ class Test_validate_device_class(TestCase):
         t.assertEqual(ret, None)
 
 
-class Test_get_object_by_pid(TestCase):
+class Test_get_object_by_pid(BaseTestCase):
     def test_finds_object(t):
         device = Mock(name="device")
         device.componentSearch.return_value = [
@@ -645,7 +644,7 @@ class Test_get_object_by_pid(TestCase):
         t.assertEqual(ret, None)
 
 
-class Test__validate_datamap(TestCase):
+class Test__validate_datamap(BaseTestCase):
     def test_relationshipmap(t):
         datamap = RelationshipMap()
         ret = _validate_datamap(
@@ -706,7 +705,7 @@ class Test__validate_datamap(TestCase):
         t.assertEqual(ret.path, sentinel.compname)
 
 
-class Test_process_relationshipmap(TestCase):
+class Test_process_relationshipmap(BaseTestCase):
     @patch("{src}._get_relmap_target".format(**PATH), autospec=True)
     def test_missing_relname(t, _get_relmap_target):
         """Returns None if the parent device does not have the specified
@@ -792,8 +791,9 @@ class Test_process_relationshipmap(TestCase):
         t.assertEqual(processed.maps[2].id, "eth0_3")
 
 
-class Test__get_relationshipmap_diff(TestCase):
+class Test__get_relationshipmap_diff(BaseTestCase):
     def setUp(t):
+        super(Test__get_relationshipmap_diff, t).setUp()
         current_ids = ["id1", "id2", "id3"]
         relname = "relationship"
         t.object_1 = Mock(id="id1")
@@ -832,7 +832,7 @@ class Test__get_relationshipmap_diff(TestCase):
         t.assertEqual(ret, {"removed": [t.object_1], "locked": [t.object_2]})
 
 
-class Test_get_relationship_ids(TestCase):
+class Test_get_relationship_ids(BaseTestCase):
     def test__get_relationship_ids(t):
         relname = "relationship_name"
         relationship = Mock(name="relatinoship")
@@ -845,7 +845,7 @@ class Test_get_relationship_ids(TestCase):
         t.assertEqual(ret, set(["r1", "r2", "r3"]))
 
 
-class Test__get_objmap_target(TestCase):
+class Test__get_objmap_target(BaseTestCase):
     def test__get_objmap_target(t):
         device = Mock(name="device")
         relname = "relationship_name"
@@ -876,7 +876,7 @@ class Test__get_objmap_target(TestCase):
         t.assertEqual(ret, sentinel.component)
 
 
-class Test__clone_datamap(TestCase):
+class Test__clone_datamap(BaseTestCase):
     def test_RelationshipMap(t):
         relname = "rel"
         compname = "comp"
@@ -975,7 +975,7 @@ class Test__clone_datamap(TestCase):
 ##############################################################################
 
 
-class Test__remove_relationship(TestCase):
+class Test__remove_relationship(BaseTestCase):
     def test_remove_object_from_devices_relationship(t):
         device = Mock(name="device", spec_set=["removeRelation"])
         ret = _remove_relationship(device, sentinel.relname, sentinel.obj)
@@ -999,8 +999,9 @@ class Test__remove_relationship(TestCase):
         t.assertEqual(ret, False)
 
 
-class Test__create_object(TestCase):
+class Test__create_object(BaseTestCase):
     def setUp(t):
+        super(Test__create_object, t).setUp()
         patches = [
             "importClass",
         ]

--- a/Products/DataCollector/ApplyDataMap/tests/test_datamaputils.py
+++ b/Products/DataCollector/ApplyDataMap/tests/test_datamaputils.py
@@ -8,7 +8,6 @@
 ##############################################################################
 
 from base64 import b64encode
-from unittest import TestCase
 from mock import Mock, sentinel, patch
 
 from Products.DataCollector.plugins.DataMaps import ObjectMap
@@ -30,13 +29,14 @@ from ..datamaputils import (
     _update_object,
     _update_callable_attribute,
 )
+from .utils import BaseTestCase
 
 log.setLevel("DEBUG")
 
 PATH = {"src": "Products.DataCollector.ApplyDataMap.datamaputils"}
 
 
-class TestisSameData(TestCase):
+class TestisSameData(BaseTestCase):
     def test_isSameData(t):
         ret = isSameData("a", "a")
         t.assertTrue(ret)
@@ -49,9 +49,7 @@ class TestisSameData(TestCase):
 
     def test_unsorted_lists_of_dicts_differ(t):
         a = [{"a": 1, "b": 2}, {"c": 3}, {"d": 4}]
-        c = [
-            {"d": 4},
-        ]
+        c = [{"d": 4}]
         t.assertFalse(isSameData(a, c))
 
     def test_unsorted_tuple_of_dicts_match(t):
@@ -90,8 +88,9 @@ class GetSetObject:
         return self.Attr
 
 
-class TestCheckTheLocks(TestCase):
+class TestCheckTheLocks(BaseTestCase):
     def setUp(t):
+        super(TestCheckTheLocks, t).setUp()
         t.datamap = Mock(name="datamap")
         t.device = Mock(name="device")
         t.device.isLockedFromUpdates.return_value = False
@@ -140,7 +139,7 @@ class TestCheckTheLocks(TestCase):
         t.assertEqual(t.datamap._directive, "delete_locked")
 
 
-class TestLockedFromUpdates(TestCase):
+class TestLockedFromUpdates(BaseTestCase):
     def test_locked(t):
         obj = Mock(spec=["isLockedFromUpdates"])
         obj.isLockedFromUpdates.return_value = True
@@ -160,7 +159,7 @@ class TestLockedFromUpdates(TestCase):
         t.assertEqual(ret, False)
 
 
-class TestLockedFromDeletion(TestCase):
+class TestLockedFromDeletion(BaseTestCase):
     def test_locked(t):
         obj = Mock(spec=["isLockedFromDeletion"])
         obj.isLockedFromDeletion.return_value = True
@@ -180,9 +179,16 @@ class TestLockedFromDeletion(TestCase):
         t.assertEqual(ret, False)
 
 
-class TestEvaluateLegacyDirective(TestCase):
+class TestEvaluateLegacyDirective(BaseTestCase):
     def setUp(t):
+        super(TestEvaluateLegacyDirective, t).setUp()
         t.object_map = ObjectMap()
+
+    def test_legacy__add_false_flag(t):
+        t.object_map._add = False
+        ret = _evaluate_legacy_directive(t.object_map)
+        t.assertEqual(ret._directive, "update")
+        t.assertEqual(t.object_map._directive, "update")
 
     def test_legacy__add_flag(t):
         t.object_map._add = True
@@ -221,7 +227,7 @@ class TestEvaluateLegacyDirective(TestCase):
         t.assertEqual(t.object_map._directive, "nochange")
 
 
-class TestObjectMapToDeviceDiff(TestCase):
+class TestObjectMapToDeviceDiff(BaseTestCase):
     def test_no_change(t):
         """Unchanged objects return an empty dict"""
         object_map = ObjectMap(
@@ -339,7 +345,7 @@ class TestObjectMapToDeviceDiff(TestCase):
                 t.assertEqual(val, getattr(objectmap, key).decode(enc))
 
 
-class TestAttributeDiff(TestCase):
+class TestAttributeDiff(BaseTestCase):
     def test_changed(t):
         obj = Mock(name="object")
         obj.attr = sentinel.original
@@ -379,7 +385,7 @@ class TestAttributeDiff(TestCase):
         t.assertEqual(ret, None)
 
 
-class TestGetAttrValue(TestCase):
+class TestGetAttrValue(BaseTestCase):
     def test_set_methods(t):
         """given an attribute that starts with 'set'
         returns the value from the attribute's 'get' method
@@ -413,7 +419,7 @@ class TestGetAttrValue(TestCase):
         t.assertEqual(ret, MISSINGNO)
 
 
-class TestSanitizeValue(TestCase):
+class TestSanitizeValue(BaseTestCase):
     def test_handles_strings(t):
         value = "some_string"
         ret = _sanitize_value(value, sentinel.obj)
@@ -452,7 +458,7 @@ class TestSanitizeValue(TestCase):
             _sanitize_value(value, sentinel.obj)
 
 
-class TestDecodeValue(TestCase):
+class TestDecodeValue(BaseTestCase):
     def test_decodes_strings(t):
         original_str = "some_string"
         value = b64encode(original_str)
@@ -463,7 +469,7 @@ class TestDecodeValue(TestCase):
         t.assertEqual(ret, original_str)
 
 
-class TestUpdateObject(TestCase):
+class TestUpdateObject(BaseTestCase):
     def test_update(t):
         obj = Device("deviceid")
         obj.attr = sentinel.a
@@ -485,12 +491,12 @@ class TestUpdateObject(TestCase):
         obj.setAttr("x")
         t.assertEqual(obj.Attr, "x")
 
-        _update_object(obj, diff)
+        changed = _update_object(obj, diff)
 
         _update_callable_attribute.assert_called_with(
             obj.setAttr, "sanitized sentinel.value"
         )
-        obj.setLastChange.assert_called_with()
+        t.assertTrue(changed)
 
     def test_ignores_undefined_attributes(t):
         """does not add attributes that do not exist on the target"""
@@ -506,7 +512,7 @@ class TestUpdateObject(TestCase):
         t.assertTrue(ret)
 
 
-class TestUpdateCallableAttribute(TestCase):
+class TestUpdateCallableAttribute(BaseTestCase):
     def test_uses_set_method_to_update(t):
         obj = Mock(name="object", spec_set=["setAttr"])
         value = (

--- a/Products/DataCollector/ApplyDataMap/tests/utils.py
+++ b/Products/DataCollector/ApplyDataMap/tests/utils.py
@@ -1,0 +1,21 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2022, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+import logging
+
+from unittest import TestCase
+
+
+class BaseTestCase(TestCase):
+
+    def setUp(t):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(t):
+        logging.disable(logging.NOTSET)

--- a/Products/DataCollector/tests/testHRSWRunMap.py
+++ b/Products/DataCollector/tests/testHRSWRunMap.py
@@ -7,13 +7,22 @@
 #
 ##############################################################################
 
-
 import logging
-import re
+
 from unittest import TestCase, makeSuite
+
 from Products.DataCollector.plugins.zenoss.snmp.HRSWRunMap import HRSWRunMap
 
 log = logging.getLogger("zen.testcases")
+
+
+class BaseTestCase(TestCase):
+
+    def setUp(t):
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(t):
+        logging.disable(logging.NOTSET)
 
 
 class FakeObjectMap(object):
@@ -28,7 +37,7 @@ class FakeDevice(object):
     osProcessClassMatchData = [dict(includeRegex='foo',
                                     excludeRegex='nothing',
                                     replaceRegex='.*',
-                                    replacement ='foo',
+                                    replacement='foo',
                                     primaryUrlPath='url',
                                     primaryDmdId='quux')]
 
@@ -39,7 +48,7 @@ def createHRSWRunMap():
     return sw_run_map
 
 
-class TestHRSWRunMap(TestCase):
+class TestHRSWRunMap(BaseTestCase):
 
     def test_process(self):
         sw_run_map = createHRSWRunMap()

--- a/Products/DataCollector/tests/test_incrementalupdate_integration.py
+++ b/Products/DataCollector/tests/test_incrementalupdate_integration.py
@@ -7,16 +7,17 @@
 #
 ##############################################################################
 
-from Products.ZenTestCase.BaseTestCase import BaseTestCase
-
 import transaction
 
+from Products.DataCollector.ApplyDataMap import (
+    ApplyDataMap,
+    IncrementalDataMap,
+)
 from Products.DataCollector.plugins.DataMaps import ObjectMap, RelationshipMap
-from Products.DataCollector.ApplyDataMap import ApplyDataMap, IncrementalDataMap
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
 
 
 class applyDataMapTests(BaseTestCase):
-
     def afterSetUp(self):
         """Preparation invoked before each test is run."""
         super(applyDataMapTests, self).afterSetUp()
@@ -65,13 +66,15 @@ class applyDataMapTests(BaseTestCase):
         self.assertTrue(changed, "update failed")
 
         self.assertEqual(
-            1, self.device.os.interfaces.countObjects(),
-            "wrong number of interfaces created by ObjectMap"
+            1,
+            self.device.os.interfaces.countObjects(),
+            "wrong number of interfaces created by ObjectMap",
         )
 
         self.assertEqual(
-            10e9, self.device.os.interfaces.eth0.speed,
-            "eth0.speed not updated by ObjectMap"
+            10e9,
+            self.device.os.interfaces.eth0.speed,
+            "eth0.speed not updated by ObjectMap",
         )
 
         # Test implicit nochange directive
@@ -90,20 +93,21 @@ class applyDataMapTests(BaseTestCase):
         }
 
         idm = IncrementalDataMap(self.device, ObjectMap(DATA))
-        idm._target = self.device # absolutely incorrect but sufficient here
+        idm._target = self.device  # absolutely incorrect but sufficient here
 
         changed = self.service.applyDataMap(self.device, idm)
         self.assertFalse(changed, "_add = False resulted in change")
 
         self.assertEqual(
-            0, self.device.os.interfaces.countObjects(),
-            "ObjectMap with _add = False created a component"
+            0,
+            self.device.os.interfaces.countObjects(),
+            "ObjectMap with _add = False created a component",
         )
 
     def test_updatedComponent_removeTrue(self):
         """Test updating a component with _remove or remove set to True."""
 
-        for remove_key in ('_remove', 'remove'):
+        for remove_key in ("_remove", "remove"):
             DATA = {
                 "id": "eth0",
                 "compname": "os",
@@ -116,11 +120,13 @@ class applyDataMapTests(BaseTestCase):
                     raise AttributeError("the interface does not exist")
 
             idm = IncrementalDataMap(self.device, ObjectMap(DATA))
-            idm._target = self.device # absolutely incorrect but sufficient here
+            idm._target = (
+                self.device
+            )  # absolutely incorrect but sufficient here
             idm._parent = Parent()
 
             changed = self.service.applyDataMap(self.device, idm)
-            self.assertFalse(changed, 'update is not idempotent')
+            self.assertFalse(changed, "update is not idempotent")
 
             self.service.applyDataMap(
                 self.device,
@@ -132,19 +138,21 @@ class applyDataMapTests(BaseTestCase):
                         "modname": "Products.ZenModel.IpInterface",
                         "speed": 10e9,
                     }
-                )
+                ),
             )
             self.assertEqual(
-                1, self.device.os.interfaces.countObjects(),
-                'failed to add object'
+                1,
+                self.device.os.interfaces.countObjects(),
+                "failed to add object",
             )
 
             changed = self.service.applyDataMap(self.device, ObjectMap(DATA))
             self.assertTrue(changed, "remove object failed")
 
             self.assertEqual(
-                0, self.device.os.interfaces.countObjects(),
-                "failed to remove component"
+                0,
+                self.device.os.interfaces.countObjects(),
+                "failed to remove component",
             )
 
     def base_relmap(self):
@@ -153,13 +161,9 @@ class applyDataMapTests(BaseTestCase):
             relname="interfaces",
             modname="Products.ZenModel.IpInterface",
             objmaps=[
-                ObjectMap({
-                    "id": "eth0"
-                }),
-                ObjectMap({
-                    "id": "eth1"
-                }),
-            ]
+                ObjectMap({"id": "eth0"}),
+                ObjectMap({"id": "eth1"}),
+            ],
         )
 
     def test_updateRelationship(self):
@@ -167,8 +171,9 @@ class applyDataMapTests(BaseTestCase):
         changed = self.service.applyDataMap(self.device, self.base_relmap())
         self.assertTrue(changed, "relationship creation failed")
         self.assertEqual(
-            2, self.device.os.interfaces.countObjects(),
-            "wrong number of interfaces created by first RelationshipMap"
+            2,
+            self.device.os.interfaces.countObjects(),
+            "wrong number of interfaces created by first RelationshipMap",
         )
 
     def test_updateRelationship_is_idempotent(self):
@@ -191,8 +196,9 @@ class applyDataMapTests(BaseTestCase):
 
         self.assertTrue(changed, "remove related item failed")
         self.assertEquals(
-            1, self.device.os.interfaces.countObjects(),
-            "wrong number of interfaces after trimmed RelationshipMap"
+            1,
+            self.device.os.interfaces.countObjects(),
+            "wrong number of interfaces after trimmed RelationshipMap",
         )
 
     def test_updateRelationship_remove_all_objects(self):
@@ -206,6 +212,7 @@ class applyDataMapTests(BaseTestCase):
 
         self.assertTrue(changed, "failed to remove related objects")
         self.assertEquals(
-            0, self.device.os.interfaces.countObjects(),
-            "wrong number of interfaces after empty RelationshipMap"
+            0,
+            self.device.os.interfaces.countObjects(),
+            "wrong number of interfaces after empty RelationshipMap",
         )

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -481,16 +481,24 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
         else:
             ManagedEntity._setPropValue(self, id, value)
 
-
     security.declareProtected(ZEN_MANAGE_DEVICE, 'applyDataMap')
-    def applyDataMap(self, datamap, relname="", compname="", modname="", parentId=""):
+    def applyDataMap(
+        self, datamap, relname="", compname="", modname="", parentId=""
+    ):
         """
         Apply a datamap passed as a list of dicts through XML-RPC.
         """
         from Products.DataCollector.ApplyDataMap import ApplyDataMap
+
         adm = ApplyDataMap()
-        adm.applyDataMap(self, datamap, relname=relname,
-                         compname=compname, modname=modname, parentId="")
+        return adm.applyDataMap(
+            self,
+            datamap,
+            relname=relname,
+            compname=compname,
+            modname=modname,
+            parentId="",
+        )
 
     def path(self):
         """


### PR DESCRIPTION
* When _add == False, ADM will still update data.
* Regardless of how _add is set, ADM will not update ZODB when changes are not detected.

Fixes ZEN-32767.