### PR TITLE
Add `dmd_read_only` flag to `DMD` mixin class.

### DIFF
--- a/Products/Jobber/task/base.py
+++ b/Products/Jobber/task/base.py
@@ -15,7 +15,7 @@ import uuid
 
 from AccessControl.SecurityManagement import getSecurityManager
 from celery import Task
-from celery.exceptions import Ignore, SoftTimeLimitExceeded
+from celery.exceptions import SoftTimeLimitExceeded
 
 from ..config import getConfig
 from ..utils.log import get_task_logger, get_logger
@@ -118,9 +118,6 @@ class ZenTask(SendZenossEventMixin, Task):
             del self.__run
 
     def __exec(self, *args, **kwargs):
-        if self.request.id is None:
-            self.log.error("Bad task: No ID found  request=%s", self.request)
-            raise Ignore()
         self.log.info("Job started")
         mlog.debug("Job started  request=%s", self.request)
         start = time.time()

--- a/Products/Jobber/tests/test_dmd.py
+++ b/Products/Jobber/tests/test_dmd.py
@@ -1,0 +1,77 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+import logging
+
+from unittest import TestCase
+
+from mock import MagicMock, patch
+
+from ..task import requires, DMD
+from ..zenjobs import app
+
+
+class DMDTest(TestCase):
+    """Test the DMD mixin class."""
+
+    def setUp(self):
+        log = logging.getLogger()
+        log.setLevel(logging.FATAL + 1)
+
+    def tearDown(self):
+        log = logging.getLogger()
+        log.setLevel(logging.NOTSET)
+
+    @app.task(bind=True, base=requires(DMD))
+    def dmd_task_rw(self):
+        pass
+
+    @app.task(bind=True, base=requires(DMD), dmd_read_only=True)
+    def dmd_task_ro(self):
+        pass
+
+    def test_rw_defaults(t):
+        t.assertIsInstance(t.dmd_task_rw, DMD)
+        t.assertFalse(t.dmd_task_rw.dmd_read_only)
+        t.assertIsNone(t.dmd_task_rw.dmd)
+
+    def test_ro_defaults(t):
+        t.assertIsInstance(t.dmd_task_ro, DMD)
+        t.assertTrue(t.dmd_task_ro.dmd_read_only)
+        t.assertIsNone(t.dmd_task_ro.dmd)
+
+    @patch("Products.Jobber.task.dmd.transaction")
+    def test_rw(t, transaction_):
+        db = MyMagicMock()
+        app.db = db
+        try:
+            t.dmd_task_rw()
+            transaction_.abort.assert_not_called()
+            transaction_.commit.assert_called_with()
+        finally:
+            del app.db
+
+    @patch("Products.Jobber.task.dmd.transaction")
+    def test_ro(t, transaction_):
+        db = MyMagicMock()
+        app.db = db
+        try:
+            t.dmd_task_ro()
+            transaction_.commit.assert_not_called()
+            transaction_.abort.assert_called_with()
+        finally:
+            del app.db
+
+
+class MyMagicMock(MagicMock):
+
+    def __of__(self, *args, **kw):
+        return self

--- a/Products/ZenCollector/configcache/task.py
+++ b/Products/ZenCollector/configcache/task.py
@@ -32,6 +32,7 @@ from .utils import get_pending_timeout
     summary="Create Device Configuration Task",
     description_template="Create the configuration for device {2}.",
     ignore_result=True,
+    dmd_read_only=True,
 )
 def build_device_config(
     self, monitorname, deviceid, configclassname, submitted=None

--- a/Products/ZenModel/Device.py
+++ b/Products/ZenModel/Device.py
@@ -459,11 +459,6 @@ class Device(
         Returns all the templates bound to this Device
 
         @rtype: list
-
-        >>> from Products.ZenModel.Device import manage_addDevice
-        >>> manage_addDevice(devices, 'test')
-        >>> devices.test.getRRDTemplates()
-        [<RRDTemplate at /zport/dmd/Devices/rrdTemplates/Device>]
         """
         if not hasattr(self, "zDeviceTemplates"):
             return ManagedEntity.getRRDTemplates(self)


### PR DESCRIPTION
Add the `dmd_read_only` attribute to tasks using the `DMD` mixin class. When set to True, the transaction is aborted when the task completes. By default, `dmd_read_only` is False.

ZEN-34849