### PR TITLE
Delete the config when the device ID is not found.

### DIFF
--- a/Products/ZenCollector/configcache/tests/test_build_device_config.py
+++ b/Products/ZenCollector/configcache/tests/test_build_device_config.py
@@ -14,8 +14,9 @@ import mock
 from unittest import TestCase
 
 from Products.Jobber.tests.utils import RedisLayer
+from Products.ZenCollector.services.config import DeviceProxy
 
-from ..cache import DeviceKey
+from ..cache import DeviceKey, DeviceRecord
 from ..cache.storage import DeviceConfigStore
 from ..tasks.deviceconfig import buildDeviceConfig
 
@@ -26,7 +27,6 @@ PATH = {
 
 
 class TestBuildDeviceConfig(TestCase):
-
     layer = RedisLayer
 
     def setUp(t):
@@ -80,6 +80,44 @@ class TestBuildDeviceConfig(TestCase):
         dmd = mock.Mock()
         log = mock.Mock()
         key = DeviceKey(svcname, monitor, t.device_name)
+
+        _createObject.return_value = t.store
+        _resolve.return_value = svcclass
+        svcclass.return_value = svc
+        dmd.Devices.findDeviceByIdExact.return_value = None
+
+        t.store.set_pending((key, submitted))
+
+        buildDeviceConfig(dmd, log, monitor, t.device_name, clsname, submitted)
+
+        status = t.store.get_status(key)
+        t.assertIsNone(status)
+
+    @mock.patch("{task}.createObject".format(**PATH), autospec=True)
+    @mock.patch("{task}.resolve".format(**PATH), autospec=True)
+    def test_device_reidentified(t, _resolve, _createObject):
+        # A 're-identified' device will no longer be found in ZODB under its
+        # old ID, but a config keyed for the old ID will still exist.
+        monitor = "localhost"
+        clsname = "Products.ZenHub.services.PingService.PingService"
+        svcname = clsname.rsplit(".", 1)[0]
+        proxy = DeviceProxy()
+        submitted = 123456.34
+        record = DeviceRecord.make(
+            svcname,
+            monitor,
+            t.device_name,
+            t.device_uid,
+            submitted - 300,
+            proxy,
+        )
+        key = record.key
+        t.store.add(record)
+
+        svcclass = mock.Mock()
+        svc = mock.MagicMock()
+        dmd = mock.Mock()
+        log = mock.Mock()
 
         _createObject.return_value = t.store
         _resolve.return_value = svcclass


### PR DESCRIPTION
The build_device_config job will now delete the device configuration for any device not found in ZODB.

ZEN-34818