### PR TITLE
Add unicode type check for the object id

### DIFF
--- a/Products/ZenModel/ZenPacker.py
+++ b/Products/ZenModel/ZenPacker.py
@@ -63,6 +63,8 @@ class ZenPacker(object):
                 pass
         if len(result) == 0:
             try:
+		if isinstance(id, unicode):
+		    id = id.encode('utf-8')
                 result.append(self.dmd.unrestrictedTraverse(id))
             except KeyError:
                 pass


### PR DESCRIPTION
Fixes ZEN-34923.

When findObject is being executed during the job running the id object passed in the unrestrictedTraverse method could be unicode. It breaks the method and findObject returns an empty list while the object exists which is incorrect.