### PR TITLE
Change the form of the device reidentifying

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/DeviceDialogs.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/DeviceDialogs.js
@@ -38,24 +38,12 @@
         constructor: function(config) {
             config = config || {};
             Ext.applyIf(config, {
-                height: 410,
+                height: 310,
                 width: 500,
                 padding: '20 40 20 18',
                 id: 'rename_device_dialog',
                 title: _t('Reidentify Device'),
                 submitHandler: Ext.bind(this.handleSubmit, this),
-
-                buttons: [{
-                    xtype: 'NotClosableDialogButton',
-                    text: _t('Submit'),
-                    disabled: true,
-                    type: 'submit',
-                    ref: 'buttonSubmit',
-                },{
-                    xtype: 'DialogButton',
-                    ref: 'buttonCancel',
-                    text: _t('Cancel')
-                }],
 
                 items: [{
                     xtype: 'hidden',
@@ -78,37 +66,7 @@
                     padding: '20 48 20 0',
                     xtype: 'displayfield',
                     fieldCls: 'x-form-display-field-jumbo',
-                    value: _t('Caution: Existing performance data stored for this device will be lost unless that data is reassociated with the new device ID.')
-                }, {
-                    xtype: 'fieldcontainer',
-                    margin: '0 30 14 20',
-                    defaultType: 'radiofield',
-                    layout: 'vbox',
-                    align: 'left',
-                    items: [
-                        {
-                            boxLabel: 'Reassociate existing performance data with new device ID',
-                            name: 'retainGraphData',
-                            inputValue: true,
-                            checked: true,
-                        }, {
-                            xtype: 'displayfield',
-                            margin: '0 0 20 16',
-                            width: '350px',
-                            fieldCls: 'x-form-display-field-note',
-                            value: _t('Note: This process could take some time, during which no metrics will be collected or graphed for this device.')
-                        }, {
-                            boxLabel: 'Delete existing performance data and start fresh with new device ID',
-                            name: 'retainGraphData',
-                            inputValue: false,
-                        }, {
-                            xtype: 'displayfield',
-                            fieldCls: 'x-form-display-field-note',
-                            margin: '0 0 20 16',
-                            width: '350px',
-                            value: _t('Note: Collection of new performance data will begin immediately.')
-                        }
-                    ]
+                    value: _t('Caution: Existing performance data stored for this device will be lost.')
                 }]
             });
             this.callParent([config]);


### PR DESCRIPTION
Fixes ZEN-34172.

To resolve the issue the option to migrate performance data during
device re-identifying was removed by changing of device
re-identification form.