### PR TITLE
Replace __cmp__ with __eq__/__lt__/__le__ combos.

### DIFF
--- a/Products/ZenEvents/Availability.py
+++ b/Products/ZenEvents/Availability.py
@@ -113,9 +113,19 @@ class Availability(object):
     def __int__(self):
         return int(self.availability * 100)
 
-    def __cmp__(self, other):
-        return cmp((self.availability, self.device, self.component()),
-                   (other.availability, other.device, other.component()))
+    def __eq__(self, other):
+        if not isinstance(other, Availability):
+            return False
+        this = (self.availability, self.device, self.component())
+        that = (other.availability, other.device, other.component())
+        return this == that
+
+    def __lt__(self, other):
+        if not isinstance(other, Availability):
+            return NotImplemented
+        this = (self.availability, self.device, self.component())
+        that = (other.availability, other.device, other.component())
+        return this < that
 
     def getDevice(self, dmd):
         return dmd.Devices.findDevice(self.device)
@@ -183,9 +193,26 @@ class Report(object):
     def __hash__(self):
         return hash(self.tuple())
 
-    def __cmp__(self, other):
-        return cmp(self.tuple(), other.tuple())
+    def __eq__(self, other):
+        if not isinstance(other, Report):
+            return False
+        if self is other:
+            return True
+        return self.tuple() == other.tuple()
 
+    def __lt__(self, other):
+        if not isinstance(other, Report):
+            return NotImplemented
+        if self is other:
+            return False
+        return self.tuple() < other.tuple()
+
+    def __le__(self, other):
+        if not isinstance(other, Report):
+            return NotImplemented
+        if self is other:
+            return True
+        return self.tuple() <= other.tuple()
 
     def run(self, dmd):
         """Run the report, returning an Availability object for each device"""

--- a/Products/ZenHub/services/PerformanceConfig.py
+++ b/Products/ZenHub/services/PerformanceConfig.py
@@ -53,12 +53,32 @@ class SnmpConnInfo(pb.Copyable, pb.RemoteCopy):
             setattr(self, propertyName, getattr(device, propertyName, None))
             self.id = device.id
 
-    def __cmp__(self, other):
-        for propertyName in ATTRIBUTES:
-            c = cmp(getattr(self, propertyName), getattr(other, propertyName))
-            if c != 0:
-                return c
-        return 0
+    def __eq__(self, other):
+        if not isinstance(other, SnmpConnInfo):
+            return False
+        if self is other:
+            return True
+        return all(
+            getattr(self, name) == getattr(other, name) for name in ATTRIBUTES
+        )
+
+    def __lt__(self, other):
+        if not isinstance(other, SnmpConnInfo):
+            return NotImplemented
+        if self is other:
+            return False
+        return any(
+            getattr(self, name) < getattr(other, name) for name in ATTRIBUTES
+        )
+
+    def __le__(self, other):
+        if not isinstance(other, SnmpConnInfo):
+            return NotImplemented
+        if self is other:
+            return True
+        return not any(
+            getattr(self, name) > getattr(other, name) for name in ATTRIBUTES
+        )
 
     def summary(self):
         result = "SNMP info for %s at %s:%s" % (

--- a/Products/ZenModel/ZenMenuItem.py
+++ b/Products/ZenModel/ZenMenuItem.py
@@ -56,12 +56,26 @@ class ZenMenuItem(ZenModelRM, ZenPackable):
             parent = aq_parent(parent)
         return parent
 
-    def __cmp__(self, other):
-        if isinstance(other, ZenMenuItem):
-            if other and other.ordering:
-                return cmp(other.ordering, self.ordering)
-            else:
-                return cmp(0.0, self.ordering)
-        return cmp(id(self), id(other))
-    
+    def __eq__(self, other):
+        if not isinstance(other, ZenMenuItem):
+            return False
+        if self is other:
+            return True
+        return self.ordering == other.ordering
+
+    def __lt__(self, other):
+        if not isinstance(other, ZenMenuItem):
+            return NotImplemented
+        if self is other:
+            return False
+        return self.ordering < other.ordering
+
+    def __le__(self, other):
+        if not isinstance(other, ZenMenuItem):
+            return NotImplemented
+        if self is other:
+            return True
+        return self.ordering <= other.ordering
+
+
 InitializeClass(ZenMenuItem)


### PR DESCRIPTION
Some __cmp__ implementations don't work with 'in' operators and __cmp__ is not supported in Python 3.

ZEN-34657