### PR TITLE
Revert "Move initialize_zenoss_env into worker_process_init signal handler, so that it runs in the worker process, and not in the main zenjobs one."

### DIFF
--- a/Products/Jobber/model.py
+++ b/Products/Jobber/model.py
@@ -27,6 +27,7 @@ from .interfaces import IJobStore, IJobRecord
 from .storage import Fields
 from .task.utils import job_log_has_errors
 from .utils.log import inject_logger
+from .zenjobs import app
 
 mlog = logging.getLogger("zen.zenjobs.model")
 
@@ -120,8 +121,6 @@ class JobRecord(object):
 
     @property
     def job_type(self):
-        from .zenjobs import app
-
         task = app.tasks.get(self.name)
         if task is None:
             return self.name if self.name else ""
@@ -154,8 +153,6 @@ class JobRecord(object):
 
     @property
     def result(self):
-        from .zenjobs import app
-
         return app.tasks[self.name].AsyncResult(self.jobid)
 
     def __eq__(self, other):
@@ -291,8 +288,6 @@ class RedisRecord(dict):
 
     @classmethod
     def _build(cls, jobid, taskname, args, kwargs, headers, properties):
-        from .zenjobs import app
-
         task = app.tasks[taskname]
         fields = {}
         description = properties.pop("description", None)
@@ -318,8 +313,6 @@ def save_jobrecord(log, body=None, headers=None, properties=None, **ignored):
     :param dict headers: Headers to accompany message sent to Celery worker
     :param dict properties: Additional task and custom key/value pairs
     """
-    from .zenjobs import app
-
     if not body:
         # If body is empty (or None), no job to save.
         log.info("no body, so no job")
@@ -394,8 +387,6 @@ def stage_jobrecord(log, storage, sig):
     :param sig: The job data
     :type sig: celery.canvas.Signature
     """
-    from .zenjobs import app
-
     task = app.tasks.get(sig.task)
 
     # Tasks with ignored results cannot be tracked,
@@ -421,8 +412,6 @@ def commit_jobrecord(log, storage, sig):
     :param sig: The job data
     :type sig: celery.canvas.Signature
     """
-    from .zenjobs import app
-
     task = app.tasks.get(sig.task)
 
     # Tasks with ignored results cannot be tracked,
@@ -504,8 +493,6 @@ def job_end(log, task_id, task=None, **ignored):
 @inject_logger(log=mlog)
 @_catch_exception
 def job_success(log, result, sender=None, **ignored):
-    from .zenjobs import app
-
     if sender is not None and sender.ignore_result:
         return
     task_id = sender.request.id
@@ -522,8 +509,6 @@ def job_success(log, result, sender=None, **ignored):
 @inject_logger(log=mlog)
 @_catch_exception
 def job_failure(log, task_id, exception=None, sender=None, **ignored):
-    from .zenjobs import app
-
     if sender is not None and sender.ignore_result:
         return
     status = app.backend.get_status(task_id)
@@ -554,8 +539,6 @@ def job_failure(log, task_id, exception=None, sender=None, **ignored):
 @inject_logger(log=mlog)
 @_catch_exception
 def job_retry(log, request, reason=None, sender=None, **ignored):
-    from .zenjobs import app
-
     if sender is not None and sender.ignore_result:
         return
     jobstore = getUtility(IJobStore, "redis")

--- a/Products/Jobber/signals.zcml
+++ b/Products/Jobber/signals.zcml
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <configure xmlns:celery="http://namespaces.zope.org/celery">
 
-    <include file="meta.zcml"/>
-
    <!-- worker configuration -->
 
    <celery:signal
@@ -18,11 +16,6 @@
    <celery:signal
       name="setup_logging"
       handler=".log.configure_logging"
-      />
-
-   <celery:signal
-      name="worker_process_init"
-      handler=".worker.initialize_zenoss_env"
       />
 
    <celery:signal

--- a/Products/Jobber/task/utils.py
+++ b/Products/Jobber/task/utils.py
@@ -16,6 +16,7 @@ from itertools import chain
 from zope.component import getUtility
 
 from ..interfaces import IJobStore
+from ..zenjobs import app
 
 
 def requires(*features):
@@ -25,8 +26,6 @@ def requires(*features):
     (*features, ZenTask, celery.app.task.Task, object) where 'features'
     are the classes given to this function.
     """
-    from ..zenjobs import app
-
     bases = tuple(features) + (app.Task, object)
     culled = []
     for feature in reversed(bases):

