### PR TITLE
Add 'stats' subcommand to configcache command.

### DIFF
--- a/Products/ZenCollector/configcache/cli/__init__.py
+++ b/Products/ZenCollector/configcache/cli/__init__.py
@@ -14,6 +14,7 @@ from .expire import Expire
 from .list import List_
 from .remove import Remove
 from .show import Show
+from .stats import Stats
 
 
-__all__ = ("Expire", "List_", "Remove", "Show")
+__all__ = ("Expire", "List_", "Remove", "Show", "Stats")

--- a/Products/ZenCollector/configcache/cli/_groups.py
+++ b/Products/ZenCollector/configcache/cli/_groups.py
@@ -1,0 +1,231 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import print_function, absolute_import, division
+
+from collections import defaultdict
+from itertools import chain
+
+import attr
+
+from ._stats import UniqueCountStat
+
+
+class DeviceGroup(object):
+
+    name = "devices"
+    order = 1
+
+    def __init__(self, stats):
+        # Only one row, so use summary
+        self._summary = tuple(s() for s in stats)
+        try:
+            # DeviceGroup doesn't want CountStat
+            posn = stats.index(UniqueCountStat)
+        except ValueError:
+            # Not found, so don't worry about it
+            self._counter = None
+            self._otherstats = self._summary
+        else:
+            # Found, replace it with UniqueCountStat
+            self._counter = self._summary[posn]
+            self._otherstats = self._summary[0:posn] + self._summary[posn+1:]
+        self._stats = stats
+        self._samples = 0
+
+    def handle_key(self, key):
+        if self._counter is None:
+            return
+        self._counter.mark(key.device)
+        self._samples += 1
+
+    def handle_timestamp(self, key, ts):
+        for stat in self._otherstats:
+            stat.mark(ts)
+        self._samples += 1
+
+    def handle_status(self, status):
+        pass
+
+    def headings(self):
+        return [s.name for s in self._stats]
+
+    def hints(self):
+        return [s.type_ for s in self._stats]
+
+    def rows(self):
+        return []
+
+    def summary(self):
+        if self._samples == 0:
+            return []
+        return list(s.value() for s in self._summary)
+
+
+class ServiceGroup(object):
+
+    name = "services"
+    order = 2
+
+    def __init__(self, stats):
+        self._stats = stats
+        self._byrow = defaultdict(self._makerowvalue)
+        self._summary = tuple(s() for s in stats)
+        self._samples = 0
+
+    def _makerowvalue(self):
+        return tuple(stat() for stat in self._stats)
+
+    def handle_key(self, key):
+        pass
+
+    def handle_timestamp(self, key, ts):
+        for stat in self._byrow[key.service]:
+            stat.mark(ts)
+        for stat in self._summary:
+            stat.mark(ts)
+        self._samples += 1
+
+    def handle_status(self, status):
+        pass
+
+    def headings(self):
+        headings = ["configuration service class"]
+        headings.extend(s.name for s in self._stats)
+        return headings
+
+    def hints(self):
+        hints = ["str"]
+        hints.extend(s.type_ for s in self._stats)
+        return hints
+
+    def rows(self):
+        if self._samples == 0:
+            return []
+        return (
+            self._makerow(svcname, stats)
+            for svcname, stats in self._byrow.iteritems()
+        )
+
+    def _makerow(self, svcname, stats):
+        return tuple(chain((svcname,), (s.value() for s in stats)))
+
+    def summary(self):
+        if self._samples == 0:
+            return []
+        return list(s.value() for s in self._summary)
+
+
+class MonitorGroup(object):
+
+    name = "monitors"
+    order = 3
+
+    def __init__(self, stats):
+        self._stats = stats
+        self._byrow = defaultdict(self._makerowvalue)
+        self._summary = tuple(s() for s in stats)
+        self._samples = 0
+
+    def _makerowvalue(self):
+        return tuple(stat() for stat in self._stats)
+
+    def handle_key(self, key):
+        pass
+
+    def handle_timestamp(self, key, ts):
+        for stat in self._byrow[key.monitor]:
+            stat.mark(ts)
+        for stat in self._summary:
+            stat.mark(ts)
+        self._samples += 1
+
+    def handle_status(self, status):
+        pass
+
+    def headings(self):
+        headings = ["collector"]
+        headings.extend(s.name for s in self._stats)
+        return headings
+
+    def hints(self):
+        hints = ["str"]
+        hints.extend(s.type_ for s in self._stats)
+        return hints
+
+    def rows(self):
+        if self._samples == 0:
+            return []
+        return (
+            self._makerow(name, stats)
+            for name, stats in self._byrow.iteritems()
+        )
+
+    def _makerow(self, name, stats):
+        return tuple(chain((name,), (s.value() for s in stats)))
+
+    def summary(self):
+        if self._samples == 0:
+            return []
+        return list(s.value() for s in self._summary)
+
+
+class StatusGroup(object):
+
+    name = "statuses"
+    order = 4
+
+    def __init__(self, stats):
+        self._stats = stats
+        self._byrow = defaultdict(self._makerowvalue)
+        self._summary = tuple(s() for s in stats)
+        self._samples = 0
+
+    def _makerowvalue(self):
+        return tuple(stat() for stat in self._stats)
+
+    def handle_key(self, key):
+        pass
+
+    def handle_timestamp(self, key, ts):
+        pass
+
+    def handle_status(self, status):
+        data = attr.astuple(status)
+        for stat in self._byrow[type(status).__name__]:
+            stat.mark(data[-1])
+        for stat in self._summary:
+            stat.mark(data[-1])
+        self._samples += 1
+
+    def headings(self):
+        headings = ["status"]
+        headings.extend(s.name for s in self._stats)
+        return headings
+
+    def hints(self):
+        hints = ["str"]
+        hints.extend(s.type_ for s in self._stats)
+        return hints
+
+    def rows(self):
+        if self._samples == 0:
+            return []
+        return (
+            self._makerow(name, stats)
+            for name, stats in self._byrow.iteritems()
+        )
+
+    def _makerow(self, name, stats):
+        return tuple(chain((name,), (s.value() for s in stats)))
+
+    def summary(self):
+        if self._samples == 0:
+            return []
+        return list(s.value() for s in self._summary)

