### PR TITLE
Fix collection for zenvsphere, zenperfsnmp services

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -451,7 +451,7 @@ class CollectorDaemon(RRDDaemon):
         timestamp="N",
         min="U",
         max="U",
-        threshEventData=None,
+        threshEventData={},
         deviceId=None,
         contextUUID=None,
         deviceUUID=None,
@@ -531,7 +531,7 @@ class CollectorDaemon(RRDDaemon):
         timestamp="N",
         min="U",
         max="U",
-        threshEventData=None,
+        threshEventData={},
         metadata=None,
         extraTags=None,
     ):


### PR DESCRIPTION
Fixes ZEN-34655.

zenvsphere and zenperfsnmp do not set the threshEventData attribute. Therefore, writeMetric uses the default value for this attribute which is None. This causes the TypeError during the collection The default value for threshEventData is set to empty dictionary.