### PR TITLE
Add zDeviceConfigMinimumTTL property.

### DIFF
--- a/Products/ZenCollector/configcache/cache/model.py
+++ b/Products/ZenCollector/configcache/cache/model.py
@@ -95,6 +95,17 @@ class _ConfigStatus(object):
                 return NotImplemented
             return self.updated == other.updated
 
+    class Retired(object):
+        """The cofiguration is retired, but not yet expired."""
+
+        def __init__(self, ts):
+            self.updated = ts
+
+        def __eq__(self, other):
+            if not isinstance(other, _ConfigStatus.Retired):
+                return NotImplemented
+            return self.updated == other.updated
+
     class Expired(object):
         """The configuration has expired."""
 

--- a/Products/ZenCollector/configcache/tests/test_propertymap.py
+++ b/Products/ZenCollector/configcache/tests/test_propertymap.py
@@ -1,6 +1,6 @@
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -14,8 +14,8 @@ from unittest import TestCase
 from ..utils.propertymap import DevicePropertyMap
 
 
-class EmptyBestMatchMapTest(TestCase):
-    """Test an empty BestMatchMap object."""
+class EmptyDevicePropertyMapTest(TestCase):
+    """Test an empty DevicePropertyMap object."""
 
     def setUp(t):
         t.bmm = DevicePropertyMap({}, None)
@@ -30,8 +30,8 @@ class EmptyBestMatchMapTest(TestCase):
         t.assertIsNone(t.bmm.smallest_value())
 
 