--- a/Products/ZenCollector/configcache/cli/_json.py
+++ b/Products/ZenCollector/configcache/cli/_json.py
@@ -1,0 +1,83 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import print_function, absolute_import, division
+
+import json
+
+
+class JSONOutput(object):
+    """
+    {
+        "devices": [
+            "summary" : {
+                "number_of_devices": 4,
+                ...
+            }
+        ],
+        "services": {
+            "data": [
+                {<column-name>: <value>, ... }, ...
+            ],
+            "summary": {
+                <column-name>: <value>,  # except first column
+                ...
+            }
+        },
+        "monitors": {
+            "data": [
+                {<column-name>: <value>, ... }, ...
+            ],
+            "summary": {
+                <column-name>: <value>,  # except first column
+                ...
+            }
+        },
+        "statuses": {
+            "data": [
+                {<column-name>: <value>, ... }, ...
+            ],
+            "summary": {
+                <column-name>: <value>,  # except first column
+                ...
+            }
+        }
+    }
+    """
+
+    def write(self, *groups):
+        result = {}
+        for group in groups:
+            rows = list(group.rows())
+            summary = group.summary()
+            headings = [
+                hdr.replace(" ", "_").lower() for hdr in group.headings()
+            ]
+
+            if len(rows) == 0 and len(summary) == 0:
+                continue
+
+            if len(headings) == 1 and len(rows) == 1:
+                result[group.name] = [
+                    {headings[0].replace(" ", "_").lower(): rows[0][0]}
+                ]
+                continue
+
+            rows = [
+                {hdr: value for hdr, value in zip(headings, row)}
+                for row in rows
+            ]
+            if len(rows) == 0:
+                summary = {hdr: value for hdr, value in zip(headings, summary)}
+            else:
+                summary = {
+                    hdr: value for hdr, value in zip(headings[1:], summary)
+                }
+            result[group.name] = {"data": rows, "summary": summary}
+        print(json.dumps(result))

