### PR TITLE
fix: configure Celery on initialization

### DIFF
--- a/Products/Jobber/signals.zcml
+++ b/Products/Jobber/signals.zcml
@@ -3,11 +3,6 @@
 
    <include file="meta.zcml"/>
 
-   <celery:signal
-      name="user_preload_options"
-      handler=".worker.apply_config_file"
-      />
-
    <!-- worker configuration -->
 
    <celery:signal

--- a/Products/Jobber/worker.py
+++ b/Products/Jobber/worker.py
@@ -20,20 +20,10 @@ import ZODB.config
 
 from Zope2.App import zcml
 
-from .config import getConfig, CeleryConfig
+from .config import getConfig
 from .utils.app import get_app
 
 _mlog = logging.getLogger("zen.zenjobs.worker")
-
-
-def apply_config_file(options, app, **kw):
-    # Note: **kw has 'signal' and 'sender'
-    cfgfile = options.get("config_file")
-    if not cfgfile:
-        cfgfile = "zenjobs.conf"
-    cfg = getConfig(cfgfile)
-    celerycfg = CeleryConfig.from_config(cfg)
-    app.config_from_object(celerycfg)
 
 
 def initialize_zenoss_env(**kw):

--- a/Products/Jobber/zenjobs.py
+++ b/Products/Jobber/zenjobs.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 
 from celery import Celery
-from celery.bin import Option
 from kombu import serialization
 
 from .serialization import without_unicode
@@ -26,17 +25,10 @@ serialization.register(
 
 
 def _buildapp():
-    from .config import CeleryConfig, getConfig
     app = Celery(
         "zenjobs",
         task_cls="Products.Jobber.task:ZenTask",
-    )
-    default = CeleryConfig.from_config(getConfig())
-    app.config_from_object(default)
-    app.user_options["preload"].add(
-        Option(
-            "--config-file", default=None, help="Name of the configuration file"
-        )
+        config_source="Products.Jobber.config:ZenCeleryConfig",
     )
     return app
 


### PR DESCRIPTION
Set the Celery config early during startup because Celery doesn't appear to support being configured multiple times.  Only the initial configuration is used by Celery.

ZEN-34828