--- a/Products/Jobber/tests/test_jobstore_updates.py
+++ b/Products/Jobber/tests/test_jobstore_updates.py
@@ -19,6 +19,7 @@ from mock import patch, Mock
 from zope.component import getGlobalSiteManager
 
 from ..model import (
+    app,
     IJobStore,
     job_start,
     job_end,
@@ -28,7 +29,6 @@ from ..model import (
 )
 from ..storage import JobStore
 from .utils import subTest, RedisLayer
-from ..zenjobs import app
 
 UNEXPECTED = type("UNEXPECTED", (object,), {})()
 PATH = {"src": "Products.Jobber.model"}
@@ -126,7 +126,7 @@ class JobSuccessTest(_CommonFixture, TestCase):
         job_start("1")
 
     @patch("{src}.time".format(**PATH), autospec=True)
-    @patch("Products.Jobber.zenjobs.app.backend", autospec=True)
+    @patch("{src}.app.backend".format(**PATH), autospec=True)
     def test_success(t, _backend, _time):
         tm = 1597059131.762538
 
@@ -165,7 +165,7 @@ class JobFailureTest(_CommonFixture, TestCase):
         job_start("1")
 
     @patch("{src}.time".format(**PATH), autospec=True)
-    @patch("Products.Jobber.zenjobs.app.backend", autospec=True)
+    @patch("{src}.app.backend".format(**PATH), autospec=True)
     def test_aborted(t, _backend, _time):
         tm = 1597059131.762538
 
@@ -187,7 +187,7 @@ class JobFailureTest(_CommonFixture, TestCase):
         t.assertEqual(expected_finished, finished)
 
     @patch("{src}.time".format(**PATH), autospec=True)
-    @patch("Products.Jobber.zenjobs.app.backend", autospec=True)
+    @patch("{src}.app.backend".format(**PATH), autospec=True)
     def test_failure(t, _backend, _time):
         tm = 1597059131.762538
 
@@ -209,7 +209,7 @@ class JobFailureTest(_CommonFixture, TestCase):
         t.assertEqual(expected_finished, finished)
 
     @patch("{src}.time".format(**PATH), autospec=True)
-    @patch("Products.Jobber.zenjobs.app.backend", autospec=True)
+    @patch("{src}.app.backend".format(**PATH), autospec=True)
     def test_callbacks_are_aborted(t, _backend, _time):
         next_jobid = "456"
         next_job = dict(t.initial)
@@ -257,7 +257,7 @@ class JobRetryTest(_CommonFixture, TestCase):
         req = type("request", (object,), {"id": "1"})()
         job_retry(req)
 
-    @patch("Products.Jobber.zenjobs.app.backend", autospec=True)
+    @patch("{src}.app.backend".format(**PATH), autospec=True)
     def test_nominal(t, _backend):
         tm = 1597059131.762538
         req = type("request", (object,), {"id": t.jobid})()

--- a/Products/Jobber/worker.py
+++ b/Products/Jobber/worker.py
@@ -10,35 +10,16 @@
 from __future__ import absolute_import
 
 import logging
-import time
 import ZODB.config
 
 from .config import ZenJobs
+from .zenjobs import app
 
 mlog = logging.getLogger("zen.zenjobs.worker")
 
 
-def initialize_zenoss_env(**kw):
-    start = time.time()
-    from Zope2.App import zcml
-    import Products.Jobber
-    import Products.ZenWidgets
-    from OFS.Application import import_products
-    from Products.ZenUtils.Utils import load_config, load_config_override
-    from Products.ZenUtils.zenpackload import load_zenpacks
-
-    import_products()
-    # load_zenpacks()  # already called by import_products via Products.ZenossStartup
-    zcml.load_site()
-    load_config("signals.zcml", Products.Jobber)
-    load_config_override('scriptmessaging.zcml', Products.ZenWidgets)
-    mlog.getChild("initialize_zenoss_env").info("Zenoss environment initialized (%d sec elapsed)" % (time.time() - start))
-
-
 def setup_zodb(**kw):
     """Initialize a ZODB connection."""
-    from .zenjobs import app
-
     zodbcfg = ZenJobs.get("zodb-config-file")
     url = "file://%s" % zodbcfg
     app.db = ZODB.config.databaseFromURL(url)
@@ -47,7 +28,5 @@ def setup_zodb(**kw):
 
 def teardown_zodb(**kw):
     """Shut down the ZODB connection."""
-    from .zenjobs import app
-
     app.db.close()
     mlog.getChild("teardown_zodb").info("ZODB connection closed")

--- a/Products/Jobber/zenjobs.py
+++ b/Products/Jobber/zenjobs.py
@@ -12,14 +12,8 @@ from __future__ import absolute_import
 from celery import Celery
 from kombu.serialization import register
 
-import Products.Jobber
-
-from Products.ZenUtils.Utils import load_config
-
 from .serialization import without_unicode
 
-
-load_config("signals.zcml", Products.Jobber)
 
 # Register custom serializer
 register(

--- a/bin/zenjobs
+++ b/bin/zenjobs
@@ -16,6 +16,23 @@ import sys
 from celery.__main__ import main
 
 
+def _initialize_zenoss_env():
+    from Zope2.App import zcml
+    import Products.Jobber
+    import Products.ZenWidgets
+    from OFS.Application import import_products
+    from Products.ZenUtils.Utils import load_config, load_config_override
+    from Products.ZenUtils.zenpackload import load_zenpacks
+
+    import_products()
+    load_zenpacks()
+    zcml.load_site()
+    load_config("signals.zcml", Products.Jobber)
+    load_config_override('scriptmessaging.zcml', Products.ZenWidgets)
+
+
+_initialize_zenoss_env()
+
 sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
 
 # All calls to celery need to the application so include it here.


### PR DESCRIPTION
Reverts zenoss/zenoss-prodbin#4358