--- a/Products/ZenCollector/configcache/cli/_stats.py
+++ b/Products/ZenCollector/configcache/cli/_stats.py
@@ -1,0 +1,181 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import print_function, absolute_import, division
+
+import sys
+import time
+
+_current_time = None
+
+
+def _current_time_unset():
+    global _current_time
+    _current_time = time.time()
+    try:
+        return _current_time
+    finally:
+        global _get_current_time
+        _get_current_time = _current_time_set
+
+
+def _current_time_set():
+    global _current_time
+    return _current_time
+
+
+_get_current_time = _current_time_unset
+
+
+class CountStat(object):
+
+    name = "count"
+    type_ = "int"
+
+    def __init__(self):
+        self._count = 0
+
+    def mark(self, *args):
+        self._count += 1
+
+    def value(self):
+        return self._count
+
+
+class UniqueCountStat(CountStat):
+
+    name = "count of devices"
+
+    def __init__(self):
+        self._values = set()
+
+    def mark(self, value):
+        self._values.add(value)
+
+    def value(self):
+        return len(self._values)
+
+
+class AverageStat(object):
+
+    name = "average"
+    type_ = "timedelta"
+
+    def __init__(self):
+        self._total = 0
+        self._count = 0
+
+    def mark(self, value):
+        self._count += 1
+        self._total += value
+
+    def value(self):
+        if self._count == 0:
+            return 0
+        return self._total / self._count
+
+
+class AverageAgeStat(AverageStat):
+
+    name = "average age"
+
+    def value(self):
+        avg = super(AverageAgeStat, self).value()
+        if avg == 0:
+            return 0
+        return _get_current_time() - avg
+
+
+class MedianStat(object):
+
+    name = "median"
+    type_ = "timedelta"
+
+    def __init__(self):
+        self._min = sys.maxsize
+        self._max = 0
+
+    def mark(self, value):
+        value = int(value)
+        self._min = min(self._min, value)
+        self._max = max(self._max, value)
+
+    def value(self):
+        if self._min == sys.maxsize:
+            return 0
+        return (self._min + self._max) / 2
+
+
+class MedianAgeStat(MedianStat):
+
+    name = "median age"
+
+    def value(self):
+        median = super(MedianAgeStat, self).value()
+        if median == 0:
+            return 0
+        return _get_current_time() - median
+
+
+class MinStat(object):
+
+    name = "min"
+    type_ = "float"
+
+    def __init__(self):
+        self._min = sys.maxsize
+
+    def mark(self, value):
+        self._min = min(self._min, int(value))
+
+    def value(self):
+        if self._min == sys.maxsize:
+            return 0
+        return self._min
+
+
+class MaxAgeStat(MinStat):
+
+    name = "max age"
+    type_ = "timedelta"
+
+    def value(self):
+        maxv = super(MaxAgeStat, self).value()
+        if maxv == 0:
+            return 0
+        return _get_current_time() - maxv
+
+
+class MaxStat(object):
+
+    name = "max"
+    type_ = "float"
+
+    def __init__(self):
+        self._max = 0
+
+    def mark(self, value):
+        self._max = max(self._max, int(value))
+
+    def value(self):
+        if self._max == 0:
+            return 0
+        return self._max
+
+
+class MinAgeStat(MaxStat):
+
+    name = "min age"
+    type_ = "timedelta"
+
+    def value(self):
+        minv = super(MinAgeStat, self).value()
+        if minv == 0:
+            return 0
+        return _get_current_time() - minv

