### PR TITLE
Fix trigger form for admin/zenmanager user

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/triggers.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/triggers.js
@@ -152,6 +152,9 @@ Ext.onReady(function () {
         tab.cascade(function(){
             if (Ext.isFunction(this.disable)) {
                 this.disable();
+                if (this.xtype === 'panel') {
+                    this.addCls('x-item-disabled');
+                }
             }
         });
         tab.setDisabled(false);
@@ -161,9 +164,6 @@ Ext.onReady(function () {
         tab.cascade(function() {
             if (Ext.isFunction(this.enable)) {
                 this.enable();
-                if (this.xtype === 'panel') {
-                    this.addCls('x-item-disabled');
-                }
             }
         });
         tab.setDisabled(false);


### PR DESCRIPTION
Fixes ZEN-34136.

The issue occurred because of the mistake in the backport ZEN-33838,
which was fixed.