### PR TITLE
ZEN-34591: ZEN-34454 potentially causes silent zenping failure

### DIFF
--- a/Products/ZenHub/services/PingPerformanceConfig.py
+++ b/Products/ZenHub/services/PingPerformanceConfig.py
@@ -42,6 +42,7 @@ class IpAddressProxy(pb.Copyable, pb.RemoteCopy):
         ds=None,
         perfServer="localhost",
         metadata=None,
+        context=None,
     ):
         self.ip = ipunwrap(ip)
         self.ipVersion = ipVersion
@@ -70,7 +71,7 @@ class IpAddressProxy(pb.Copyable, pb.RemoteCopy):
                 dp.rrdmin,
                 dp.rrdmax,
                 metadata,
-                dp.getTags(iface),
+                dp.getTags(context),
             )
 
             self.points.append(ipdData)
@@ -145,6 +146,7 @@ class PingPerformanceConfig(CollectorConfigService):
                         ds=dsList[0],
                         perfServer=perfServer,
                         metadata=metadata,
+                        context=iface
                     )
                     monitoredIps.append(ipProxy)
 
@@ -174,6 +176,7 @@ class PingPerformanceConfig(CollectorConfigService):
                     ds=dsList[0],
                     perfServer=perfServer,
                     metadata=metadata,
+                    context=device
                 )
                 proxy.monitoredIps.append(ipProxy)
                 addedIp = True


### PR DESCRIPTION
During the ZEN-34454 fix, there was an incorrect transfer of `dp.getTags(iface)` inside the `IpAddressProxy`. 
This class isn't working with a real context `iface` just with the `title` but `dp.getTags` method requires real context.
In the fix, we passed through the new constructor arg of `IpAddressProxy`  the real context for the target method