--- a/Products/ZenCollector/configcache/cli/_tables.py
+++ b/Products/ZenCollector/configcache/cli/_tables.py
@@ -1,0 +1,124 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import print_function, absolute_import, division
+
+import datetime
+
+from itertools import chain
+
+
+class TablesOutput(object):
+
+    def write(self, *groups):
+        for group in groups:
+            self._display(
+                list(group.rows()),
+                group.summary(),
+                group.headings(),
+                group.hints(),
+            )
+
+    def _display(self, rows, summary, headings, hints):
+        if not rows and not summary:
+            return
+
+        # Transform row values for presentation
+        if rows:
+            rows = [
+                tuple(_xform(value, hint) for value, hint in zip(row, hints))
+                for row in sorted(rows, key=lambda x: x[0])
+            ]
+
+        # Transform total values for presentation
+        if summary:
+            if rows:
+                summary = tuple(
+                    _xform(v, h) for v, h in zip([""] + summary, hints)
+                )
+            else:
+                summary = tuple(
+                    _xform(v, h) for v, h in zip(summary, hints)
+                )
+
+        # Transform column headers for presentation
+        if summary and not rows:
+            headings = [hdr.capitalize() for hdr in headings]
+        else:
+            headings = [hdr.upper() for hdr in headings]
+
+        # Initialize maxwidth values for each column
+        maxwidths = [0 for _ in headings]
+
+        if summary and not rows:
+            hdrmaxw = max(len(hdr) for hdr in headings)
+            maxwidths = [hdrmaxw] * len(headings)
+        else:
+            for row in rows:
+                for idx, (mw, col) in enumerate(zip(maxwidths, row)):
+                    maxwidths[idx] = max(mw, len(str(col)))
+            for idx, (mw, hd) in enumerate(zip(maxwidths, headings)):
+                maxwidths[idx] = max(mw, len(hd))
+            for idx, (mw, tv) in enumerate(zip(maxwidths[1:], summary)):
+                maxwidths[idx + 1] = max(mw, len(str(tv)))
+
+        offset = len(maxwidths)
+        tmplt = "  ".join(
+            "{{{0}:{{{1}}}}}".format(idx, idx + offset)
+            for idx in range(0, offset)
+        )
+        fmtspecs = [
+            _get_fmt_spec(mw, hint) for mw, hint in zip(maxwidths, hints)
+        ]
+        print()
+        if summary and not rows:
+            for hdr, value in zip(headings, summary):
+                print("{0:{2}}: {1}".format(hdr, value, maxwidths[0]))
+        else:
+            if headings:
+                print(tmplt.format(*chain(headings, fmtspecs)))
+                sep = ["-" * c for c in maxwidths]
+                print(tmplt.format(*chain(sep, maxwidths)))
+
+            for row in rows:
+                print(tmplt.format(*chain(row, fmtspecs)))
+
+            if summary:
+                print(tmplt.format(*chain(sep, maxwidths)))
+                print(tmplt.format(*chain(summary, fmtspecs)))
+
+
+def _xform(value, hint):
+    if hint == "timedelta":
+        td = datetime.timedelta(seconds=value)
+        hours = td.seconds // 3600
+        minutes = (td.seconds - (hours * 3600)) // 60
+        seconds = td.seconds - (hours * 3600) - (minutes * 60)
+        return "{0} {1:02}:{2:02}:{3:02}".format(
+            (
+                ""
+                if td.days == 0
+                else "{} day{}".format(td.days, "" if td.days == 1 else "s")
+            ),
+            hours,
+            minutes,
+            seconds,
+        ).strip()
+    else:
+        return value
+
+
+def _get_fmt_spec(mw, hint):
+    if hint == "int":
+        return ">{}".format(mw)
+    elif hint == "timedelta":
+        return ">{}".format(mw)
+    elif hint == "float":
+        return ">{}.2f".format(mw)
+    return mw

