### PR TITLE
Add error handling around getParentNode.

### DIFF
--- a/Products/ZenCollector/configcache/modelchange/oids.py
+++ b/Products/ZenCollector/configcache/modelchange/oids.py
@@ -165,7 +165,11 @@ class ThresholdToDevice(BaseTransform):
         )
         obj = self._entity
         while not isinstance(obj, DeviceClass):
-            obj = obj.getParentNode()
+            try:
+                obj = obj.getParentNode()
+            except Exception:
+                log.exception("unable to find device class  entity=%r", obj)
+                return None
         return _getDevicesFromDeviceClass(obj)
 
 


### PR DESCRIPTION
Sometimes, an object doesn't have the getParentNode method, so record this unexpected situation into the log.

ZEN-34834