### PR TITLE
fix: revert to depending on jobs.zcml to register jobs

### DIFF
--- a/Products/Jobber/bin.py
+++ b/Products/Jobber/bin.py
@@ -15,13 +15,6 @@ def main():
 
     from celery.bin.celery import main
     from Products.ZenUtils.Utils import load_config
-    from Products.ZenUtils.zenpackload import load_zenpacks
-
-    # The Zenoss environment requires that the 'zenoss.zenpacks' entrypoints
-    # be explicitely loaded because celery doesn't know to do that.
-    # Not loading those entrypoints means that celery will be unaware of
-    # any celery 'task' definitions in the ZenPacks.
-    load_zenpacks()
 
     load_config("signals.zcml", Products.Jobber)
 

--- a/Products/Jobber/worker.py
+++ b/Products/Jobber/worker.py
@@ -35,8 +35,16 @@ def initialize_zenoss_env(**kw):
     import Products.ZenWidgets
 
     from Products.ZenUtils.Utils import load_config_override
+    from Products.ZenUtils.zenpackload import load_zenpacks
 
     import_products()
+
+    # The Zenoss environment requires that the 'zenoss.zenpacks' entrypoints
+    # be explicitely loaded because celery doesn't know to do that.
+    # Not loading those entrypoints means that celery will be unaware of
+    # any celery 'task' definitions in the ZenPacks.
+    load_zenpacks()
+
     zcml.load_site()
     load_config_override("scriptmessaging.zcml", Products.ZenWidgets)
 


### PR DESCRIPTION
The ZenPacks defining their own jobs must add a jobs.zcml file that identifies these jobs so that zenjobs can find and register them.

ZEN-34751