### PR TITLE
fix: scheduler removeTasks requires a sequence.

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -705,7 +705,9 @@ class CollectorDaemon(RRDDaemon):
                 )
                 for taskToRemove in tasksToRemove
             }
-            self._scheduler.removeTasks(task.name for task in tasksToRemove)
+            self._scheduler.removeTasks(
+                tuple(task.name for task in tasksToRemove)
+            )
             self._configListener.updated(cfg)
         else:
             self._devices.add(configId)

--- a/Products/ZenCollector/scheduler/scheduler.py
+++ b/Products/ZenCollector/scheduler/scheduler.py
@@ -332,7 +332,7 @@ class TaskScheduler(object):
         Remove tasks
         """
         if not isinstance(taskNames, Sequence):
-            raise ValueError("argument is not a sequence")
+            taskNames = tuple(taskNames)
 
         doomedTasks = []
         # child ids are any task that are children of the current task being


### PR DESCRIPTION
The TaskScheduler removeTasks method requires its argument to be a sequence, like a list or tuple.

ZEN-34717