### PR TITLE
ZEN-34096: Site error for a page that is opened for a long time

### DIFF
--- a/Products/ZenUtils/MySqlZodbFactory.py
+++ b/Products/ZenUtils/MySqlZodbFactory.py
@@ -47,6 +47,7 @@ def _make_exceptions_module():
     import MySQLdb
     exceptions = types.ModuleType("_mysql_exceptions")
     for ex in (
+        MySQLdb.Error,
         MySQLdb.DatabaseError,
         MySQLdb.DataError,
         MySQLdb.IntegrityError,


### PR DESCRIPTION
```AttributeError: "'module' object has no attribute 'Error'"``` 
appears when auth0 cookies have expired and we fall into `zenoss_error_message` method [here](https://github.com/zenoss/zenoss-prodbin/blob/457b34c8b706e3785af134abe669da3661ad0a25/Products/ZenModel/DataRoot.py#L427) 