### PR TITLE
Replace import path for ZenRRD parsers

### DIFF
--- a/Products/ZenRRD/parsers/Auto.py
+++ b/Products/ZenRRD/parsers/Auto.py
@@ -9,8 +9,8 @@
 
 from Products.ZenRRD.CommandParser import CommandParser, ParsedResults
 
-from .Cacti import Cacti
-from .Nagios import Nagios
+from Products.ZenRRD.parsers.Cacti import Cacti
+from Products.ZenRRD.parsers.Nagios import Nagios
 
 
 class Auto(CommandParser):


### PR DESCRIPTION
Fixes ZEN-34100.

Wrong import path cause traceback during processing
command datasource