### PR TITLE
fix: correctly support building configs for new devices

### DIFF
--- a/Products/ZenCollector/configcache/cache/model.py
+++ b/Products/ZenCollector/configcache/cache/model.py
@@ -11,33 +11,33 @@ from __future__ import absolute_import, print_function
 
 import attr
 
-from attr.validators import instance_of
+from attr.validators import instance_of, optional
 
 from Products.ZenCollector.services.config import DeviceProxy
 
 
 @attr.s(frozen=True, slots=True)
 class CacheQuery(object):
-    service = attr.ib(validator=[instance_of(str)], default="*")
-    monitor = attr.ib(validator=[instance_of(str)], default="*")
-    device = attr.ib(validator=[instance_of(str)], default="*")
+    service = attr.ib(validator=instance_of(str), default="*")
+    monitor = attr.ib(validator=instance_of(str), default="*")
+    device = attr.ib(validator=instance_of(str), default="*")
 
 
 @attr.s(frozen=True, slots=True)
 class CacheKey(object):
-    service = attr.ib(validator=[instance_of(str)])
-    monitor = attr.ib(validator=[instance_of(str)])
-    device = attr.ib(validator=[instance_of(str)])
+    service = attr.ib(validator=instance_of(str))
+    monitor = attr.ib(validator=instance_of(str))
+    device = attr.ib(validator=instance_of(str))
 
 
 @attr.s(slots=True)
 class CacheRecord(object):
     key = attr.ib(
-        validator=[instance_of(CacheKey)], on_setattr=attr.setters.NO_OP
+        validator=instance_of(CacheKey), on_setattr=attr.setters.NO_OP
     )
-    uid = attr.ib(validator=[instance_of(str)], on_setattr=attr.setters.NO_OP)
-    updated = attr.ib(validator=[instance_of(float)])
-    config = attr.ib(validator=[instance_of(DeviceProxy)])
+    uid = attr.ib(validator=instance_of(str), on_setattr=attr.setters.NO_OP)
+    updated = attr.ib(validator=instance_of(float))
+    config = attr.ib(validator=instance_of(DeviceProxy))
 
     @classmethod
     def make(cls, svc, mon, dev, uid, updated, config):
@@ -60,8 +60,12 @@ class CacheRecord(object):
 class _Status(object):
     """Base class for status classes."""
 
-    key = attr.ib(validator=[instance_of(CacheKey)])
-    uid = attr.ib(validator=[instance_of(str)])
+    key = attr.ib(validator=instance_of(CacheKey))
+    uid = attr.ib(validator=optional(instance_of(str)))
+
+    @property
+    def has_config(self):
+        return self.uid is not None
 
 
 class _ConfigStatus(object):
@@ -73,31 +77,31 @@ class _ConfigStatus(object):
     class Current(_Status):
         """The configuration is current."""
 
-        updated = attr.ib(validator=[instance_of(float)])
+        updated = attr.ib(validator=instance_of(float))
 
     @attr.s(slots=True, frozen=True, repr_ns="ConfigStatus")
     class Retired(_Status):
         """The cofiguration is retired, but not yet expired."""
 
-        updated = attr.ib(validator=[instance_of(float)])
+        retired = attr.ib(validator=instance_of(float))
 
     @attr.s(slots=True, frozen=True, repr_ns="ConfigStatus")
     class Expired(_Status):
         """The configuration has expired."""
 
-        expired = attr.ib(validator=[instance_of(float)])
+        expired = attr.ib(validator=instance_of(float))
 
     @attr.s(slots=True, frozen=True, repr_ns="ConfigStatus")
     class Pending(_Status):
         """The configuration is waiting for a rebuild."""
 
-        submitted = attr.ib(validator=[instance_of(float)])
+        submitted = attr.ib(validator=instance_of(float))
 
     @attr.s(slots=True, frozen=True, repr_ns="ConfigStatus")
     class Building(_Status):
         """The configuration is rebuilding."""
 
