### PR TITLE
Fix permission verification for event management

### DIFF
--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -653,7 +653,7 @@ class EventsRouter(DirectRouter):
         except (AttributeError, KeyError):
             return False
 
-        manage_events_for = list()
+        manage_events_for = []
         for r in user.getAllAdminRoles():
             if r.role in READ_WRITE_ROLES:
                 role_managed_object = r.managedObject()

--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -647,14 +647,26 @@ class EventsRouter(DirectRouter):
         try:
             if uid is not None:
                 uid = getUtility(IVirtualRoot).strip_virtual_root(uid)
-                organizer_name = self.context.dmd.Devices.getOrganizer(uid).getOrganizerName()
+                organizer = self.context.dmd.Devices.getOrganizer(uid)
             else:
                 return self._hasPermissionsForAllEvents(ZEN_MANAGE_EVENTS, evids)
         except (AttributeError, KeyError):
             return False
-        manage_events_for = (r.managedObjectName() for r in user.getAllAdminRoles() if r.role in READ_WRITE_ROLES)
-        return organizer_name in manage_events_for
-    
+
+        manage_events_for = list()
+        for r in user.getAllAdminRoles():
+            if r.role in READ_WRITE_ROLES:
+                role_managed_object = r.managedObject()
+                for sub_org in role_managed_object.getSubOrganizers():
+                    manage_events_for.append(
+                        role_managed_object.getBreadCrumbUrlPath()
+                    )
+                    manage_events_for.append(
+                        sub_org.getBreadCrumbUrlPath()
+                    )
+
+        return organizer.getBreadCrumbUrlPath() in manage_events_for
+
     def can_add_events(self, summary, device, component, severity, evclasskey,
                   evclass=None, monitor=None, **kwargs):
         ctx = self.context.dmd.Devices.findDevice(device.strip())


### PR DESCRIPTION
Fixes ZEN-33568.

The issue occurred because the verification of permissions for event
management within the organizers such as Systems, Groups, and Locations,
was performed using the names of general organizers. It didn't take into
account that different kinds of organizers can have the same names and
can have sub organizers. To fix the issue, the verification of event
management permission was changed by adding verification of sub
organizers. In addition, to identify permissions for different
administered objects the usage of the organizer name was changed on the
bread crumb URL path, which makes all identifiers unique.