-class BestMatchMapTest(TestCase):
-    """Test a BestMatchMap object."""
+class DevicePropertyMapTest(TestCase):
+    """Test a DevicePropertyMap object."""
 
     mapping = {
         "/zport/dmd/Devices": 10,
@@ -49,7 +49,7 @@ class BestMatchMapTest(TestCase):
     def tearDown(t):
         del t.bmm
 
-    def test_get_root(t):
+    def test_minimal_match(t):
         value = t.bmm.get("/zport/dmd/Devices/Server-stuff/devices/dev2")
         t.assertEqual(10, value)
 
@@ -63,7 +63,7 @@ class BestMatchMapTest(TestCase):
         value = t.bmm.get("/zport/dmd/Devices/Server/Linux/devices/dev3")
         t.assertEqual(11, value)
 
-    def test_get_too_short_request(t):
+    def test_no_match(t):
         value = t.bmm.get("/Devices")
         t.assertEqual(t._default, value)
 

--- a/Products/ZenCollector/configcache/tests/test_propertymap_makers.py
+++ b/Products/ZenCollector/configcache/tests/test_propertymap_makers.py
@@ -1,0 +1,276 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+from Products.ZenTestCase.BaseTestCase import BaseTestCase
+
+from ..utils.constants import Constants
+from ..utils.propertymap import DevicePropertyMap
+
+
+class TestDevicePropertyMapTTLMakers(BaseTestCase):
+
+    ttl_overrides = {
+        "Server/Linux": 16320,
+        "Server/Linux/linux0": 68000,
+        "Power": 8000,
+        "Network": 32000,
+    }
+
+    min_ttl_overrides = {
+        "Server/Linux/linux0": 300,
+    }
+
+    def afterSetUp(t):
+        super(TestDevicePropertyMapTTLMakers, t).afterSetUp()
+
+        t.dmd.Devices.createOrganizer("/Server/Linux")
+        t.dmd.Devices.createOrganizer("/Server/Cmd")
+        t.dmd.Devices.createOrganizer("/Network")
+        t.dmd.Devices.createOrganizer("/Power")
+
+        t.dmd.Devices.Server.Linux.setZenProperty(
+            Constants.time_to_live_id, t.ttl_overrides["Server/Linux"]
+        )
+        t.dmd.Devices.Power.setZenProperty(
+            Constants.time_to_live_id, t.ttl_overrides["Power"]
+        )
+        t.dmd.Devices.Network.setZenProperty(
+            Constants.time_to_live_id, t.ttl_overrides["Network"]
+        )
+
+        t.linux_dev = t.dmd.Devices.Server.Linux.createInstance("linux0")
+        t.linux_dev.setZenProperty(
+            Constants.time_to_live_id, t.ttl_overrides["Server/Linux/linux0"]
+        )
+        t.linux_dev.setZenProperty(
+            Constants.minimum_time_to_live_id,
+            t.min_ttl_overrides["Server/Linux/linux0"],
+        )
+
+        t.cmd_dev = t.dmd.Devices.Server.Cmd.createInstance("cmd0")
+
+    def test_make_ttl_map(t):
+        ttlmap = DevicePropertyMap.make_ttl_map(t.dmd.Devices)
+
+        pathid = t.dmd.Devices.Server.getPrimaryId()
+        expected = Constants.time_to_live_value
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Linux.getPrimaryId()
+        expected = t.ttl_overrides["Server/Linux"]
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Cmd.getPrimaryId()
+        expected = Constants.time_to_live_value
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Power.getPrimaryId()
+        expected = t.ttl_overrides["Power"]
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Network.getPrimaryId()
+        expected = t.ttl_overrides["Network"]
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.linux_dev.getPrimaryId()
+        expected = t.ttl_overrides["Server/Linux/linux0"]
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.cmd_dev.getPrimaryId()
+        expected = Constants.time_to_live_value
+        actual = ttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+    def test_make_min_ttl_map(t):
+        minttlmap = DevicePropertyMap.make_minimum_ttl_map(t.dmd.Devices)
+
+        pathid = t.dmd.Devices.Server.getPrimaryId()
+        expected = Constants.minimum_time_to_live_value
+        actual = minttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.linux_dev.getPrimaryId()
+        expected = t.min_ttl_overrides["Server/Linux/linux0"]
+        actual = minttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.cmd_dev.getPrimaryId()
+        expected = Constants.minimum_time_to_live_value
+        actual = minttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+    def test_bad_min_ttl_value(t):
+        bad_minttl_value = Constants.time_to_live_value + 100
+        t.cmd_dev.setZenProperty(
+            Constants.minimum_time_to_live_id,
+            bad_minttl_value,
+        )
+
+        minttlmap = DevicePropertyMap.make_minimum_ttl_map(t.dmd.Devices)
+
+        pathid = t.cmd_dev.getPrimaryId()
+        expected = Constants.time_to_live_value
+        actual = minttlmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+
+class TestDevicePropertyMapPendingTimeout(BaseTestCase):
+
+    pending_overrides = {
+        "Server/Linux": 500,
+        "Server/Linux/linux0": 600,
+        "Power": 800,
+        "Network": 850,
+    }
+
+    def afterSetUp(t):
+        super(TestDevicePropertyMapPendingTimeout, t).afterSetUp()
+
+        t.dmd.Devices.createOrganizer("/Server/Linux")
+        t.dmd.Devices.createOrganizer("/Server/Cmd")
+        t.dmd.Devices.createOrganizer("/Network")
+        t.dmd.Devices.createOrganizer("/Power")
+
+        t.dmd.Devices.Server.Linux.setZenProperty(
+            Constants.pending_timeout_id, t.pending_overrides["Server/Linux"]
+        )
+        t.dmd.Devices.Power.setZenProperty(
+            Constants.pending_timeout_id, t.pending_overrides["Power"]
+        )
+        t.dmd.Devices.Network.setZenProperty(
+            Constants.pending_timeout_id, t.pending_overrides["Network"]
+        )
+
+        t.linux_dev = t.dmd.Devices.Server.Linux.createInstance("linux0")
+        t.linux_dev.setZenProperty(
+            Constants.pending_timeout_id,
+            t.pending_overrides["Server/Linux/linux0"],
+        )
+
+        t.cmd_dev = t.dmd.Devices.Server.Cmd.createInstance("cmd0")
+
+    def test_make_pending_timeout_map(t):
+        pendingmap = DevicePropertyMap.make_pending_timeout_map(t.dmd.Devices)
+
+        pathid = t.dmd.Devices.Server.getPrimaryId()
+        expected = Constants.pending_timeout_value
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Linux.getPrimaryId()
+        expected = t.pending_overrides["Server/Linux"]
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Cmd.getPrimaryId()
+        expected = Constants.pending_timeout_value
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Power.getPrimaryId()
+        expected = t.pending_overrides["Power"]
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Network.getPrimaryId()
+        expected = t.pending_overrides["Network"]
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.linux_dev.getPrimaryId()
+        expected = t.pending_overrides["Server/Linux/linux0"]
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.cmd_dev.getPrimaryId()
+        expected = Constants.pending_timeout_value
+        actual = pendingmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+
+class TestDevicePropertyMapBuildTimeout(BaseTestCase):
+
+    build_overrides = {
+        "Server/Linux": 500,
+        "Server/Linux/linux0": 600,
+        "Power": 800,
+        "Network": 850,
+    }
+
+    def afterSetUp(t):
+        super(TestDevicePropertyMapBuildTimeout, t).afterSetUp()
+
+        t.dmd.Devices.createOrganizer("/Server/Linux")
+        t.dmd.Devices.createOrganizer("/Server/Cmd")
+        t.dmd.Devices.createOrganizer("/Network")
+        t.dmd.Devices.createOrganizer("/Power")
+
+        t.dmd.Devices.Server.Linux.setZenProperty(
+            Constants.build_timeout_id, t.build_overrides["Server/Linux"]
+        )
+        t.dmd.Devices.Power.setZenProperty(
+            Constants.build_timeout_id, t.build_overrides["Power"]
+        )
+        t.dmd.Devices.Network.setZenProperty(
+            Constants.build_timeout_id, t.build_overrides["Network"]
+        )
+
+        t.linux_dev = t.dmd.Devices.Server.Linux.createInstance("linux0")
+        t.linux_dev.setZenProperty(
+            Constants.build_timeout_id,
+            t.build_overrides["Server/Linux/linux0"],
+        )
+
+        t.cmd_dev = t.dmd.Devices.Server.Cmd.createInstance("cmd0")
+
+    def test_make_build_timeout_map(t):
+        buildmap = DevicePropertyMap.make_build_timeout_map(t.dmd.Devices)
+
+        pathid = t.dmd.Devices.Server.getPrimaryId()
+        expected = Constants.build_timeout_value
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Linux.getPrimaryId()
+        expected = t.build_overrides["Server/Linux"]
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Server.Cmd.getPrimaryId()
+        expected = Constants.build_timeout_value
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Power.getPrimaryId()
+        expected = t.build_overrides["Power"]
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.dmd.Devices.Network.getPrimaryId()
+        expected = t.build_overrides["Network"]
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.linux_dev.getPrimaryId()
+        expected = t.build_overrides["Server/Linux/linux0"]
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)
+
+        pathid = t.cmd_dev.getPrimaryId()
+        expected = Constants.build_timeout_value
+        actual = buildmap.get(pathid)
+        t.assertEqual(expected, actual)