-        started = attr.ib(validator=[instance_of(float)])
+        started = attr.ib(validator=instance_of(float))
 
     def __contains__(self, value):
         return isinstance(

--- a/Products/ZenCollector/configcache/cli.py
+++ b/Products/ZenCollector/configcache/cli.py
@@ -168,11 +168,11 @@ def _format_status(status):
     if isinstance(status, ConfigStatus.Current):
         return "current since {}".format(_format_date(status.updated))
     elif isinstance(status, ConfigStatus.Retired):
-        return "retired"
+        return "retired since {}".format(_format_date(status.retired))
     elif isinstance(status, ConfigStatus.Expired):
-        return "expired"
+        return "expired since {}".format(_format_date(status.expired))
     elif isinstance(status, ConfigStatus.Pending):
-        return "build request submitted {}".format(
+        return "waiting to build since {}".format(
             _format_date(status.submitted)
         )
     elif isinstance(status, ConfigStatus.Building):

--- a/Products/ZenCollector/configcache/propertymap.py
+++ b/Products/ZenCollector/configcache/propertymap.py
@@ -44,7 +44,7 @@ class DevicePropertyMap(object):
                 obj,
                 Constants.minimum_time_to_live_id,
                 Constants.minimum_time_to_live_value,
-                _getZDeviceConfigMinimumTTL,
+                _getZProperty,
             ),
             Constants.minimum_time_to_live_value,
         )
@@ -138,19 +138,3 @@ def _getZProperty(obj, propname, default):
     if value is None:
         return default
     return value
-
-
-def _getZDeviceConfigMinimumTTL(obj, propname, default):
-    """
-    Compares zDeviceConfigTTL and zDeviceConfigMinimumTTL and
-    returns the lesser of the two.
-    """
-    ttl = _getZProperty(
-        obj, Constants.time_to_live_id, Constants.time_to_live_value
-    )
-    minttl = _getZProperty(
-        obj,
-        Constants.minimum_time_to_live_id,
-        Constants.minimum_time_to_live_value,
-    )
-    return minttl if minttl < ttl else ttl

--- a/Products/ZenCollector/configcache/tests/test_propertymap_makers.py
+++ b/Products/ZenCollector/configcache/tests/test_propertymap_makers.py
@@ -113,17 +113,16 @@ class TestDevicePropertyMapTTLMakers(BaseTestCase):
         actual = minttlmap.get(pathid)
         t.assertEqual(expected, actual)
 
-    def test_bad_min_ttl_value(t):
-        bad_minttl_value = Constants.time_to_live_value + 100
+    def test_large_min_ttl_value(t):
+        minttl_value = Constants.time_to_live_value + 100
         t.cmd_dev.setZenProperty(
-            Constants.minimum_time_to_live_id,
-            bad_minttl_value,
+            Constants.minimum_time_to_live_id, minttl_value
         )
 
         minttlmap = DevicePropertyMap.make_minimum_ttl_map(t.dmd.Devices)
 
         pathid = t.cmd_dev.getPrimaryId()
-        expected = Constants.time_to_live_value
+        expected = Constants.time_to_live_value + 100
         actual = minttlmap.get(pathid)
         t.assertEqual(expected, actual)
 

--- a/Products/ZenCollector/configcache/tests/test_storage.py
+++ b/Products/ZenCollector/configcache/tests/test_storage.py
@@ -83,6 +83,52 @@ class EmptyConfigStoreTest(TestCase):
             t.store.search("blargh")
 
 
+class NoConfigTest(TestCase):
+    """Test statuses when no config is present."""
+
+    layer = RedisLayer
+
+    key = CacheKey("a", "b", "c")
+    now = 12345.0
+
+    def setUp(t):
+        t.store = ConfigStore(t.layer.redis)
+
+    def tearDown(t):
+        del t.store
+
+    def test_current_status(t):
+        t.assertIsNone(next(t.store.get_status(t.key), None))
+
+    def test_search_with_status(t):
+        t.store.set_pending((t.key, t.now))
+        t.assertEqual(0, len(tuple(t.store.search())))
+
+    def test_retired(t):
+        expected = ConfigStatus.Retired(t.key, None, t.now)
+        t.store.set_retired((t.key, t.now))
+        status = next(t.store.get_status(t.key), None)
+        t.assertEqual(expected, status)
+
+    def test_expired(t):
+        expected = ConfigStatus.Expired(t.key, None, t.now)
+        t.store.set_expired((t.key, t.now))
+        status = next(t.store.get_status(t.key), None)
+        t.assertEqual(expected, status)
+
+    def test_pending(t):
+        expected = ConfigStatus.Pending(t.key, None, t.now)
+        t.store.set_pending((t.key, t.now))
+        status = next(t.store.get_status(t.key), None)
+        t.assertEqual(expected, status)
+
+    def test_building(t):
+        expected = ConfigStatus.Building(t.key, None, t.now)
+        t.store.set_building((t.key, t.now))
+        status = next(t.store.get_status(t.key), None)
+        t.assertEqual(expected, status)
+
+
 class _BaseTest(TestCase):
     # Base class to share setup code
 
