### PR TITLE
Change configcache modelapi response keys

### DIFF
--- a/Products/ZenUI3/browser/modelapi/modelapi.py
+++ b/Products/ZenUI3/browser/modelapi/modelapi.py
@@ -399,7 +399,7 @@ class ConfigCacheDaemons(BaseApiView):
     @property
     def _services(self):
         return (
-            ('ConfigCache-Invalidators', 'invalidator'),
-            ('ConfigCache-Builders', 'builder'),
-            ('ConfigCache-Managers', 'manager'),
+            ('configCacheInvalidators', 'invalidator'),
+            ('configCacheBuilders', 'builder'),
+            ('configCacheManagers', 'manager'),
         )


### PR DESCRIPTION
Implements ZEN-34675.

To avoid JS errors and unnecessary code on the RM Monitor ZP side the configcahe response keys are corrected.