### PR TITLE
ZEN-34366: allow -replacement and -addition templates for non-ZPL dev…

### DIFF
--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -407,14 +407,13 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
                 continue
 
             template = self.getRRDTemplateByName(templateName)
+            if not template:
+                continue
             replacement = self.getRRDTemplateByName(
                 '{}-replacement'.format(templateName))
 
             if replacement and replacement not in templates:
                 templates.append(replacement)
-                #self.setZenProperty(
-                #    'zDeviceTemplates',
-                #    self.zDeviceTemplates + [replacement.titleOrId()])
             else:
                 templates.append(template)
 
@@ -423,12 +422,7 @@ class Device(ManagedEntity, Commandable, Lockable, MaintenanceWindowable,
 
             if addition and addition not in templates:
                 templates.append(addition)
-                #self.setZenProperty(
-                #    'zDeviceTemplates',
-                #    self.zDeviceTemplates + [addition.titleOrId()])
 
-            if template:
-                templates.append(template)
         return templates
 
     def getDataSourceOptions(self):

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -574,9 +574,23 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
                 order.insert(0, templateName)
 
         for name in order:
+            templates = []
             template = self.getRRDTemplateByName(name)
-            if template:
-                return [template]
+            replacement = self.getRRDTemplateByName(
+                '{}-replacement'.format(templateName))
+
+            if replacement and replacement not in templates:
+                templates.append(replacement)
+            else:
+                templates.append(template)
+
+            addition = self.getRRDTemplateByName(
+                '{}-addition'.format(templateName))
+
+            if addition and addition not in templates:
+                templates.append(addition)
+            if templates:
+                return templates
 
         return []
 

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -576,8 +576,10 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
         for name in order:
             templates = []
             template = self.getRRDTemplateByName(name)
+            if not template:
+                continue
             replacement = self.getRRDTemplateByName(
-                '{}-replacement'.format(templateName))
+                '{}-replacement'.format(name))
 
             if replacement and replacement not in templates:
                 templates.append(replacement)
@@ -585,7 +587,7 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
                 templates.append(template)
 
             addition = self.getRRDTemplateByName(
-                '{}-addition'.format(templateName))
+                '{}-addition'.format(name))
 
             if addition and addition not in templates:
                 templates.append(addition)

--- a/Products/ZenModel/MetricMixin.py
+++ b/Products/ZenModel/MetricMixin.py
@@ -141,11 +141,13 @@ class MetricMixin(object):
     def getRRDTemplates(self):
         templates = []
         defaultName = self.getRRDTemplateName()
+        default = self.getRRDTemplateByName(defaultName)
+        if not default:
+            return []
         replacement = self.getRRDTemplateByName('{}-replacement'.format(defaultName))
         if replacement:
             templates.append(replacement)
         else:
-            default = self.getRRDTemplateByName(defaultName)
             if default:
                 templates.append(default)
         addition = self.getRRDTemplateByName('{}-addition'.format(defaultName))

--- a/Products/ZenModel/MetricMixin.py
+++ b/Products/ZenModel/MetricMixin.py
@@ -139,10 +139,19 @@ class MetricMixin(object):
         return False
 
     def getRRDTemplates(self):
-        default = self.getRRDTemplateByName(self.getRRDTemplateName())
-        if not default:
-            return []
-        return [default]
+        templates = []
+        defaultName = self.getRRDTemplateName()
+        replacement = self.getRRDTemplateByName('{}-replacement'.format(defaultName))
+        if replacement:
+            templates.append(replacement)
+        else:
+            default = self.getRRDTemplateByName(defaultName)
+            if default:
+                templates.append(default)
+        addition = self.getRRDTemplateByName('{}-addition'.format(defaultName))
+        if addition:
+            templates.append(addition)
+        return templates
 
     def getRRDTemplate(self):
         try:
@@ -335,7 +344,6 @@ class MetricMixin(object):
         results = []
         if isinstance(dpnames, basestring):
             dpnames = [dpnames]
-        facade = getFacade('metric', self.dmd)
 
         # parse start and end into unix timestamps
         start, end = self._rrdAtTimeToUnix(start, end)

--- a/Products/ZenModel/tests/testRRDTemplates.py
+++ b/Products/ZenModel/tests/testRRDTemplates.py
@@ -76,9 +76,12 @@ class TestRRDTemplates(ZenModelBaseTest):
         linux = self.dmd.Devices.createOrganizer('/Server/Linux')
 
         devices.manage_addRRDTemplate('Device')
-        devices.manage_addRRDTemplate('Device-addition')
+        server.manage_addRRDTemplate('Device-addition')
         server.manage_addRRDTemplate('Device-replacement')
         linux.manage_addRRDTemplate('Device')
+        # the next two should be ignored because the base template does not exist
+        linux.manage_addRRDTemplate('nothere-additional')
+        linux.manage_addRRDTemplate('nothere-replacement')
 
         devdev = devices.createInstance('devdev')
         devdev.setZenProperty('zDeviceTemplates', ['Device'])
@@ -92,7 +95,7 @@ class TestRRDTemplates(ZenModelBaseTest):
         sertemps = map(getid, serdev.getRRDTemplates())
         lintemps = map(getid, lindev.getRRDTemplates())
 
-        devtmpls = ['/Devices/Device', '/Devices/Device-addition']
+        devtmpls = ['/Devices/Device']
         sertmpls = ['/Devices/Server/Device-replacement', '/Devices/Device-addition']
         lintmpls = ['/Devices/Server/Linux/Device', '/Devices/Device-addition']
 

--- a/Products/ZenModel/tests/testRRDTemplates.py
+++ b/Products/ZenModel/tests/testRRDTemplates.py
@@ -68,6 +68,38 @@ class TestRRDTemplates(ZenModelBaseTest):
         self.assert_('test2' not in lintemps)
         self.assert_('test3' in lintemps)
 
+    def testDeviceTemplateSelection(self):
+        # test correct selection of templates for a device
+
+        devices = self.dmd.Devices
+        server = self.dmd.Devices.createOrganizer('/Server')
+        linux = self.dmd.Devices.createOrganizer('/Server/Linux')
+
+        devices.manage_addRRDTemplate('Device')
+        devices.manage_addRRDTemplate('Device-addition')
+        server.manage_addRRDTemplate('Device-replacement')
+        linux.manage_addRRDTemplate('Device')
+
+        devdev = devices.createInstance('devdev')
+        devdev.setZenProperty('zDeviceTemplates', ['Device'])
+        serdev = devices.createInstance('serdev')
+        serdev.setZenProperty('zDeviceTemplates', ['Device'])
+        lindev = devices.createInstance('lindev')
+        lindev.setZenProperty('zDeviceTemplates', ['Device'])
+
+        getid = lambda x:'/'.join((x.getRRDPath(), x.id))
+        devtemps = map(getid, devdev.getRRDTemplates())
+        sertemps = map(getid, serdev.getRRDTemplates())
+        lintemps = map(getid, lindev.getRRDTemplates())
+
+        devtmpls = ['/Devices/Device', '/Devices/Device-addition']
+        sertmpls = ['/Devices/Server/Device-replacement', '/Devices/Device-addition']
+        lintmpls = ['/Devices/Server/Linux/Device', '/Devices/Device-addition']
+
+        self.assertEqual(devtmpls, devtemps)
+        self.assertEqual(devtmpls, sertemps)
+        self.assertEqual(devtmpls, lintemps)
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()


### PR DESCRIPTION
…ices and components.  This will require an update to ZPL's DeviceBase.getRRDTemplates() which assumes replaced templates have not already been removed from the list