### PR TITLE
Inputs into save_jobrecord have changed.

### DIFF
--- a/Products/Jobber/tests/test_redisrecord.py
+++ b/Products/Jobber/tests/test_redisrecord.py
@@ -140,25 +140,15 @@ class BaseBuildRedisRecord(object):
     def test_from_signal(t):
         userid = "blink"
         t.expected["userid"] = userid
-        body = {
-            "id": t.jobid,
-            "task": t.task.name,
-            "args": t.args,
-            "kwargs": t.kw,
-        }
-        headers = {"userid": userid}
+        body = (t.args, t.kw, {})
+        headers = {"userid": userid, "task": t.task.name, "id": t.jobid}
         properties = {}
         actual = RedisRecord.from_signal(body, headers, properties)
         t.assertDictEqual(t.expected, actual)
 
     def test_from_signal_with_details(t):
-        body = {
-            "id": t.jobid,
-            "task": t.task.name,
-            "args": t.args,
-            "kwargs": t.kw,
-        }
-        headers = {}
+        body = (t.args, t.kw, {})
+        headers = {"id": t.jobid, "task": t.task.name}
         properties = {"a": 1, "b": 2}
         t.expected["details"] = properties
         actual = RedisRecord.from_signal(body, headers, properties)


### PR DESCRIPTION
Enabling the Celery's message protocol v2 has changed the structure of the data passed to the save_jobrecord function, so this commit updates the function to handle the changed structure of the inputs.

ZEN-34843