### PR TITLE
Fix ImportError for zenvsphere daemon

### DIFF
--- a/Products/ZenCollector/scheduler/__init__.py
+++ b/Products/ZenCollector/scheduler/__init__.py
@@ -10,6 +10,11 @@
 from __future__ import absolute_import
 
 from .scheduler import Scheduler, TaskScheduler
+from .task import CallableTaskFactory, CallableTask
 
-
-__all__ = ("Scheduler", "TaskScheduler")
+__all__ = (
+    "Scheduler",
+    "TaskScheduler",
+    "CallableTaskFactory",
+    "CallableTask"
+)


### PR DESCRIPTION
Fixes ZEN-34719.

Added CallableTaskFactory and CallableTask classes to scheduler __init__.py