### PR TITLE
Fix zenbatch regex matching

### DIFF
--- a/Products/ZenModel/BatchDeviceDumper.py
+++ b/Products/ZenModel/BatchDeviceDumper.py
@@ -378,7 +378,7 @@ class BatchDeviceDumper(ZCmdBase):
     def makeRegexMatcher(self):
         if self.options.regex:
             regex = re.compile(self.options.regex)
-            return lambda dev: dev is not None and regex.match(dev.id)
+            return lambda dev: dev is not None and regex.match(dev.getPrimaryId())
 
     def chooseDevice(self, root, matcher=None):
         for dev in root.devices():


### PR DESCRIPTION
Fixes ZEN-34069.

To fix the issue the device id for regex match was substituted by the
method getPrimaryId().