### PR TITLE
ZEN-34078: Copy to Clipboard doesn't work when Model Device (Debug) generates a lot of output (backport)

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/CommandWindow.js
@@ -150,16 +150,25 @@ Ext.define("Zenoss.CommandWindow", {
         var tempText = document.createElement("textarea");
         tempText.value = body;
         document.body.appendChild(tempText);
-        tempText.focus();
-        tempText.select();
-        try {
-            if (document.execCommand('copy')) {
-               Zenoss.flares.Manager.success('Copied command output to clipboard');
+      
+        function afterTextareaAppending() {
+            tempText.focus();
+            tempText.select();
+            try {
+                if (document.execCommand('copy')) {
+                    Zenoss.flares.Manager.success('Copied command output to clipboard');
+                }
+            } catch (err) {
+                console.error("Failed to copy command output to clipboard", err);
+            } finally {
+                document.body.removeChild(tempText);
             }
-        } catch(err) {
-            console.error("Failed to copy command output to clipboard", err);
-        } finally {
-            document.body.removeChild(tempText);
+        }
+
+        if (Ext.isChrome) {
+            setTimeout(afterTextareaAppending);
+        } else {
+            afterTextareaAppending();
         }
     },
     closeAndRedirect: function() {

--- a/Products/ZenUI3/browser/resources/js/zenoss/ExtOverrides.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/ExtOverrides.js
@@ -1043,5 +1043,13 @@ Ext.override(Ext.util.Sorter, {
             me.doMultiSelect(toSelect, true);
         }
     });
+    
+    Ext.isEdge = (function () {
+        return /edge/.test(Ext.userAgent);
+    })();
+
+    Ext.isChrome = !Ext.isEdge && (function () {
+        return /\bchrome\b/.test(Ext.userAgent);
+    })();
 
 }());


### PR DESCRIPTION
Fixed "copy to clipboard" for a lot of output. 

Fixes [ZEN-34078](https://jira.zenoss.com/browse/ZEN-34078)

Moved changes from this PR https://github.com/zenoss/zenoss-prodbin/pull/3414
This should fix for support/6.x
Checked manually