### PR TITLE
Compare user input device ID to the device ID.

### DIFF
--- a/Products/ZenCollector/daemon.py
+++ b/Products/ZenCollector/daemon.py
@@ -656,7 +656,7 @@ class CollectorDaemon(RRDDaemon):
             (
                 cfg
                 for cfg in itertools.chain(new, updated)
-                if self.options.device == cfg.configId
+                if self.options.device == cfg.id
             ),
             None,
         )


### PR DESCRIPTION
A device's config may have a `configId` value different from the `id` value, so compare a user specified device ID with the config's `id` value.

ZEN-34850