### PR TITLE
Fix management of organizers for group users

### DIFF
--- a/Products/Zuul/__init__.py
+++ b/Products/Zuul/__init__.py
@@ -211,6 +211,15 @@ def filterUidsByPermission(dmd, permission, uids):
     return validUids
 
 
+def checkAdministeredObjectPermission(uid, permission, context=None):
+    """
+    Return True if the current user has the specified Administrated object
+    permission on the given context or the dmd; otherwise, return False.
+    """
+    context = context or get_dmd()
+    return checkPermission(permission, context.dmd.unrestrictedTraverse(uid))
+
+
 def checkPermission(permission, context=None):
     """
     Return true if the current user has the specified permission on the given

--- a/Products/Zuul/routers/device.py
+++ b/Products/Zuul/routers/device.py
@@ -326,8 +326,12 @@ class DeviceRouter(TreeRouter):
         if not (
             Zuul.checkPermission(ZEN_MANAGE_DEVICE, self.context)
             or (
-                Zuul.checkPermission(ZEN_CHANGE_DEVICE_PRODSTATE, self.context)
+                Zuul.checkPermission(ZEN_CHANGE_DEVICE_PRODSTATE,
+                                     self.context)
                 and sorted(data.keys()) == ['productionState', 'uid']
+            )
+            or Zuul.checkAdministeredObjectPermission(
+                data.get('uid'), ZEN_MANAGE_DMD, self.context
             )
         ):
             raise Exception('You do not have permission to save changes.')


### PR DESCRIPTION
Fixes ZEN-33828.

To resolve the issue the check for roles granted to the current user
via Administered Objects by both group membership or direct assignment
was added.