### PR TITLE
ZEN-33669: Site error for a page that is opened for a long time

### DIFF
--- a/Products/ZenUI3/browser/resources/js/silent-auth/silentAuth.js
+++ b/Products/ZenUI3/browser/resources/js/silent-auth/silentAuth.js
@@ -29,7 +29,7 @@ var silentAuthNS = {
         return false
     },
     authenticateSilently: function () {
-        this.auth0_cz.checkSession({ timeout: 5000 }, (err, result) => {
+        this.auth0_cz.checkSession({}, (err, result) => {
             if (err) {
                 console.log(err);
             } else if (result) {
@@ -93,10 +93,8 @@ var silentAuthNS = {
         })
     },
     silentReauth: function () {
-        if (window.localStorage.getItem("accessToken")) {
-            if (!this.isAuthenticated()) {
-                this.authenticateSilently();
-            }
+        if (!this.isAuthenticated()) {
+            this.authenticateSilently();
         }
     }
 }

--- a/Products/ZenUI3/browser/templates/base-new.pt
+++ b/Products/ZenUI3/browser/templates/base-new.pt
@@ -36,7 +36,7 @@
 
         <!-- Static javascript -->
         <script src="/++resource++zenui/js/zenoss/theme.js"></script>
-        <script type="text/javascript" src="https://cdn.auth0.com/js/auth0/9.10.0/auth0.min.js"></script>
+        <script type="text/javascript" src="https://cdn.auth0.com/js/auth0/9.13.2/auth0.min.js"></script>
         <script type="text/javascript" src="/zingstatic/ZC_CONFIG.js"></script>
         <script src="/++resource++zenui/js/silent-auth/cookies.js"></script>
         <script src="/++resource++zenui/js/silent-auth/silentAuth.js"></script>


### PR DESCRIPTION
Silent auth will never work with checking of key exists in browser local storage as we never put this info from other places there. 
Also, silent auth will work only if we put the CZ instance host to the  Allowed Web Origins list in https://manage.auth0.com/dashboard/us/zenoss-dev/applications/DEpUm5pU4B5mOXmVtC9CHBmAXImveJlQ/settings.
As soon as silent auth starting work there's no way to get n from zope web application, because of regular (every 30 sec) access token refreshing. https://github.com/zenoss/zenoss-prodbin/blob/c254db8cfa35e4f645e2e7f5f16ad171fade071e/Products/ZenUI3/browser/__init__.py#L46