### PR TITLE
Fix the creation events with an empty summary

### DIFF
--- a/Products/ZenRRD/zencommand.py
+++ b/Products/ZenRRD/zencommand.py
@@ -490,6 +490,12 @@ class SshPerformanceCollectionTask(BaseTask):
                         self._devId,
                         "timeout",
                     )
+        except defer.CancelledError:
+            message = "Twisted deferred was cancelled."
+            log.debug(
+                "Connection lost  device=%s ip=%s interval=%s description=%s",
+                self._devId, self._manageIp, self.interval, message
+            )
 
         except Exception as e:
             self.state = TaskStates.STATE_PAUSED
@@ -498,7 +504,7 @@ class SshPerformanceCollectionTask(BaseTask):
                     self._devId,
                     self._manageIp,
                     self.interval,
-                    e.message,
+                    str(e),
                 )
             )
             if log.isEnabledFor(logging.DEBUG):
@@ -508,7 +514,7 @@ class SshPerformanceCollectionTask(BaseTask):
             self._eventService.sendEvent(
                 STATUS_EVENT,
                 device=self._devId,
-                summary=e.message,
+                summary=str(e),
                 component=COLLECTOR_NAME,
                 severity=Error,
             )

--- a/Products/ZenUtils/Executor.py
+++ b/Products/ZenUtils/Executor.py
@@ -195,22 +195,21 @@ class AsyncExecutor(object):
             self._log.debug("Executor has stopped  executor=%s", self._id)
         except (error.TimeoutError, defer.TimeoutError) as ex:
             self._log.error(
-                "Task timed out  executor={} task-id={} label={}",
+                "Task timed out  executor=%s task-id=%s label=%s",
                 self._id, task.id, task.label,
             )
             task.error(ex)
         except defer.CancelledError as ex:
             self._log.debug(
                 "Task cancelled (probably due to a connection timeout)  "
-                "executor={} task-id={} label={}",
+                "executor=%s task-id=%s label=%s",
                 self._id, task.id, task.label,
             )
             task.error(ex)
         except Exception as ex:
             message = (
-                "Bad task  executor={} task-id={} label={}".format(
-                    self._id, task.id, task.label,
-                )
+                "Bad task  executor=%s task-id=%s label=%s",
+                self._id, task.id, task.label
             )
             if self._log.isEnabledFor(logging.DEBUG):
                 self._log.exception(message)


### PR DESCRIPTION
Fixes ZEN-28577.

The TypeError in CancelledError handling in Executor occurred because
the wrong log string formatting in the CancelledError handling section
in Executop.py was made. The issue was resolved by fixing the string
formatting. The issue occurred due to improper processing of errors
twisted.internet.defer.CancelledError and
twisted.internet.error.ConnectionLost, which caused adding events with
an empty summary. To fix the problem, additional except-sections for
these errors were added, which handle these errors and send events with
a clear non-empty summary for twisted.internet.error.ConnectionLost.