### PR TITLE
Allow zencommand to get configs without defined credentials.

### DIFF
--- a/Products/ZenHub/services/CommandPerformanceConfig.py
+++ b/Products/ZenHub/services/CommandPerformanceConfig.py
@@ -135,14 +135,13 @@ class CommandPerformanceConfig(CollectorConfigService):
                 if not ds.enabled:
                     continue
 
-                # Ignore SSH datasources if no username set
                 useSsh = getattr(ds, "usessh", False)
                 if useSsh and not device.zCommandUsername:
+                    # Send an event about no username set
                     self._warnUsernameNotSet(device)
-                    continue
-
-                # clear any lingering no-username events
-                self._clearUsernameNotSet(device)
+                else:
+                    # clear any lingering no-username events
+                    self._clearUsernameNotSet(device)
 
                 parserName = getattr(ds, "parser", "Auto")
                 ploader = getParserLoader(self.dmd, parserName)
@@ -253,8 +252,9 @@ class CommandPerformanceConfig(CollectorConfigService):
                 comp, device, perfServer, commands, proxy.thresholds
             )
 
-        proxy.datasources = list(commands)
-        return proxy
+        if commands:
+            proxy.datasources = list(commands)
+            return proxy
 
     def _sendCmdEvent(
         self,

--- a/Products/ZenRRD/runner.py
+++ b/Products/ZenRRD/runner.py
@@ -211,8 +211,8 @@ class SshRunner(object):
         self.manageIp = self.proxy.manageIp
         self.port = self.proxy.zCommandPort
 
-        _username = self.proxy.zCommandUsername
-        _password = self.proxy.zCommandPassword
+        _username = self.proxy.zCommandUsername or ""
+        _password = self.proxy.zCommandPassword or ""
         _loginTimeout = self.proxy.zCommandLoginTimeout
         _commandTimeout = self.proxy.zCommandCommandTimeout
         _keyPath = self.proxy.zKeyPath


### PR DESCRIPTION
Old behavior was to not create a config if SSH credentials were not defined, but this behavior does not work with the configcache system. So, allow zencommand to receive configs without SSH credentials and accept the errors that happen.

ZEN-34758