### PR TITLE
Expire or retire configs more carefully.

### DIFF
--- a/Products/ZenCollector/configcache/cache/storage.py
+++ b/Products/ZenCollector/configcache/cache/storage.py
@@ -147,7 +147,7 @@ class ConfigStore(object):
             for service, monitor, device in self.__config.scan(self.__client)
         )
 
-    def search(self, query=CacheQuery()):
+    def search(self, query=None):
         """
         Returns the configuration keys matching the search criteria.
 
@@ -156,6 +156,8 @@ class ConfigStore(object):
         @raises TypeError: Unsupported value given for a field
         @raises AttributeError: Unknown field
         """
+        if query is None:
+            query = CacheQuery()
         if not isinstance(query, CacheQuery):
             raise TypeError("'{!r} is not a CacheQuery".format(query))
         return self._query(**attr.asdict(query))
@@ -224,7 +226,7 @@ class ConfigStore(object):
             )
         )
 
-    def query_updated(self, query=CacheQuery()):
+    def query_updated(self, query=None):
         """
         Return the last update timestamp of every configuration selected
         by the query.
@@ -232,6 +234,8 @@ class ConfigStore(object):
         @type query: CacheQuery
         @rtype: Iterable[Tuple[CacheKey, float]]
         """
+        if query is None:
+            query = CacheQuery()
         predicate = self._get_device_predicate(query.device)
         return (
             (key, ts)
@@ -272,13 +276,13 @@ class ConfigStore(object):
                 self._delete_statuses(pipe, svc, mon, dvc)
             pipe.execute()
 
-        devices = set(key.device for key in keys)
-        remaining = set(
+        devices = {key.device for key in keys}
+        remaining = {
             key.device
             for key in chain.from_iterable(
                 self._query(device=dvc) for dvc in devices
             )
-        )
+        }
         deleted = devices - remaining
         if deleted:
             self.__uids.delete(self.__client, *deleted)
@@ -430,13 +434,15 @@ class ConfigStore(object):
         uid = self.__uids.get(self.__client, key.device)
         return self._get_status_from_scores(scores, key, uid)
 
-    def query_statuses(self, query=CacheQuery()):
+    def query_statuses(self, query=None):
         """
         Return all status objects matching the query.
 
         @type query: CacheQuery
         @rtype: Iterable[ConfigStatus]
         """
+        if query is None:
+            query = CacheQuery()
         keys = set()
         uids = {}
         tables = (

--- a/Products/ZenCollector/configcache/handlers.py
+++ b/Products/ZenCollector/configcache/handlers.py
@@ -15,23 +15,22 @@ from .cache import CacheKey, CacheQuery, ConfigStatus
 
 
 class NewDeviceHandler(object):
-
     def __init__(self, log, store, dispatcher):
         self.log = log
         self.store = store
         self.dispatcher = dispatcher
 
     def __call__(self, deviceId, monitor, buildlimit, newDevice=True):
-        all_keys = set(
+        all_keys = {
             CacheKey(svcname, monitor, deviceId)
             for svcname in self.dispatcher.service_names
-        )
+        }
         query = CacheQuery(device=deviceId, monitor=monitor)
-        pending_keys = set(
+        pending_keys = {
             status.key
             for status in self.store.query_statuses(query)
             if isinstance(status, ConfigStatus.Pending)
-        )
+        }
         non_pending_keys = all_keys - pending_keys
         for key in pending_keys:
             self.log.info(
@@ -58,30 +57,39 @@ class NewDeviceHandler(object):
 
 
 class DeviceUpdateHandler(object):
-
     def __init__(self, log, store, dispatcher):
         self.log = log
         self.store = store
         self.dispatcher = dispatcher
 
     def __call__(self, keys, minttl):
-        current_statuses = tuple(
-            filter(None, (self.store.get_status(key) for key in keys))
+        statuses = tuple(
+            status
+            for status in (self.store.get_status(key) for key in keys)
+            if not isinstance(
+                status,
+                (
+                    # These statuses won't get 'stuck' in a wait period
+                    # before manager handles them.
+                    ConfigStatus.Expired,
+                    ConfigStatus.Retired,
+                ),
+            )
         )
 
         now = time.time()
         retirement = now - minttl
 
-        retired = set(
+        # Transitioning to Retired is relevant only for Current.
+        retired = {
             status.key
-            for status in current_statuses
-            if status.updated >= retirement
-        )
-        expired = set(
-            status.key
-            for status in current_statuses
-            if status.key not in retired
-        )
+            for status in statuses
+            if isinstance(status, ConfigStatus.Current)
+            and status.updated >= retirement
+        }
+        expired = {
+            status.key for status in statuses if status.key not in retired
+        }
 
         self.store.set_retired(*((key, now) for key in retired))
         self.store.set_expired(*((key, now) for key in expired))
@@ -105,7 +113,6 @@ class DeviceUpdateHandler(object):
 
 
 class MissingConfigsHandler(object):
-
     def __init__(self, log, store, dispatcher):
         self.log = log
         self.store = store
@@ -148,7 +155,6 @@ class MissingConfigsHandler(object):
 
 
 class RemoveConfigsHandler(object):
-
     def __init__(self, log, store):
         self.log = log
         self.store = store

--- a/Products/ZenCollector/configcache/tests/test_deviceupdatehandler.py
+++ b/Products/ZenCollector/configcache/tests/test_deviceupdatehandler.py
@@ -1,0 +1,166 @@
+
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2019, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import, print_function
+
+import logging
+
+from unittest import TestCase
+
+from mock import Mock, patch
+
+from ..cache import CacheKey, ConfigStatus
+from ..cache.storage import ConfigStore
+from ..dispatcher import BuildConfigTaskDispatcher
+from ..handlers import DeviceUpdateHandler
+
+
+PATH = {"src": "Products.ZenCollector.configcache.handlers"}
+
+
+class DeviceUpdateHandlerTest(TestCase):
+    """Test the DeviceUpdateHandler object."""
+
+    def setUp(t):
+        t.store = Mock(ConfigStore)
+        t.dispatcher = Mock(BuildConfigTaskDispatcher)
+        t.dispatcher.service_names = ("ServiceA", "ServiceB")
+        t.log = Mock(logging.getLogger("zen"))
+        t.handler = DeviceUpdateHandler(t.log, t.store, t.dispatcher)
+
+    def tearDown(t):
+        del t.handler
+        del t.log
+        del t.dispatcher
+        del t.store
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_current_to_expired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        updated1 = 33330.0
+        updated2 = 33331.0
+        now = 34000.0
+        _time.time.return_value = now
+
+        status1 = ConfigStatus.Current(key1, "/a/b/c1", updated1)
+        status2 = ConfigStatus.Current(key2, "/a/b/c2", updated2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 100.0)
+
+        t.store.set_retired.assert_called_with()
+        t.store.set_expired.assert_called_with((key2, now), (key1, now))
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_current_to_retired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        updated1 = 33330.0
+        updated2 = 33331.0
+        now = 34000.0
+        _time.time.return_value = now
+
+        status1 = ConfigStatus.Current(key1, "/a/b/c1", updated1)
+        status2 = ConfigStatus.Current(key2, "/a/b/c2", updated2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 1000.0)
+
+        t.store.set_retired.assert_called_with((key2, now), (key1, now))
+        t.store.set_expired.assert_called_with()
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_current_to_retired_and_expired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'd', 'c2')
+        updated1 = 33330.0
+        updated2 = 32331.0
+        now = 34000.0
+        _time.time.return_value = now
+
+        status1 = ConfigStatus.Current(key1, "/a/b/c1", updated1)
+        status2 = ConfigStatus.Current(key2, "/a/d/c2", updated2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 1000.0)
+
+        t.store.set_retired.assert_called_with((key1, now))
+        t.store.set_expired.assert_called_with((key2, now))
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_pending_to_expired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        updated1 = 33330.0
+        updated2 = 32331.0
+        now = 34000.0
+        _time.time.return_value = now
+
+        status1 = ConfigStatus.Pending(key1, "/a/b/c1", updated1)
+        status2 = ConfigStatus.Pending(key2, "/a/b/c2", updated2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 1000.0)
+
+        t.store.set_retired.assert_called_with()
+        t.store.set_expired.assert_called_with((key2, now), (key1, now))
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_only_expired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        expired1 = 33330.0
+        expired2 = 33331.0
+        _time.time.return_value = 34000.0
+
+        status1 = ConfigStatus.Expired(key1, "/a/b/c1", expired1)
+        status2 = ConfigStatus.Expired(key2, "/a/b/c2", expired2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 100.0)
+
+        t.store.set_retired.assert_called_with()
+        t.store.set_expired.assert_called_with()
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_only_retired(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        expired1 = 33330.0
+        expired2 = 33331.0
+        _time.time.return_value = 34000.0
+
+        status1 = ConfigStatus.Retired(key1, "/a/b/c1", expired1)
+        status2 = ConfigStatus.Retired(key2, "/a/b/c2", expired2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 1000.0)
+
+        t.store.set_retired.assert_called_with()
+        t.store.set_expired.assert_called_with()
+
+    @patch("{src}.time".format(**PATH), autospec=True)
+    def test_only_building(t, _time):
+        key1 = CacheKey('a', 'b', 'c1')
+        key2 = CacheKey('a', 'b', 'c2')
+        expired1 = 33330.0
+        expired2 = 33331.0
+        _time.time.return_value = 34000.0
+        now = 34000.0
+
+        status1 = ConfigStatus.Building(key1, "/a/b/c1", expired1)
+        status2 = ConfigStatus.Building(key2, "/a/b/c2", expired2)
+        t.store.get_status.side_effect = (status1, status2)
+
+        t.handler((key1, key2), 1000.0)
+
+        t.store.set_retired.assert_called_with()
+        t.store.set_expired.assert_called_with((key2, now), (key1, now))


### PR DESCRIPTION
The DeviceUpdateHandler now considers the current status when expiring or retiring a config.

ZEN-34962