@@ -390,505 +436,592 @@ class ConfigStoreGetNewerTest(_BaseTest):
         t.assertEqual(t.record2.updated, status.updated)
 
 
-class TestRetiredStatus(_BaseTest):
+class SetStatusOnceTest(_BaseTest):
     """
-    Test APIs regarding the ConfigStatus.Retired status.
-    """
-
-    def test_set_retired(t):
-        t.store.add(t.record1)
-        expected = (t.record1.key,)
-
-        actual = t.store.set_retired(t.record1.key)
-        t.assertTupleEqual(expected, actual)
-
-    def test_set_retired_twice(t):
-        t.store.add(t.record1)
-        expected = ()
-
-        t.store.set_retired(t.record1.key)
-        actual = t.store.set_retired(t.record1.key)
-        t.assertTupleEqual(expected, actual)
-
-    def test_retired_status(t):
-        t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Retired)
-        t.assertEqual(status.updated, t.record1.updated)
-
-    def test_get_retired(t):
-        t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
-
-        result = tuple(t.store.get_retired())
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Retired)
-        t.assertEqual(status.updated, t.record1.updated)
-
-
-class TestExpiredStatus(_BaseTest):
-    """
-    Test APIs regarding the ConfigStatus.Expired status.
+    Test the behavior when a set_<status> method is called once.
     """
 
