### PR TITLE
Improve zproxy metrics collection reliability

### DIFF
--- a/bin/metrics/zenossStatsView.py
+++ b/bin/metrics/zenossStatsView.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 ##############################################################################
 #
-# Copyright (C) Zenoss, Inc. 2017, all rights reserved.
+# Copyright (C) Zenoss, Inc. 2017-2024, all rights reserved.
 #
 # This content is made available according to terms specified in
 # License.zenoss under the directory where your Zenoss product is installed.
@@ -34,6 +34,8 @@ class ZProxyMetricGatherer(MetricGatherer):
     ZPROXY_CONF_DIR = '/opt/zenoss/zproxy/conf/'
     # Note that changing the follwing ID format will break this script.
     INSTANCE_ID_FORMAT = '{}_{}'
+    
+    last_changed = {}
 
     def __init__(self, interval=30):
         super(ZProxyMetricGatherer, self).__init__()
@@ -84,21 +86,28 @@ class ZProxyMetricGatherer(MetricGatherer):
             self.zopes = {}
 
         # Check mtime of /opt/zenoss/zproxy/conf/zope-upstreams.conf
-        # if it's newer than, say, now - self.interval, reread it.
+        # if it's newer than it was modified last time, reread it.
         zope_upstream_file = self.ZPROXY_CONF_DIR + 'zope-upstreams.conf'
         zenapi_upstream_file = self.ZPROXY_CONF_DIR + 'apizopes-upstreams.conf'
         zenreports_upstream_file = self.ZPROXY_CONF_DIR + 'zopereports-upstreams.conf'
         zauth_upstream_file = self.ZPROXY_CONF_DIR + 'zauth-upstreams.conf'
+        
+        def read_upstream_file(upstream_file):
+            with open(upstream_file, 'r') as inf:
+                zopes = inf.readlines()
+                zopes = [line.rstrip('\n;') for line in zopes]
+                zopes = [line.split(' ')[-1] for line in zopes]
+            return zopes
 
         def check_upstream_util(upstream_file):
             upstream_modified = os.path.getmtime(upstream_file)
-            now = time.time()
             zopes = []
-            if first_time or upstream_modified > (now - self.interval):
-                with open(upstream_file, 'r') as inf:
-                    zopes = inf.readlines()
-                    zopes = [line.rstrip('\n;') for line in zopes]
-                    zopes = [line.split(' ')[-1] for line in zopes]
+            if first_time:
+                zopes = read_upstream_file(upstream_file)
+                self.last_changed[upstream_file] = upstream_modified
+            elif upstream_modified > self.last_changed.get('upstream_file'):
+                zopes = read_upstream_file(upstream_file)
+                self.last_changed[upstream_file] = upstream_modified
             return zopes
 
         def check_upstream(svcName, upstream_file):
@@ -126,7 +135,7 @@ class ZProxyMetricGatherer(MetricGatherer):
         for id_, zope in zopes.iteritems():
             try:
                 s = requests.Session()
-                # ZEN-29775 add a tomeout to zope instance call
+                # ZEN-29775 add a timeout to zope instance call
                 result = s.get(self.ZPROXY_STATS_URL % zope, timeout=10)
                 if result.status_code == 200:
                     data = result.json()


### PR DESCRIPTION
Fixes ZEN-34955.

Added last change record for Zope config files.
Now we are comparing the returned last modified value with a recorded last change value.