### PR TITLE
Add model API for Config Cache components

### DIFF
--- a/Products/ZenUI3/browser/modelapi/configure.zcml
+++ b/Products/ZenUI3/browser/modelapi/configure.zcml
@@ -129,4 +129,11 @@
         permission="zenoss.Common"
         />
 
+    <browser:view
+        class=".modelapi.ConfigCacheDaemons"
+        name="ConfigCacheDaemons"
+        for="Products.ZenModel.interfaces.IDataRoot"
+        permission="zenoss.Common"
+        />
+
 </configure>

--- a/Products/ZenUI3/browser/modelapi/modelapi.py
+++ b/Products/ZenUI3/browser/modelapi/modelapi.py
@@ -391,3 +391,15 @@ class Memcached(BaseApiView):
         memcacheds = self._getServiceInstances('memcached')
         memcacheds += self._getServiceInstances('memcached-session')
         return memcacheds
+
+class ConfigCacheDaemons(BaseApiView):
+    """
+    This view emits info for configcache services: invalidator, builders, and manager
+    """
+    @property
+    def _services(self):
+        return (
+            ('ConfigCache-Invalidators', 'invalidator'),
+            ('ConfigCache-Builders', 'builder'),
+            ('ConfigCache-Managers', 'manager'),
+        )


### PR DESCRIPTION
Implements ZEN-34675.

Added model API browser view for Config Cache components. 
It needs for RMMonitor ZP to be able to model these components.