### PR TITLE
Fixes ZEN-35223

### DIFF
--- a/Products/ZenUtils/patches/zodbpackmonkey.py
+++ b/Products/ZenUtils/patches/zodbpackmonkey.py
@@ -107,6 +107,13 @@ class ZodbPackMonkeyHelper(object):
         count = cursor.executemany(sql, batch)
         return count
 
+    def delete_orphaned_references(self, cursor, batch):
+        """ Deletes identified orphaned references. """
+        sql = """DELETE FROM {0} WHERE zoid = %s AND to_zoid = %s AND tid = %s""".format(self.REF_TABLE_NAME)
+        count = cursor.executemany(sql, batch)
+
+        return count
+
     def log_exception(self, e, info=''):
         log.error("Monkey patch for zodbpack raised and exception: %s: %s", info, e)
 
@@ -130,9 +137,30 @@ class ZodbPackMonkeyHelper(object):
         Returns all references where oid is in zoid or to_zoid
         """
         values = ','.join(str(zoid) for zoid, tid in batch)
-        sql = """ SELECT zoid, to_zoid FROM {0} WHERE zoid!=to_zoid AND (zoid IN ({1}) OR to_zoid IN ({1}))""".format(self.REF_TABLE_NAME, values)
+        sql = """ SELECT {0}.zoid, {0}.to_zoid FROM {0}
+            LEFT JOIN object_state on object_ref.zoid = object_state.zoid
+            WHERE object_state.zoid is NOT NULL
+            AND {0}.zoid!={0}.to_zoid
+            AND ({0}.zoid IN ({1}) OR {0}.to_zoid IN ({1}))""".format(self.REF_TABLE_NAME, values)
         cursor.execute(sql)
         result = cursor.fetchall()
+
+        return result
+
+    def _get_orphaned_references(self, cursor):
+        """
+        Returns all orphaned references in object_ref where zoid and to_zoid
+        do not have corresponding entries in object_state.
+        """
+        sql = """ SELECT {0}.zoid, {0}.to_zoid, {0}.tid from {0}
+        LEFT JOIN object_state as container ON {0}.zoid = container.zoid
+        LEFT JOIN object_state as contained ON {0}.to_zoid = contained.zoid
+        WHERE container.zoid IS NULL OR contained.zoid IS NULL;
+        """.format(self.REF_TABLE_NAME)
+
+        cursor.execute(sql)
+        result = cursor.fetchall()
+
         return result
 
     def _get_oid_references(self, cursor, oids):
@@ -386,6 +414,17 @@ try:
         store_connection = PrePackConnection(self.connmanager)
         try:
             try:
+                log.info("Searching for orphaned references.")
+                orphaned_references = MONKEY_HELPER._get_orphaned_references(store_connection.cursor)
+
+                if orphaned_references:
+                    deleted_orphaned_references = MONKEY_HELPER.delete_orphaned_references(store_connection.cursor, orphaned_references)
+                    msg = "Removed %d orphaned references"
+                else:
+                    deleted_orphaned_references = 0
+                    msg = "Identified %d orphaned references"
+
+                log.info(msg, deleted_orphaned_references)
                 self._pre_pack_main(load_connection, store_connection, pack_tid, get_references)
             except Exception:
                 log.exception("pre_pack: failed")

--- a/Products/ZenUtils/patches/zodbpackmonkey.py
+++ b/Products/ZenUtils/patches/zodbpackmonkey.py
@@ -109,8 +109,10 @@ class ZodbPackMonkeyHelper(object):
 
     def delete_orphaned_references(self, cursor, batch):
         """ Deletes identified orphaned references. """
-        sql = """DELETE FROM {0} WHERE zoid = %s AND to_zoid = %s AND tid = %s
-            """.format(self.REF_TABLE_NAME)
+        sql = """DELETE FROM {0}
+            WHERE zoid = %s
+            AND to_zoid = %s
+            AND tid = %s""".format(self.REF_TABLE_NAME)
         count = cursor.executemany(sql, batch)
 
         return count


### PR DESCRIPTION
Added methods to identify and remove orphaned references in ZODB.object_ref that were causing zenossdbpack to fail to remove oid groups.