### PR TITLE
SRE-2609 Increase Timeout For Generating Callhome Report Directly

### DIFF
--- a/Products/ZenCallHome/transport/methods/directpost.py
+++ b/Products/ZenCallHome/transport/methods/directpost.py
@@ -17,7 +17,7 @@ from Products.ZenCallHome.transport import CallHome
 from Products.ZenCallHome.CallHomeStatus import CallHomeStatus
 
 POST_CHECKIN_URL = "https://callhome.zenoss.com/callhome/v2/post"
-_URL_TIMEOUT = 5
+_URL_TIMEOUT = 30
 
 logger = logging.getLogger("zen.callhome")
 


### PR DESCRIPTION
Callhome reports take ~8 seconds to complete on average with half of that involved with calling SalesForce. We need to increase the timeout so that callhome has enough time to generate a report and callback.