--- a/Products/ZenCollector/configcache/utils/__init__.py
+++ b/Products/ZenCollector/configcache/utils/__init__.py
@@ -9,28 +9,17 @@
 
 from __future__ import absolute_import
 
-from .propertymap import DevicePropertyMap
+from .constants import Constants
 from .dispatcher import BuildConfigTaskDispatcher
 from .pollers import RelStorageInvalidationPoller
+from .propertymap import DevicePropertyMap
 from .services import getConfigServices
-
-
-class Constants(object):
-
-    build_timeout_id = "zDeviceConfigBuildTimeout"
-    pending_timeout_id = "zDeviceConfigPendingTimeout"
-    time_to_live_id = "zDeviceConfigTTL"
-
-    # Default values
-    build_timeout_value = 7200
-    pending_timeout_value = 7200
-    time_to_live_value = 43200
 
 
 __all__ = (
     "BuildConfigTaskDispatcher",
     "Constants",
     "DevicePropertyMap",
-    "RelStorageInvalidationPoller",
     "getConfigServices",
+    "RelStorageInvalidationPoller",
 )

--- a/Products/ZenCollector/configcache/utils/constants.py
+++ b/Products/ZenCollector/configcache/utils/constants.py
@@ -1,0 +1,22 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+
+class Constants(object):
+
+    build_timeout_id = "zDeviceConfigBuildTimeout"
+    pending_timeout_id = "zDeviceConfigPendingTimeout"
+    time_to_live_id = "zDeviceConfigTTL"
+    minimum_time_to_live_id = "zDeviceConfigMinimumTTL"
+
+    # Default values
+    build_timeout_value = 7200
+    pending_timeout_value = 7200
+    time_to_live_value = 43200
+    minimum_time_to_live_value = 0

