### PR TITLE
Updated cProps call to use the `.items()` function of the dictionary …

### DIFF
--- a/Products/ZenModel/ZDeviceLoader.py
+++ b/Products/ZenModel/ZDeviceLoader.py
@@ -239,7 +239,7 @@ class CreateDeviceJob(Job):
 
             # Now set the custom properties
             if cProperties is not None:
-                for prop, value in cProperties:
+                for prop, value in cProperties.items():
                     self.setCustomProperty(device, prop, value)
 
             return '/'.join(device.getPhysicalPath())


### PR DESCRIPTION
…to fix the "too many items to unpack error" when attempting to load a device with cProps defined via the Device API router.