### PR TITLE
Fix adding MIBs during Meraki ZP installation

### DIFF
--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -235,7 +235,7 @@ class ZenMib(ZCmdBase):
                 sys.exit(1)
 
         # Verify that the target MIB organizer exists
-        if self.options.path[0] != '/':
+        if self.options.path and self.options.path[0] != '/':
             self.options.path = '/' + self.options.path
         miborgpath = "/zport/dmd/Mibs" + self.options.path
         miborg = self.dmd.unrestrictedTraverse(miborgpath, None)

--- a/Products/ZenModel/zenmib.py
+++ b/Products/ZenModel/zenmib.py
@@ -235,6 +235,8 @@ class ZenMib(ZCmdBase):
                 sys.exit(1)
 
         # Verify that the target MIB organizer exists
+        if self.options.path[0] != '/':
+            self.options.path = '/' + self.options.path
         miborgpath = "/zport/dmd/Mibs" + self.options.path
         miborg = self.dmd.unrestrictedTraverse(miborgpath, None)
         if miborg is None:


### PR DESCRIPTION
Fixes ZEN-34191.

The issue occurred because the loadPath, which means upload directory
path, for Meraki ZenPack runMibLoader was set without a leading slash.
The issue was fixed by adding corresponding verification of the MIBs
organizer path and adding the leading slash when it is required.