--- a/Products/ZenCollector/configcache/cli/stats.py
+++ b/Products/ZenCollector/configcache/cli/stats.py
@@ -1,0 +1,158 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2024, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import print_function, absolute_import, division
+
+import argparse
+import sys
+
+from zope.component import createObject
+
+from Products.ZenUtils.RedisUtils import getRedisClient, getRedisUrl
+
+from ..app import initialize_environment
+from ..app.args import get_subparser
+from ..cache import CacheQuery
+
+from .args import get_common_parser, MultiChoice
+from ._tables import TablesOutput
+from ._json import JSONOutput
+from ._stats import (
+    AverageAgeStat,
+    CountStat,
+    MaxAgeStat,
+    MedianAgeStat,
+    MinAgeStat,
+    UniqueCountStat,
+)
+from ._groups import DeviceGroup, ServiceGroup, MonitorGroup, StatusGroup
+
+
+class Stats(object):
+    description = "Show statistics about the configuration cache"
+
+    configs = (("stats.zcml", __name__),)
+
+    _groups = ("collector", "device", "service", "status")
+    _statistics = ("count", "avg_age", "median_age", "min_age", "max_age")
+
+    @staticmethod
+    def add_arguments(parser, subparsers):
+        subp = get_subparser(
+            subparsers, "stats", Stats.description, parent=get_common_parser()
+        )
+        subp.add_argument(
+            "-S",
+            dest="statistic",
+            action=MultiChoice,
+            choices=Stats._statistics,
+            default=argparse.SUPPRESS,
+            help="Specify the statistics to return.  One or more statistics "
+            "may be specified (comma separated). By default, all "
+            "statistics are returned.",
+        )
+        subp.add_argument(
+            "-G",
+            dest="group",
+            action=MultiChoice,
+            choices=Stats._groups,
+            default=argparse.SUPPRESS,
+            help="Specify the statistics groupings to return.  One or more "
+            "groupings may be specified (comma separated). By default, all "
+            "groupings are returned.",
+        )
+        subp.add_argument(
+            "-f",
+            dest="format",
+            choices=("tables", "json"),
+            default="tables",
+            help="Output statistics in the specified format",
+        )
+        subp.set_defaults(factory=Stats)
+
+    def __init__(self, args):
+        stats = []
+        for statId in getattr(args, "statistic", Stats._statistics):
+            if statId == "count":
+                stats.append(CountStat)
+            elif statId == "avg_age":
+                stats.append(AverageAgeStat)
+            elif statId == "median_age":
+                stats.append(MedianAgeStat)
+            elif statId == "min_age":
+                stats.append(MinAgeStat)
+            elif statId == "max_age":
+                stats.append(MaxAgeStat)
+        self._groups = []
+        for groupId in getattr(args, "group", Stats._groups):
+            if groupId == "collector":
+                self._groups.append(MonitorGroup(stats))
+            elif groupId == "device":
+                try:
+                    # DeviceGroup doesn't want CountStat
+                    posn = stats.index(CountStat)
+                except ValueError:
+                    # Not found, so don't worry about it
+                    dg_stats = stats
+                    pass
+                else:
+                    # Found, replace it with UniqueCountStat
+                    dg_stats = list(stats)
+                    dg_stats[posn] = UniqueCountStat
+                self._groups.append(DeviceGroup(dg_stats))
+            if groupId == "service":
+                self._groups.append(ServiceGroup(stats))
+            elif groupId == "status":
+                self._groups.append(StatusGroup(stats))
+        if args.format == "tables":
+            self._format = TablesOutput()
+        elif args.format == "json":
+            self._format = JSONOutput()
+        self._monitor = "*{}*".format(args.collector).replace("***", "*")
+        self._service = "*{}*".format(args.service).replace("***", "*")
+        self._devices = getattr(args, "device", [])
+
+    def run(self):
+        haswildcard = any("*" in d for d in self._devices)
+        if haswildcard and len(self._devices) > 1:
+            print(
+                "Only one DEVICE argument supported when a wildcard is used.",
+                file=sys.stderr,
+            )
+            return
+        initialize_environment(configs=self.configs, useZope=False)
+        client = getRedisClient(url=getRedisUrl())
+        store = createObject("configcache-store", client)
+
+        if len(self._devices) == 1:
+            query = CacheQuery(self._service, self._monitor, self._devices[0])
+        else:
+            query = CacheQuery(self._service, self._monitor)
+        include = _get_device_predicate(self._devices)
+        for key, ts in store.query_updated(query):
+            if not include(key.device):
+                continue
+            for group in self._groups:
+                group.handle_key(key)
+                group.handle_timestamp(key, ts)
+        for status in store.get_statuses(query):
+            if not include(status.key.device):
+                continue
+            for group in self._groups:
+                group.handle_status(status)
+
+        self._format.write(
+            *(group for group in sorted(self._groups, key=lambda x: x.order))
+        )
+
+
+def _get_device_predicate(devices):
+    if len(devices) < 2:
+        return lambda _: True
+    return lambda x: next((True for d in devices if x == d), False)

--- a/Products/ZenCollector/configcache/cli/stats.zcml
+++ b/Products/ZenCollector/configcache/cli/stats.zcml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<!--
+Copyright (C) Zenoss, Inc. 2024 all rights reserved.
+
+This content is made available according to terms specified in
+License.zenoss under the directory where your Zenoss product is installed.
+-->
+<configure xmlns="http://namespaces.zope.org/zope">
+
+   <include file="meta.zcml" package="zope.component" />
+   <include file="store.zcml" package="Products.ZenCollector.configcache" />
+
+</configure>

--- a/Products/ZenCollector/configcache/configcache.py
+++ b/Products/ZenCollector/configcache/configcache.py
@@ -10,7 +10,7 @@
 from __future__ import absolute_import, print_function
 
 from .app.args import get_arg_parser
-from .cli import Expire, List_, Remove, Show
+from .cli import Expire, List_, Remove, Show, Stats
 from .invalidator import Invalidator
 from .manager import Manager
 from .version import Version
@@ -24,10 +24,11 @@ def main(argv=None):
     Version.add_arguments(parser, subparsers)
     Manager.add_arguments(parser, subparsers)
     Invalidator.add_arguments(parser, subparsers)
-    List_.add_arguments(parser, subparsers)
-    Show.add_arguments(parser, subparsers)
     Expire.add_arguments(parser, subparsers)
+    List_.add_arguments(parser, subparsers)
     Remove.add_arguments(parser, subparsers)
+    Show.add_arguments(parser, subparsers)
+    Stats.add_arguments(parser, subparsers)
 
     args = parser.parse_args()
     args.factory(args).run()


### PR DESCRIPTION
The 'stats' subcommand will return a report on different statistics regarding the current state of the configuration cache.

The set of statistics include count, average age, median age, minimum age, and maximum age.  These statistics are grouped by service class, collector (monitor), status, and device.

ZEN-34892