-    def test_set_expired(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 500
+    def test_retired_once(t):
+        ts = t.record1.updated + 100
+        expected = ConfigStatus.Retired(t.record1.key, None, ts)
+        t.store.set_retired((t.record1.key, ts))
 
-        expected = (t.record1.key,)
-        actual = t.store.set_expired((t.record1.key, ts))
-        t.assertTupleEqual(expected, actual)
+        actual = next(t.store.get_retired(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
 
-    def test_set_expired_twice(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 500
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
 
-        expected = ()
-
-        t.store.set_expired((t.record1.key, ts))
-        actual = t.store.set_expired((t.record1.key, ts))
-        t.assertTupleEqual(expected, actual)
-
-    def test_expired_status(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 500
+    def test_expired_once(t):
+        ts = t.record1.updated + 100
+        expected = ConfigStatus.Expired(t.record1.key, None, ts)
         t.store.set_expired((t.record1.key, ts))
 
-        result = tuple(t.store.get_status(t.record1.key))
+        actual = next(t.store.get_expired(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
 
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+    def test_pending_once(t):
+        ts = t.record1.updated + 100
+        expected = ConfigStatus.Pending(t.record1.key, None, ts)
+        t.store.set_pending((t.record1.key, ts))
+
+        actual = next(t.store.get_pending(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+    def test_building_once(t):
+        ts = t.record1.updated + 100
+        expected = ConfigStatus.Building(t.record1.key, None, ts)
+        t.store.set_building((t.record1.key, ts))
+
+        actual = next(t.store.get_building(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+
+
+class SetStatusTwiceTest(_BaseTest):
+    """
+    Test the behavior when a set_<status> method is called twice
+    with different timestamp values.
+    """
+
+    def test_retired_twice(t):
+        ts1 = t.record1.updated + 100
+        ts2 = t.record1.updated + 200
+        expected = ConfigStatus.Retired(t.record1.key, None, ts2)
+        t.store.set_retired((t.record1.key, ts1))
+        t.store.set_retired((t.record1.key, ts2))
+
+        actual = next(t.store.get_retired(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+    def test_expired_twice(t):
+        ts1 = t.record1.updated + 100
+        ts2 = t.record1.updated + 200
+        expected = ConfigStatus.Expired(t.record1.key, None, ts2)
+        t.store.set_expired((t.record1.key, ts1))
+        t.store.set_expired((t.record1.key, ts2))
+
+        actual = next(t.store.get_expired(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+    def test_pending_twice(t):
+        ts1 = t.record1.updated + 100
+        ts2 = t.record1.updated + 200
+        expected = ConfigStatus.Pending(t.record1.key, None, ts2)
+        t.store.set_pending((t.record1.key, ts1))
+        t.store.set_pending((t.record1.key, ts2))
+
+        actual = next(t.store.get_pending(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+    def test_building_twice(t):
+        ts1 = t.record1.updated + 100
+        ts2 = t.record1.updated + 200
+        expected = ConfigStatus.Building(t.record1.key, None, ts2)
+        t.store.set_building((t.record1.key, ts1))
+        t.store.set_building((t.record1.key, ts2))
+
+        actual = next(t.store.get_building(), None)
+        t.assertEqual(expected, actual)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+
+
+class TestCurrentOnlyMethods(_BaseTest):
+    """
+    Verify that the get_older and get_newer methods work for Current status.
+    """
+
+    def test_older_with_current(t):
+        t.store.add(t.record1)
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Current)
+
+        older = next(t.store.get_older(t.record1.updated), None)
+        t.assertEqual(status, older)
+
+    def test_older_with_retired(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_retired((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Retired)
+
+        older = next(t.store.get_older(t.record1.updated), None)
+        t.assertIsNone(older)
+
+    def test_older_with_expired(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_expired((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
         t.assertIsInstance(status, ConfigStatus.Expired)
 
-    def test_get_expired(t):
+        older = next(t.store.get_older(t.record1.updated), None)
+        t.assertIsNone(older)
+
+    def test_older_with_pending(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_pending((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Pending)
+
+        older = next(t.store.get_older(t.record1.updated), None)
+        t.assertIsNone(older)
+
+    def test_older_with_building(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_building((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Building)
+
+        older = next(t.store.get_older(t.record1.updated), None)
+        t.assertIsNone(older)
+
+    def test_newer_with_current(t):
+        t.store.add(t.record1)
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Current)
+
+        newer = next(t.store.get_newer(t.record1.updated - 1), None)
+        t.assertEqual(status, newer)
+
+    def test_newer_with_retired(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_retired((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Retired)
+
+        newer = next(t.store.get_newer(t.record1.updated - 1), None)
+        t.assertIsNone(newer)
+
+    def test_newer_with_expired(t):
         t.store.add(t.record1)
         ts = t.record1.updated + 500
         t.store.set_expired((t.record1.key, ts))
 
-        result = tuple(t.store.get_expired())
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
+        status = next(t.store.get_status(t.record1.key), None)
         t.assertIsInstance(status, ConfigStatus.Expired)
 
-    def test_expired_is_not_older(t):
+        newer = next(t.store.get_newer(t.record1.updated - 1), None)
+        t.assertIsNone(newer)
+
+    def test_newer_with_pending(t):
         t.store.add(t.record1)
         ts = t.record1.updated + 500
+        t.store.set_pending((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Pending)
+
+        newer = next(t.store.get_newer(t.record1.updated - 1), None)
+        t.assertIsNone(newer)
+
+    def test_newer_with_building(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 500
+        t.store.set_building((t.record1.key, ts))
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Building)
+
+        newer = next(t.store.get_newer(t.record1.updated - 1), None)
+        t.assertIsNone(newer)
+
+
+class GetStatusTest(_BaseTest):
+    """
+    Verify that get_status returns all the statuses.
+    """
+
+    def test_current(t):
+        t.store.add(t.record1)
+        expected = ConfigStatus.Current(
+            t.record1.key, t.record1.uid, t.record1.updated
+        )
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+    def test_retired(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, ts))
+        expected = ConfigStatus.Retired(t.record1.key, t.record1.uid, ts)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+    def test_expired(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 200
+        t.store.set_expired((t.record1.key, ts))
+        expected = ConfigStatus.Expired(t.record1.key, t.record1.uid, ts)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+    def test_pending(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 300
+        t.store.set_pending((t.record1.key, ts))
+        expected = ConfigStatus.Pending(t.record1.key, t.record1.uid, ts)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+    def test_building(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 400
+        t.store.set_building((t.record1.key, ts))
+        expected = ConfigStatus.Building(t.record1.key, t.record1.uid, ts)
+        actual = next(t.store.get_status(t.record1.key), None)
+        t.assertEqual(expected, actual)
+
+
+class TestClearStatus(_BaseTest):
+    """
+    Test clearing the status.
+    """
+
+    def test_clear_from_current(t):
+        t.store.add(t.record1)
+        t.store.clear_status(t.record1.key)
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Current)
+
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
+
+    def test_clear_from_expired_to_current(t):
+        t.store.add(t.record1)
+        ts = t.record1.updated + 100
         t.store.set_expired((t.record1.key, ts))
 
-        result = tuple(t.store.get_older(t.record1.updated))
-        t.assertEqual(0, len(result))
+        t.store.clear_status(t.record1.key)
+
+        status = next(t.store.get_status(t.record1.key), None)
+        t.assertIsInstance(status, ConfigStatus.Current)
+
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
+
+    def test_clear_from_retired(t):
+        retired = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, retired))
+
+        t.store.clear_status(t.record1.key)
+
+        t.assertIsNone(next(t.store.get_status(t.record1.key), None))
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
+
+    def test_clear_from_expired(t):
+        ts = t.record1.updated + 100
+        t.store.set_expired((t.record1.key, ts))
+
+        t.store.clear_status(t.record1.key)
+
+        t.assertIsNone(next(t.store.get_status(t.record1.key), None))
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
+
+    def test_clear_from_pending(t):
+        ts = t.record1.updated + 100
+        t.store.set_pending((t.record1.key, ts))
+
+        t.store.clear_status(t.record1.key)
+
+        t.assertIsNone(next(t.store.get_status(t.record1.key), None))
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
+
+    def test_clear_from_building(t):
+        ts = t.record1.updated + 100
+        t.store.set_building((t.record1.key, ts))
+
+        t.store.clear_status(t.record1.key)
+
+        t.assertIsNone(next(t.store.get_status(t.record1.key), None))
+        t.assertIsNone(next(t.store.get_retired(), None))
+        t.assertIsNone(next(t.store.get_expired(), None))
+        t.assertIsNone(next(t.store.get_pending(), None))
+        t.assertIsNone(next(t.store.get_building(), None))
 
 
-class TestPendingStatus(_BaseTest):
+class TestStatusChangesFromRetired(_BaseTest):
     """
-    Test APIs regarding the ConfigStatus.Pending status.
-    """
-
-    def test_set_pending(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        expected = (t.record1.key,)
-
-        actual = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual(expected, actual)
-
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
-
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
-
-    def test_set_pending_twice(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        expected = ()
-
-        t.store.set_pending((t.record1.key, submitted))
-        actual = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual(expected, actual)
-
-    def test_pending_status(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        t.store.set_pending((t.record1.key, submitted))
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-        t.assertEqual(submitted, status.submitted)
-
-    def test_get_pending(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        t.store.set_pending((t.record1.key, submitted))
-
-        result = tuple(t.store.get_pending())
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-        t.assertEqual(submitted, status.submitted)
-
-    def test_pending_is_not_older(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        t.store.set_pending((t.record1.key, submitted))
-
-        result = tuple(t.store.get_older(t.record1.updated))
-        t.assertEqual(0, len(result))
-
-
-class TestBuildingStatus(_BaseTest):
-    """
-    Test APIs regarding the ConfigStatus.Building status.
-    """
-
-    def test_set_building(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        expected = (t.record1.key,)
-
-        t.store.set_pending((t.record1.key, started - 100))
-        actual = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual(expected, actual)
-
-        pending_keys = tuple(t.store.get_pending())
-        t.assertTupleEqual((), pending_keys)
-
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
-
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
-
-    def test_set_building_twice(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        expected = ()
-
-        t.store.set_building((t.record1.key, started))
-        actual = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual(expected, actual)
-
-    def test_building_status(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
-
-    def test_get_building(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
-
-        result = tuple(t.store.get_building())
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
-
-    def test_building_is_not_older(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
-
-        result = tuple(t.store.get_older(t.record1.updated))
-        t.assertEqual(0, len(result))
-
-
-class TestExpiredTransitions(_BaseTest):
-    """
-    Test transitions to and from ConfigStatus.Expired.
+    Test changing the status of a config.
     """
 
     def test_retired_to_expired(t):
-        t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
-        ts = t.record1.updated + 300
+        retired = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, retired))
 
-        expired_keys = t.store.set_expired((t.record1.key, ts))
-        t.assertTupleEqual((t.record1.key,), expired_keys)
+        expired = t.record1.updated + 300
+        t.store.set_expired((t.record1.key, expired))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Expired)
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
 
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
-
-    def test_expired_to_retired(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 300
-        t.store.set_expired((t.record1.key, ts))
-        retired_keys = t.store.set_retired(t.record1.key)
-        t.assertTupleEqual((t.record1.key,), retired_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Retired)
-        t.assertEqual(t.record1.updated, status.updated)
-
-
-class TestPendingTransitions(_BaseTest):
-    """
-    Test transitions to and from ConfigStatus.Pending.
-    """
-
-    def test_current_to_pending(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-
-        pending_keys = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual((t.record1.key,), pending_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-        t.assertEqual(submitted, status.submitted)
+        expected = ConfigStatus.Expired(t.record1.key, None, expired)
+        actual = next(t.store.get_expired(), None)
+        t.assertEqual(expected, actual)
 
     def test_retired_to_pending(t):
-        t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
-        submitted = t.record1.updated + 500
+        retired = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, retired))
 
-        pending_keys = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual((t.record1.key,), pending_keys)
+        pending = t.record1.updated + 300
+        t.store.set_pending((t.record1.key, pending))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-        t.assertEqual(submitted, status.submitted)
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
 
-    def test_expired_to_pending(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 300
-        submitted = t.record1.updated + 500
-        t.store.set_expired((t.record1.key, ts))
-        pending_keys = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual((t.record1.key,), pending_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
-
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
-
-        building_keys = tuple(t.store.get_building())
-        t.assertTupleEqual((), building_keys)
-
-    def test_pending_to_expired(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 300
-        submitted = t.record1.updated + 500
-        t.store.set_pending((t.record1.key, submitted))
-
-        expired_keys = t.store.set_expired((t.record1.key, ts))
-        t.assertTupleEqual((t.record1.key,), expired_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Expired)
-        t.assertEqual(ts, status.expired)
-
-    def test_pending_to_retired(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 500
-        t.store.set_pending((t.record1.key, submitted))
-
-        retired_keys = t.store.set_retired(t.record1.key)
-        t.assertTupleEqual((t.record1.key,), retired_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Retired)
-        t.assertEqual(t.record1.updated, status.updated)
-
-
-class TestBuildingTransitions(_BaseTest):
-    """
-    Test transitions to and from ConfigStatus.Building.
-    """
-
-    def test_current_to_building(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-
-        building_keys = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual((t.record1.key,), building_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
-
-        pending_keys = tuple(t.store.get_pending())
-        t.assertTupleEqual((), pending_keys)
-
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
-
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
+        expected = ConfigStatus.Pending(t.record1.key, None, pending)
+        actual = next(t.store.get_pending(), None)
+        t.assertEqual(expected, actual)
 
     def test_retired_to_building(t):
-        t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
-        started = t.record1.updated + 500
+        retired = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, retired))
 
-        building_keys = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual((t.record1.key,), building_keys)
+        building = t.record1.updated + 300
+        t.store.set_building((t.record1.key, building))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
+        actual = next(t.store.get_retired(), None)
+        t.assertIsNone(actual)
 
-        pending_keys = tuple(t.store.get_pending())
-        t.assertTupleEqual((), pending_keys)
+        expected = ConfigStatus.Building(t.record1.key, None, building)
+        actual = next(t.store.get_building(), None)
+        t.assertEqual(expected, actual)
 
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
 
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
+class TestStatusChangesFromExpired(_BaseTest):
+    """
+    Test changing the status of a config.
+    """
+
+    def test_expired_to_retired(t):
+        expired = t.record1.updated + 100
+        t.store.set_expired((t.record1.key, expired))
+
+        retired = t.record1.updated + 300
+        t.store.set_retired((t.record1.key, retired))
+
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Retired(t.record1.key, None, retired)
+        actual = next(t.store.get_retired(), None)
+        t.assertEqual(expected, actual)
+
+    def test_expired_to_pending(t):
+        expired = t.record1.updated + 100
+        t.store.set_expired((t.record1.key, expired))
+
+        pending = t.record1.updated + 300
+        t.store.set_pending((t.record1.key, pending))
+
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Pending(t.record1.key, None, pending)
+        actual = next(t.store.get_pending(), None)
+        t.assertEqual(expected, actual)
 
     def test_expired_to_building(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 300
-        started = t.record1.updated + 500
-        t.store.set_expired((t.record1.key, ts))
+        expired = t.record1.updated + 100
+        t.store.set_expired((t.record1.key, expired))
 
-        building_keys = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual((t.record1.key,), building_keys)
+        building = t.record1.updated + 300
+        t.store.set_building((t.record1.key, building))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
+        actual = next(t.store.get_expired(), None)
+        t.assertIsNone(actual)
 
-        pending_keys = tuple(t.store.get_pending())
-        t.assertTupleEqual((), pending_keys)
+        expected = ConfigStatus.Building(t.record1.key, None, building)
+        actual = next(t.store.get_building(), None)
+        t.assertEqual(expected, actual)
 
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
 
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
+class TestStatusChangesFromPending(_BaseTest):
+    """
+    Test changing the status of a config.
+    """
+
+    def test_pending_to_retired(t):
+        pending = t.record1.updated + 100
+        t.store.set_pending((t.record1.key, pending))
+
+        retired = t.record1.updated + 300
+        t.store.set_retired((t.record1.key, retired))
+
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Retired(t.record1.key, None, retired)
+        actual = next(t.store.get_retired(), None)
+        t.assertEqual(expected, actual)
+
+    def test_pending_to_expired(t):
+        pending = t.record1.updated + 100
+        t.store.set_pending((t.record1.key, pending))
+
+        expired = t.record1.updated + 300
+        t.store.set_expired((t.record1.key, expired))
+
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Expired(t.record1.key, None, expired)
+        actual = next(t.store.get_expired(), None)
+        t.assertEqual(expected, actual)
 
     def test_pending_to_building(t):
-        t.store.add(t.record1)
-        ts = t.record1.updated + 300
-        started = t.record1.updated + 500
-        t.store.set_expired((t.record1.key, ts))
-        t.store.set_pending((t.record1.key, started - 100))
+        pending = t.record1.updated + 100
+        t.store.set_pending((t.record1.key, pending))
 
-        building_keys = t.store.set_building((t.record1.key, started))
-        t.assertTupleEqual((t.record1.key,), building_keys)
+        building = t.record1.updated + 300
+        t.store.set_building((t.record1.key, building))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Building)
-        t.assertEqual(started, status.started)
+        actual = next(t.store.get_pending(), None)
+        t.assertIsNone(actual)
 
-        pending_keys = tuple(t.store.get_pending())
-        t.assertTupleEqual((), pending_keys)
+        expected = ConfigStatus.Building(t.record1.key, None, building)
+        actual = next(t.store.get_building(), None)
+        t.assertEqual(expected, actual)
 
-        expired_keys = tuple(t.store.get_expired())
-        t.assertTupleEqual((), expired_keys)
 
-        retired_keys = tuple(t.store.get_retired())
-        t.assertTupleEqual((), retired_keys)
-
-    def test_building_to_pending(t):
-        t.store.add(t.record1)
-        submitted = t.record1.updated + 300
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
-
-        pending_keys = t.store.set_pending((t.record1.key, submitted))
-        t.assertTupleEqual((t.record1.key,), pending_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Pending)
-        t.assertEqual(submitted, status.submitted)
-
-    def test_building_to_expired(t):
-        t.store.add(t.record1)
-        expired = t.record1.updated + 300
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
-
-        expired_keys = t.store.set_expired((t.record1.key, expired))
-        t.assertTupleEqual((t.record1.key,), expired_keys)
-
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Expired)
-        t.assertEqual(expired, status.expired)
+class TestStatusChangesFromBuilding(_BaseTest):
+    """
+    Test changing the status of a config.
+    """
 
     def test_building_to_retired(t):
-        t.store.add(t.record1)
-        started = t.record1.updated + 500
-        t.store.set_building((t.record1.key, started))
+        building = t.record1.updated + 100
+        t.store.set_building((t.record1.key, building))
 
-        retired_keys = t.store.set_retired(t.record1.key)
-        t.assertTupleEqual((t.record1.key,), retired_keys)
+        retired = t.record1.updated + 300
+        t.store.set_retired((t.record1.key, retired))
 
-        result = tuple(t.store.get_status(t.record1.key))
-        t.assertEqual(1, len(result))
-        status = result[0]
-        t.assertEqual(t.record1.key, status.key)
-        t.assertIsInstance(status, ConfigStatus.Retired)
-        t.assertEqual(t.record1.updated, status.updated)
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Retired(t.record1.key, None, retired)
+        actual = next(t.store.get_retired(), None)
+        t.assertEqual(expected, actual)
+
+    def test_building_to_expired(t):
+        building = t.record1.updated + 100
+        t.store.set_building((t.record1.key, building))
+
+        expired = t.record1.updated + 300
+        t.store.set_expired((t.record1.key, expired))
+
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Expired(t.record1.key, None, expired)
+        actual = next(t.store.get_expired(), None)
+        t.assertEqual(expected, actual)
+
+    def test_building_to_pending(t):
+        building = t.record1.updated + 100
+        t.store.set_building((t.record1.key, building))
+
+        pending = t.record1.updated + 300
+        t.store.set_pending((t.record1.key, pending))
+
+        actual = next(t.store.get_building(), None)
+        t.assertIsNone(actual)
+
+        expected = ConfigStatus.Pending(t.record1.key, None, pending)
+        actual = next(t.store.get_pending(), None)
+        t.assertEqual(expected, actual)
 
 
 class TestAddTransitions(_BaseTest):
@@ -898,7 +1031,8 @@ class TestAddTransitions(_BaseTest):
 
     def test_add_overwrites_retired(t):
         t.store.add(t.record1)
-        t.store.set_retired(t.record1.key)
+        retired = t.record1.updated + 100
+        t.store.set_retired((t.record1.key, retired))
         t.store.add(t.record1)
 
         retired_keys = tuple(t.store.get_retired())
@@ -1055,11 +1189,13 @@ class DeviceUIDTest(TestCase):
         t.store.add(t.record2)
         t.store.remove(t.record1.key)
 
+        actual = t.store.get_uid(t.device_name)
+        t.assertEqual(t.device_uid, actual)
+
         records = tuple(
             t.store.get(key)
             for key in t.store.search(CacheQuery(device=t.device_name))
         )
-
         t.assertEqual(1, len(records))
         t.assertEqual(t.device_uid, records[0].uid)
 
@@ -1072,7 +1208,6 @@ class DeviceUIDTest(TestCase):
             t.store.get(key)
             for key in t.store.search(CacheQuery(device=t.device_name))
         )
-
         t.assertEqual(0, len(records))
         t.assertIsNone(t.store.get_uid(t.device_name))
 
@@ -1085,11 +1220,9 @@ def _make_config(_id, configId, guid):
     return config
 
 
-# _compare_configs used to monkeypatch DeviceProxy
-# to make equivalent instances equal.
-
-
 def _compare_configs(self, cfg):
+    # _compare_configs used to monkeypatch DeviceProxy
+    # to make equivalent instances equal.
     return all(
         (
             self.id == cfg.id,


### PR DESCRIPTION
Set the 'pending' status when dispatching config build jobs for new devices. Clear statuses on cache keys that have no configurations.

ZEN-34739