### PR TITLE
Fix display of templates in DeviceClass details view

### DIFF
--- a/Products/ZenModel/MetricMixin.py
+++ b/Products/ZenModel/MetricMixin.py
@@ -148,8 +148,7 @@ class MetricMixin(object):
         if replacement:
             templates.append(replacement)
         else:
-            if default:
-                templates.append(default)
+            templates.append(default)
         addition = self.getRRDTemplateByName('{}-addition'.format(defaultName))
         if addition:
             templates.append(addition)

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -752,11 +752,25 @@ class DeviceFacade(TreeFacade):
     def getTemplates(self, id):
         object = self._getObject(id)
 
-        rrdTemplates = object.getRRDTemplates()
-        templateNames = [t.id for t in rrdTemplates]
+        isDeviceClass = isinstance(object, DeviceClass)
+        if isDeviceClass:
+            pythonDeviceClass = object.getPythonDeviceClass()
 
-        boundTemplates = [t for t in rrdTemplates if t.id in object.zDeviceTemplates]
-        unboundTemplates = [t for t in rrdTemplates if not (t.id in object.zDeviceTemplates)]
+        zDeviceTemplates = object.zDeviceTemplates
+
+        rrdTemplates = object.getRRDTemplates()
+
+        templateNames = []
+        boundTemplates = []
+        unboundTemplates = []
+        for rrdTemplate in rrdTemplates:
+            if isDeviceClass and not issubclass(pythonDeviceClass, rrdTemplate.getTargetPythonClass()):
+                continue
+            templateNames.append(rrdTemplate.id)
+            if rrdTemplate.id in object.zDeviceTemplates:
+                boundTemplates.append(rrdTemplate)
+            else:
+                unboundTemplates.append(rrdTemplate)
 
         # used to sort the templates
         def byTitleOrId(left, right):
@@ -764,21 +778,21 @@ class DeviceFacade(TreeFacade):
 
         for rrdTemplate in sorted(boundTemplates, byTitleOrId) + sorted(unboundTemplates, byTitleOrId):
             uid = '/'.join(rrdTemplate.getPrimaryPath())
-
             path = ''
 
             # for DeviceClasses show which are bound
             if isinstance(object, DeviceClass):
-                if rrdTemplate.id in object.zDeviceTemplates:
+                if rrdTemplate.id in zDeviceTemplates:
                     path = "%s (%s)" % (path, _t('Bound'))
                 if rrdTemplate.id + '-replacement' in templateNames:
                     path = "%s (%s)" % (path, _t('Replaced'))
 
             # if defined directly on the device do not show the path
-            if isinstance(object, Device) and object.titleOrId() in path:
+            uiPath = rrdTemplate.getUIPath()
+            if (not isDeviceClass) and object.titleOrId() in uiPath:
                 path = "%s (%s)" % (path, _t('Locally Defined'))
             else:
-                path = "%s (%s)" % (path, rrdTemplate.getUIPath())
+                path = "%s (%s)" % (path, uiPath)
             yield {'id': uid,
                    'uid': uid,
                    'path': path,

--- a/Products/Zuul/facades/devicefacade.py
+++ b/Products/Zuul/facades/devicefacade.py
@@ -753,23 +753,36 @@ class DeviceFacade(TreeFacade):
         object = self._getObject(id)
 
         rrdTemplates = object.getRRDTemplates()
+        templateNames = [t.id for t in rrdTemplates]
+
+        boundTemplates = [t for t in rrdTemplates if t.id in object.zDeviceTemplates]
+        unboundTemplates = [t for t in rrdTemplates if not (t.id in object.zDeviceTemplates)]
 
         # used to sort the templates
         def byTitleOrId(left, right):
             return cmp(left.titleOrId().lower(), right.titleOrId().lower())
 
-        for rrdTemplate in sorted(rrdTemplates, byTitleOrId):
+        for rrdTemplate in sorted(boundTemplates, byTitleOrId) + sorted(unboundTemplates, byTitleOrId):
             uid = '/'.join(rrdTemplate.getPrimaryPath())
-            # only show Bound Templates
-            path = rrdTemplate.getUIPath()
+
+            path = ''
+
+            # for DeviceClasses show which are bound
+            if isinstance(object, DeviceClass):
+                if rrdTemplate.id in object.zDeviceTemplates:
+                    path = "%s (%s)" % (path, _t('Bound'))
+                if rrdTemplate.id + '-replacement' in templateNames:
+                    path = "%s (%s)" % (path, _t('Replaced'))
 
             # if defined directly on the device do not show the path
             if isinstance(object, Device) and object.titleOrId() in path:
-                path = _t('Locally Defined')
+                path = "%s (%s)" % (path, _t('Locally Defined'))
+            else:
+                path = "%s (%s)" % (path, rrdTemplate.getUIPath())
             yield {'id': uid,
                    'uid': uid,
                    'path': path,
-                   'text': '%s (%s)' % (rrdTemplate.titleOrId(), path),
+                   'text': '%s %s' % (rrdTemplate.titleOrId(), path),
                    'leaf': True
                    }
 


### PR DESCRIPTION
Fix display of templates in DeviceClass details view so that all available templates are displayed, but bound templates are marked and displayed at the top of the list, and replaced templates are also marked.