### PR TITLE
Save the zenjobs metrics to the current service.

### DIFF
--- a/Products/Jobber/monitor/broker.py
+++ b/Products/Jobber/monitor/broker.py
@@ -13,9 +13,10 @@ import requests
 
 from six.moves.urllib.parse import urlparse, urljoin, quote_plus, unquote
 
+from .logger import getLogger
+
 
 class Broker(object):
-
     def __new__(cls, broker_url):
         scheme = urlparse(broker_url).scheme
         if scheme == "amqp":
@@ -42,13 +43,34 @@ class RabbitMQ(object):
             host=self._host,
             port=self._port,
         )
+        self._log = getLogger(self)
 
     def queues(self, names):
         if not names:
             return ()
+        attempts = 1
+        timeout = 1.0
         url = urljoin(self._http_api, "queues/" + self._vhost)
         params = {"columns": ",".join(["name", "messages"])}
-        r = requests.get(url, params=params, timeout=1.0)
+        while True:
+            try:
+                r = requests.get(url, params=params, timeout=timeout)
+            except requests.Timeout:
+                if attempts < 3:
+                    attempts += 1
+                    timeout *= 2
+                else:
+                    self._log.warning(
+                        "timed out requesting data from RabbitMQ"
+                    )
+                    return ()
+            except Exception:
+                self._log.exception(
+                    "unexpected error while requesting data from RabbitMQ"
+                )
+            else:
+                break
+
         if r.status_code != 200:
             r.raise_for_status()
         return tuple(q for q in r.json() if q["name"] in names)

--- a/Products/Jobber/monitor/reporter.py
+++ b/Products/Jobber/monitor/reporter.py
@@ -63,14 +63,7 @@ class MetricsReporter(object):
             self._log.debug("%s metrics posted", len(metrics))
 
     def build_metric(self, **kw):
-        metric = Metric(**kw)
-        metric.tags.update(
-            {
-                "tenantId": cc_config.tenant_id,
-                "serviceId": metric.tags["controlplane_service_id"],
-            }
-        )
-        return metric
+        return Metric(**kw)
 
 
 class _Session(object):
@@ -101,5 +94,7 @@ class Metric(object):
 
     @tags.validator
     def _verify_keys(self, attribute, value):
-        if "controlplane_service_id" not in value:
-            raise KeyError("Missing 'controlplane_service_id' tag")
+        if "serviceId" not in value:
+            raise KeyError("Missing 'serviceId' tag")
+        if "tenantId" not in value:
+            raise KeyError("Missing 'tenantId' tag")


### PR DESCRIPTION
Refactored thread locking for metric updates to ensure all metrics are updated together for each Celery event.

Added more logging to identify missing data or issues related to retrieving metric data.

ZEN-34974