### PR TITLE
ZEN-35026:ZEN-34707 Fix error in event log for GCP device

### DIFF
--- a/Products/ZenUtils/MetricServiceRequest.py
+++ b/Products/ZenUtils/MetricServiceRequest.py
@@ -67,7 +67,6 @@ class MetricServiceRequest(object):
             metrics.append(dict(
                 metric=name,
                 aggregator=self._aggMapping.get(cf.lower(), cf.lower()),
-                rpn='',
                 rate=rate,
                 format='%.2lf',
                 tags=dict(contextUUID=[uuid]),
@@ -100,7 +99,6 @@ class MetricServiceRequest(object):
         for metric in metrics:
             log.debug("fetchMetrics metrics %s", metric)
             cf = metric.get('cf', 'average')
-            rpn = metric.get('rpn', '')
             rate = metric.get('rate', False)
             tags = metric['tags']
             downsample = metric.get('downsample', '5m-avg')
@@ -109,11 +107,9 @@ class MetricServiceRequest(object):
                 metric=metricName,
                 downsample=downsample,
                 aggregator=self._aggMapping.get(cf.lower(), cf.lower()),
-                rpn=rpn,
                 rate=rate,
                 format='%.2lf',
-                tags=tags,
-                name=metricName
+                tags=tags
             ))
 
         request = dict(

--- a/Products/Zuul/facades/metricfacade.py
+++ b/Products/Zuul/facades/metricfacade.py
@@ -634,7 +634,6 @@ class MetricFacade(ZuulFacade):
             format=format,
             tags={"contextUUID": ["*"]},
             rate=isRate,
-            name=device.getResourceKey() + metricName,
         )
         return metric
 


### PR DESCRIPTION
Fixes ZEN-35026.

An error 'Response from the server (return code 400): Unrecognized field "format" generated in the event log for GCP device