### PR TITLE
Hardened the API regarding SNMP v3 users.

### DIFF
--- a/Products/DataCollector/SnmpClient.py
+++ b/Products/DataCollector/SnmpClient.py
@@ -102,8 +102,8 @@ class SnmpClient(BaseClient):
                 result = False
             else:
                 device.setLastPollSnmpUpTime(lastchange)
-        except Exception:
-            pass
+        except Exception as ex:
+            log.debug("failed to check Cisco change: %s", ex)
         yield defer.succeed(result)
 
     def doRun(self, driver):

--- a/Products/ZenHub/services/PerformanceConfig.py
+++ b/Products/ZenHub/services/PerformanceConfig.py
@@ -114,12 +114,14 @@ class SnmpConnInfo(pb.Copyable, pb.RemoteCopy):
     def createSession(self, protocol=None):
         """Create a session based on the properties"""
         if "3" in self.zSnmpVer:
-            auth = self._get_auth()
-            priv = self._get_priv()
             sec = security.UsmUser(
                 self.zSnmpSecurityName,
-                auth=auth,
-                priv=priv,
+                auth=security.Authentication(
+                    self.zSnmpAuthType, self.zSnmpAuthPassword
+                ),
+                priv=security.Privacy(
+                    self.zSnmpPrivType, self.zSnmpPrivPassword
+                ),
                 engine=self.zSnmpEngineId,
                 context=self.zSnmpContext,
             )
@@ -137,24 +139,6 @@ class SnmpConnInfo(pb.Copyable, pb.RemoteCopy):
         )
         p.snmpConnInfo = self
         return p
-
-    def _get_auth(self):
-        if self.zSnmpAuthType:
-            try:
-                return security.Authentication(
-                    self.zSnmpAuthType, self.zSnmpAuthPassword
-                )
-            except ValueError as ex:
-                log.error("error in SNMP authentication config: %s", ex)
-
-    def _get_priv(self):
-        if self.zSnmpPrivType:
-            try:
-                return security.Privacy(
-                    self.zSnmpPrivType, self.zSnmpPrivPassword
-                )
-            except ValueError as ex:
-                log.error("error in SNMP privacy config: %s", ex)
 
     def __repr__(self):
         return "<%s for %s>" % (self.__class__, self.id)

--- a/Products/ZenRRD/zenperfsnmp.py
+++ b/Products/ZenRRD/zenperfsnmp.py
@@ -827,10 +827,24 @@ class SnmpPerformanceCollectionTask(BaseTask):
             self._snmpProxy is None
             or self._snmpProxy._snmpConnInfo != self._snmpConnInfo
         ):
-            self._snmpProxy = self._snmpConnInfo.createSession(
-                protocol=self._snmpPort.protocol
-            )
-            self._snmpProxy.open()
+            try:
+                self._snmpProxy = self._snmpConnInfo.createSession(
+                    protocol=self._snmpPort.protocol
+                )
+                self._snmpProxy.open()
+                self._sendStatusEvent(
+                    "SNMP config error cleared",
+                    eventKey="snmp_config_error",
+                    severity=Event.Clear,
+                )
+            except Exception as ex:
+                self._snmpProxy = None
+                log.error("failed to create SNMP session: %s", ex)
+                self._sendStatusEvent(
+                    "SNMP config error: {}".format(ex),
+                    eventKey="snmp_config_error",
+                )
+                raise
         return self._snmpProxy
 
     def _close(self):


### PR DESCRIPTION
SNMP v3 users now always require a passphrase if a protocol is specified.  The Privacy protocol/passphrase is ignored if no Authentication protocol/passphrase is specified.  The Authentication protocol/passphrase is ignored if no security user is specified.

ZEN-35108