### PR TITLE
Fix the downloading MIBs to nested organizers

### DIFF
--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -235,7 +235,7 @@ class ZenMib(ZCmdBase):
                 sys.exit(1)
 
         # Verify that the target MIB organizer exists
-        miborgpath = os.path.join("/zport/dmd/Mibs", self.options.path)
+        miborgpath = "/zport/dmd/Mibs" + self.options.path
         miborg = self.dmd.unrestrictedTraverse(miborgpath, None)
         if miborg is None:
             self.log.error(


### PR DESCRIPTION
Fixes ZEN-34139.

The issue occurred because the mib organizer path was computed in the
wrong way, i.e. os.path.join("/zport/dmd/Mibs", "/Nested Org") returned
"/Nested Org" because of / at the beginning. To resolve the issue the
way of computing of mib organizer path was changed to string
concatenation.