### PR TITLE
Fix actions menu disabling according to permissions

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/Action.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/Action.js
@@ -12,20 +12,13 @@
     Ext.ns('Zenoss.Action');
 
     Ext.define('Zenoss.PermissionableAction', {
-        externallyDisabled: false,
         permitted: false,
         filtered: false,
         updateDisabled: function() {
             this.setDisabled(this.checkDisabled());
         },
         checkDisabled: function() {
-            if (this.externallyDisabled) {
-                return true;
-            }
-            if (this.permitted || this.filtered) {
-                return false;
-            }
-            return true;
+            return !(this.permitted || this.filtered);
         },
         checkPermitted: function() {
             if (this.permission) {
@@ -66,7 +59,6 @@
     });
 
     function setDisabled(disable) {
-        this.externallyDisabled = disable;
         this.callParent([this.checkDisabled()]);
     }
 


### PR DESCRIPTION
Fixes ZEN-33827.

The issue occurred because pieces of code, which were removed during its
fix in ZEN-33307, were accidentally added as a part of the fix for
ZEN-33308. To resolve the issue these pieces of code were deleted and
checkDisabled function was simplified.