--- a/Products/ZenCollector/configcache/utils/services.py
+++ b/Products/ZenCollector/configcache/utils/services.py
@@ -15,7 +15,6 @@ import itertools
 import pathlib2 as pathlib
 
 import Products
-import ZenPacks
 
 from Products.ZenCollector.services.config import CollectorConfigService
 
@@ -87,6 +86,10 @@ def getConfigServices():
     :returns: Tuple of configuration service classes
     :rtype: tuple[CollectorConfigService]
     """
+    # defer import ZenPacks until here because it doesn't exist during
+    # an image build.
+    import ZenPacks
+
     search_paths = (
         pathlib.Path(p)
         for p in itertools.chain(Products.__path__, ZenPacks.__path__)

--- a/Products/ZenModel/migrate/addConfigCacheProperties.py
+++ b/Products/ZenModel/migrate/addConfigCacheProperties.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import
 
+from Products.ZenCollector.configcache.utils import Constants
 from Products.ZenRelations.zPropertyCategory import setzPropertyCategory
 
 from . import Migrate
@@ -17,18 +18,32 @@ from Products.ZenModel.ZMigrateVersion import SCHEMA_MAJOR, SCHEMA_MINOR, SCHEMA
 
 _properties = (
     (
-        ("zDeviceConfigTTL", 43200),
+        (Constants.time_to_live_id, Constants.time_to_live_value),
         {
             "type": "int",
             "label": "Device configuration expiration",
             "description": (
-                "The number of seconds to wait before rebuilding a "
+                "The maximum number of seconds to wait before rebuilding a "
                 "device configuration."
             ),
-        }
+        },
     ),
     (
-        ("zDeviceConfigBuildTimeout", 7200),
+        (
+            Constants.minimum_time_to_live_id,
+            Constants.minimum_time_to_live_value,
+        ),
+        {
+            "type": "int",
+            "label": "Device configuration pre-expiration window",
+            "description": (
+                "The number of seconds the configuration is protected "
+                "from being rebuilt."
+            ),
+        },
+    ),
+    (
+        (Constants.build_timeout_id, Constants.build_timeout_value),
         {
             "type": "int",
             "label": "Device configuration build timeout",
@@ -36,10 +51,10 @@ _properties = (
                 "The number of seconds allowed for building a device "
                 "configuration."
             ),
-        }
+        },
     ),
     (
-        ("zDeviceConfigPendingTimeout", 7200),
+        (Constants.pending_timeout_id, Constants.pending_timeout_value),
         {
             "type": "int",
             "label": "Device configuration build queued timeout",
@@ -47,7 +62,7 @@ _properties = (
                 "The number of seconds a device configuration build may be "
                 "queued before a timeout."
             ),
-        }
+        },
     ),
 )
 

--- a/Products/ZenRelations/ZenPropertyManager.py
+++ b/Products/ZenRelations/ZenPropertyManager.py
@@ -65,8 +65,16 @@ Z_PROPERTIES = [
         43200,
         "int",
         "Device configuration expiration",
-        "The number of seconds to wait before rebuilding a "
+        "The maximum number of seconds to wait before rebuilding a "
         "device configuration."
+    ),
+    (
+        "zDeviceConfigMinimumTTL",
+        0,
+        "int",
+        "Device configuration pre-expiration window",
+        "The number of seconds the configuration is protected "
+        "from being rebuilt."
     ),
     # zPythonClass maps device class to python classs (separate from device
     # class name)

--- a/Products/ZenRelations/zPropertyCategory.py
+++ b/Products/ZenRelations/zPropertyCategory.py
@@ -45,6 +45,7 @@ MAPPINGS = {
     # Configuration Cache
     # -------------------
     "zDeviceConfigTTL": "Config Cache",
+    "zDeviceConfigMinimumTTL": "Config Cache",
     "zDeviceConfigBuildTimeout": "Config Cache",
     "zDeviceConfigPendingTimeout": "Config Cache",
     #


### PR DESCRIPTION
This zproperty specifies the number of seconds a configuration must exist before it can be expired.

ZEN-34656