### PR TITLE
ZEN-33550 Improve relationship management of IpAddress objects

### DIFF
--- a/Products/ZenModel/IpAddress.py
+++ b/Products/ZenModel/IpAddress.py
@@ -104,6 +104,11 @@ class IpAddress(ManagedEntity, IpAddressIndexable):
         self.title = ipunwrap(id)
         self.version = ipobj.version
 
+    def _pre_remove(self):
+        self.manageDevice.removeRelation()
+        self.interface.removeRelation()
+        self.clientroutes.removeRelation()
+
     def setPtrName(self):
         try:
             data = socket.gethostbyaddr(ipunwrap(self.id))
@@ -284,6 +289,8 @@ class IpAddress(ManagedEntity, IpAddressIndexable):
         peers = []
         if self.device():
             peers.append(self.device().primaryAq())
+        if self.manageDevice():
+            peers.append(self.manageDevice().primaryAq())
         if self.interface():
             peers.append(self.interface().primaryAq())
         return peers

--- a/Products/ZenModel/IpInterface.py
+++ b/Products/ZenModel/IpInterface.py
@@ -207,6 +207,11 @@ class IpInterface(OSComponent, IpInterfaceIndexable):
                 notify(IndexingEvent(device, idxs=('macAddresses',), update_metadata=False))
             except KeyError:
                 pass
+            if device._operation != 1:
+                if self.ipaddresses():
+                    self.ipaddresses.removeRelation()
+                if self.iproutes():
+                    self.iproutes.removeRelation()
 
     def object_added_handler(self):
         self._update_device_macs(self.device(), self.macaddress)

--- a/Products/ZenModel/IpNetwork.py
+++ b/Products/ZenModel/IpNetwork.py
@@ -653,6 +653,12 @@ class IpNetwork(DeviceOrganizer, IpNetworkIndexable):
                 lambda n: isinstance(n, IpAddress) and n.interface(), netobj.getSubObjects())
             for i in ips:
                 i.interface().ipaddresses._setObject(i.id, i)
+            mips = filter(
+                lambda n: isinstance(n, IpAddress) and n.manageDevice(),
+                netobj.getSubObjects(),
+            )
+            for i in mips:
+                i.manageDevice().ipaddress.addRelation(i)
 
         return self.getSubNetwork(ip)
 

--- a/Products/ZenModel/IpRouteEntry.py
+++ b/Products/ZenModel/IpRouteEntry.py
@@ -22,6 +22,8 @@ from AccessControl import ClassSecurityInfo
 from Products.ZenUtils.Utils import localIpCheck, prepId
 from Products.ZenRelations.RelSchema import *
 
+from Products.ZenModel.interfaces import IObjectEventsSubscriber
+from zope.interface import implements
 
 from OSComponent import OSComponent
 
@@ -61,6 +63,8 @@ class IpRouteEntry(OSComponent):
     """
     IpRouteEntry object
     """
+
+    implements(IObjectEventsSubscriber)
     
     meta_type = 'IpRouteEntry'
 
@@ -106,6 +110,16 @@ class IpRouteEntry(OSComponent):
     security = ClassSecurityInfo()
 
     ipcheck = re.compile(r'^127\.|^0\.0\.|^169\.254\.|^224\.|^::1$|^fe80:|^ff').search
+
+    def before_object_deleted_handler(self):
+        device = self.device()
+        if device and device._operation != 1:
+            if self.interface():
+                self.interface.removeRelation()
+            if self.nexthop():
+                self.nexthop.removeRelation()
+            if self.target():
+                self.target.removeRelation()
     
     def __getattr__(self, name):
         """

--- a/Products/ZenModel/tests/testIpAddress.py
+++ b/Products/ZenModel/tests/testIpAddress.py
@@ -28,6 +28,8 @@ class TestIpAddress(ZenModelBaseTest):
     def afterSetUp(self):
         super(TestIpAddress, self).afterSetUp()
         self.dev = self.dmd.Devices.createInstance("testdev")
+        self.dev.setManageIp('2.3.4.5')
+        self.maddr = self.dev.ipaddress().primaryAq()
         tmpIface = IpInterface('test')
         self.dev.os.interfaces._setObject('test',tmpIface)
         self.iface = self.dev.getDeviceComponents()[0]
@@ -46,6 +48,15 @@ class TestIpAddress(ZenModelBaseTest):
     def testSetNetmask(self):
         self.addr.setNetmask(8)
         self.assert_(self.addr.getIpAddress() == '1.2.3.4/8')
+
+
+    def testDeviceDelete(self):
+        maddrPath = self.maddr.getPrimaryId()
+        addrPath = self.addr.getPrimaryId()
+        self.dev.deleteDevice()
+        self.assert_(self.maddr.manageDevice() is None)
+        self.assert_(self.addr.interface() is None)
+
 
 #    def testSetIpAddress(self):
 #        self.addr.setIpAddress('2.3.4.5/16')

--- a/Products/Zuul/facades/networkfacade.py
+++ b/Products/Zuul/facades/networkfacade.py
@@ -214,11 +214,12 @@ class NetworkFacade(TreeFacade):
         errorCount = 0
         for uid in uids:
             ip = self._getObject(uid)
-            # there is an interface do not delete it
-            if ip.interface():
+            # there is an interface or manageDevice do not delete it
+            if ip.interface() or ip.manageDevice():
                 errorCount += 1
                 continue
             # remove it from the relationship
+            ip._pre_remove()
             parent = aq_parent(ip)
             parent._delObject(ip.id)
             removeCount += 1


### PR DESCRIPTION
Ensure devices and ipaddress objects clean up their respective relations upon deletion. On subnetwork move, update rels on ipaddresses used by manageIp. Don't remove relations when moving a device. Add a unit test.