### PR TITLE
Fix verification of permission for event management

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -1779,20 +1779,6 @@ Ext.onReady(function () {
             }
         });
 
-        if(!_has_global_roles()) {
-            // take context from selected events, not from selected navigation item
-            Zenoss.EventActionManager.configure({
-                findParams: function() {
-                    var grid = Ext.getCmp(eventsGridId);
-                    if (grid) {
-                        var params = grid.getSelectionParameters();
-                        // delete device uid because can be selected events for different devices
-                        delete params.uid;
-                        return params;
-                    }
-                }
-            });
-        }
         if (re_attach_to_container === true) {
             var container_panel = Ext.getCmp('detail_panel');
             container_panel.items.insert(1, event_console);

--- a/Products/Zuul/routers/zep.py
+++ b/Products/Zuul/routers/zep.py
@@ -601,27 +601,17 @@ class EventsRouter(DirectRouter):
             raise Exception('Could not find event %s' % evid)
 
     def _hasPermissionsForAllEvents(self, permission, evids):
-        log.info('HP permission: %s, evids: %s', permission, evids)
         try:
             dmd = get_dmd()
-            log.info('HP dmd: %s', dmd)
             target_permission = permission.lower()
-            log.info('HP target_permission: %s', target_permission)
             events_filter = self._buildFilter(uids=None, params={}, specificEventUuids=evids)
-            log.info('HP events_filter: %s', events_filter)
             event_summaries = self.zep.getEventSummaries(0, filter=events_filter, use_permissions=True)
-            log.info('HP event_summaries: %s', event_summaries)
             devices = set()
             for summary in event_summaries['events']:
                 d = EventCompatInfo(self.context.dmd, summary)
-                log.info('HP d: %s', d)
                 dev_obj = dmd.getObjByPath(d.device['uid'])
-                log.info('HP dev_obj: %s', dev_obj)
                 devices.add(dev_obj)
-                log.info('HP devices: %s', devices)
             for device in devices:
-                log.info('HP permissionsForContext: %s',
-                         permissionsForContext(device)[target_permission])
                 if not permissionsForContext(device)[target_permission]:
                     return False
             return True
@@ -859,8 +849,6 @@ class EventsRouter(DirectRouter):
         @return:  Success message
         """
         log.debug('Issuing an acknowledge request.')
-
-        log.info('ACK uis: %s, params: %s, evids: %s', uid, params, evids)
 
         includeFilter, excludeFilter = self._buildRequestFilters(uid, params, evids, excludeIds)
 


### PR DESCRIPTION
Fixes ZEN-33833.

The issue occurred because the verification of permissions for event
management within the organizers such as Systems, Groups, and Locations,
was performed using the names of general organizers. It didn't take into
account that different kinds of organizers can have the same names and
can have sub organizers. To fix the issue, the verification of event
management permission was changed by adding verification of sub
organizers. In addition, to identify permissions for different
administered objects the usage of the organizer name was changed on the
bread crumb URL path, which makes all identifiers unique.