### PR TITLE
fix: avoid race condition involving device config loader

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -202,7 +202,13 @@ class CollectorDaemon(RRDDaemon):
         # from zenhub
         self.encryptionKeyInitialized = False
 
-        self._deviceloader = None
+        # Define _deviceloader to avoid race condition
+        # with task stats recording.
+        self._deviceloader = DeviceConfigLoader(
+            self.options,
+            self._configProxy,
+            self._deviceConfigCallback,
+        )
         self._deviceloadertask = None
         self._deviceloadertaskd = None
 
@@ -369,21 +375,16 @@ class CollectorDaemon(RRDDaemon):
         self._maintenanceCycle.start()
 
     def _startDeviceConfigLoader(self):
-        self.log.info(
-            "running the device config loader every %d seconds",
-            self._device_config_update_interval,
-        )
-        self._deviceloader = DeviceConfigLoader(
-            self.options,
-            self._configProxy,
-            self._deviceConfigCallback,
-        )
         self._deviceloadertask = task.LoopingCall(self._deviceloader)
         self._deviceloadertaskd = self._deviceloadertask.start(
             self._device_config_update_interval
         )
         reactor.addSystemEventTrigger(
             "before", "shutdown", self._deviceloadertask.stop, "before"
+        )
+        self.log.info(
+            "started receiving device config changes  interval=%d",
+            self._device_config_update_interval,
         )
 
     def _startTaskStatsLogging(self):
@@ -395,12 +396,12 @@ class CollectorDaemon(RRDDaemon):
         self._taskstatsloggerd = self._taskstatslogger.start(
             self.options.logTaskStats, now=False
         )
-        self.log.debug(
-            "started logging task statistics  interval=%d",
-            self.options.logTaskStats,
-        )
         reactor.addSystemEventTrigger(
             "before", "shutdown", self._taskstatslogger.stop, "before"
+        )
+        self.log.info(
+            "started logging task statistics  interval=%d",
+            self.options.logTaskStats,
         )
 
     @defer.inlineCallbacks

--- a/Products/ZenHub/PBDaemon.py
+++ b/Products/ZenHub/PBDaemon.py
@@ -414,7 +414,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
         self.__eventclient.start()
         self.__recordQueuedEventsCountLoop.start(2.0, now=False)
         self.__eventclient.sendEvent(self.startEvent)
-        self.log.debug("started event client")
+        self.log.info("started event client")
 
     def _setup_stats_recording(self):
         loop = task.LoopingCall(self.postStatistics)
@@ -433,7 +433,7 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
         reactor.addSystemEventTrigger(
             "before", "shutdown", self._metrologyReporter.stop
         )
-        self.log.debug("started statistics recording task")
+        self.log.info("started statistics recording task")
 
     def postStatisticsImpl(self):
         pass


### PR DESCRIPTION
The PBDaemon class started a task that was accessing an attribute of the DeviceConfigLoader before the DeviceConfigLoader instance was created. This race condition was fixed by moving the creation of the DeviceConfigLoader instance to an earlier point in CollectorDaemon's startup.

ZEN-34705