### PR TITLE
Fixes ZEN-34753

### DIFF
--- a/src/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
+++ b/src/Products/ZenUI3/browser/resources/js/zenoss/eventclasses/ClassPanels.js
@@ -292,8 +292,8 @@ Ext.onReady(function(){
                                             name: 'eventclasskey',
                                             margin: '0 40px 0 0',
                                             fieldLabel: _t('Event Class Key'),
-                                            regex: Zenoss.env.textMasks.allowedNameTextDashDot,
-                                            regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDashDot,
+                                            regex: Zenoss.env.textMasks.allowedNameTextDashDotPipeComma,
+                                            regexText: Zenoss.env.textMasks.allowedNameTextFeedbackDashDotPipeComma,
                                             width:320
                                         }
                                     ]

--- a/src/Products/ZenUI3/browser/resources/js/zenoss/zenoss.js
+++ b/src/Products/ZenUI3/browser/resources/js/zenoss/zenoss.js
@@ -203,6 +203,8 @@ Zenoss.env.textMasks = {
         allowedNameTextFeedbackDash: 'Only letters, numbers, underscores, dashes and spaces allowed',
         allowedNameTextDashDot: /^[\w\s\-\.]+$/,
         allowedNameTextFeedbackDashDot: 'Only letters, numbers, underscores, dashes, periods, and spaces allowed',
+        allowedNameTextDashDotPipeComma: /^[\w\s\-\.\|\,]+$/,
+        allowedNameTextFeedbackDashDotPipeComma: 'Only letters, numbers, underscores, dashes, periods, pipes, commas, and spaces allowed',
         allowedDescTextMask: /[\w\?,\s\.\-]/i,
         allowedDescText: /^[\w\?,\s\.\-]+$/,
         allowedDescTextFeedback: 'Allowed text: . - ? spaces, letters and numbers only'


### PR DESCRIPTION
Created two new entries in Zenoss.env.textMasks in zenoss.js:

 - allowedNameTextDashDotPipeComma
 - allowedNameTextFeedbackDashDotPipeComma

Updated ClassPanels.js to use the above entries for the Event Class Key textfield.