### PR TITLE
Use ast.literal_eval instead of json.loads.

### DIFF
--- a/Products/ZenCollector/configcache/cache/storage.py
+++ b/Products/ZenCollector/configcache/cache/storage.py
@@ -522,7 +522,7 @@ def _range(client, metadata, svc, mon, minv=None, maxv=None):
 
 
 def _unjelly(data):
-    return unjelly(json.loads(data))
+    return unjelly(ast.literal_eval(data))
 
 
 def _to_score(ts):

--- a/Products/ZenCollector/configcache/tests/test_storage.py
+++ b/Products/ZenCollector/configcache/tests/test_storage.py
@@ -1217,6 +1217,7 @@ def _make_config(_id, configId, guid):
     config.id = _id
     config._config_id = configId
     config._device_guid = guid
+    config.data = u"fancy"
     return config
 
 


### PR DESCRIPTION
json.loads makes a transformation that unjelly doesn't like.

ZEN-34797