### PR TITLE
ZEN-35025:ZEN-34693 Fix error in zenpython log

### DIFF
--- a/Products/ZenUtils/MetricServiceRequest.py
+++ b/Products/ZenUtils/MetricServiceRequest.py
@@ -116,7 +116,6 @@ class MetricServiceRequest(object):
             returnset=returnSet,
             start=start,
             end=end,
-            downsample=downsample,
             queries=metricQueries
         )
         body = FileBodyProducer(StringIO(json.dumps(request)))


### PR DESCRIPTION
Fixes ZEN-35025.

Warning 'Received response 400 from Central Query' is generated in zenpython log