### PR TITLE
Fix for refresh button

### DIFF
--- a/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/EventPanels.js
@@ -1711,8 +1711,8 @@
             return val;
         },
         refresh: function() {
-            this.callParent(arguments);
             this.getStore().reload();
+            this.callParent(arguments);
             this.fireEvent('eventgridrefresh', this);
         }
     }); // SimpleEventGridPanel

--- a/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
+++ b/Products/ZenUI3/browser/resources/js/zenoss/itinfrastructure.js
@@ -1665,8 +1665,8 @@ Ext.onReady(function () {
                         handler: function () {
                             var grid = Ext.getCmp('device_grid');
                             if (grid.isVisible(true)) {
-                                grid.refresh();
                                 grid.getStore().reload();
+                                grid.refresh();
                                 Ext.getCmp('organizer_events').refresh();
                                 refreshTreePanel();
                             }


### PR DESCRIPTION
Fixes ZEN-34963.

Changed the order to store reload followed by grid refresh to ensure that the grid's refresh operation occurs after the store has been updated with new data from the server