### PR TITLE
Specified no handlers for zenjobs-monitor's root logger.

### DIFF
--- a/Products/Jobber/monitor/logger.py
+++ b/Products/Jobber/monitor/logger.py
@@ -67,4 +67,7 @@ _logging_config = {
             "level": "INFO",
         },
     },
+    "root": {
+        "handlers": [],
+    },
 }


### PR DESCRIPTION
ZEN-34978