### PR TITLE
Added store reload during grid refresh

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
@@ -1712,6 +1712,7 @@
         },
         refresh: function() {
             this.callParent(arguments);
+            this.getStore().reload();
             this.fireEvent('eventgridrefresh', this);
         }
     }); // SimpleEventGridPanel

--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -1666,6 +1666,7 @@ Ext.onReady(function () {
                             var grid = Ext.getCmp('device_grid');
                             if (grid.isVisible(true)) {
                                 grid.refresh();
+                                grid.getStore().reload();
                                 Ext.getCmp('organizer_events').refresh();
                                 refreshTreePanel();
                             }


### PR DESCRIPTION
Fixes ZEN-34727.

*Hitting refresh button didn't refresh
the infrastructure and event console page device list. The refresh method now includes a store
reload to ensure that the latest data is
fetched and displayed