### PR TITLE
Change IpRoutesParser regex to respect new netstat output

### DIFF
--- a/Products/DataCollector/plugins/zenoss/cmd/linux/netstat_rn.py
+++ b/Products/DataCollector/plugins/zenoss/cmd/linux/netstat_rn.py
@@ -29,9 +29,9 @@ IP_GATEWAY_PROTO = re.compile(r"proto (\S+)")
 # 10.111.23.0/24 dev eth0  proto kernel  scope link  src 10.111.23.72
 #          192.168.99.0/24 dev eth0  scope link
 IP_ROUTE_RECORD = re.compile(
-    r"^(\S+)\s+dev\s+(\S+)\s+proto\s+(\S+)\s+scope\s+link\s+"
+    r"^(\S+/\d+)\s+dev\s+(\S+)\s+proto\s+(\S+)\s+scope\s+link\s+"
 )
-IP_ROUTE_RECORD_SHORT = re.compile(r"^(\S+)\s+dev\s+(\S+)\s+scope\s+link\s+")
+IP_ROUTE_RECORD_SHORT = re.compile(r"^(\S+/\d+)\s+dev\s+(\S+)\s+scope\s+link\s+")
 
 
 class BaseParser(object):


### PR DESCRIPTION
Fixes ZEN-35186.

The netstat output for Ubuntu 20/22 omits the netmask if the netmask value is /32 or 255.255.255.255.
The IpRoutesParser omits the IP routes with such a mask.
The regex has been changed to match only the routes with the following pattern <ip_address/netmask>.