### PR TITLE
ConfigCache Manager now removes invalid configs.

### DIFF
--- a/src/Products/ZenCollector/configcache/dispatcher.py
+++ b/src/Products/ZenCollector/configcache/dispatcher.py
@@ -9,6 +9,7 @@
 
 from __future__ import absolute_import
 
+from .errors import UnknownServiceError
 from .tasks import build_device_config, build_oidmap
 
 
@@ -57,7 +58,9 @@ class DeviceConfigTaskDispatcher(object):
         """
         name = self._classnames.get(servicename)
         if name is None:
-            raise ValueError("service name '%s' not found" % servicename)
+            raise UnknownServiceError(
+                "service name '%s' not found" % servicename
+            )
         soft_limit, hard_limit = _get_limits(timeout)
         build_device_config.apply_async(
             args=(monitorid, deviceid, name),

--- a/src/Products/ZenCollector/configcache/errors.py
+++ b/src/Products/ZenCollector/configcache/errors.py
@@ -1,0 +1,14 @@
+##############################################################################
+#
+# Copyright (C) Zenoss, Inc. 2025, all rights reserved.
+#
+# This content is made available according to terms specified in
+# License.zenoss under the directory where your Zenoss product is installed.
+#
+##############################################################################
+
+from __future__ import absolute_import
+
+
+class UnknownServiceError(RuntimeError):
+    """Raised when an unknown configuration service is requested."""

--- a/src/Products/ZenCollector/configcache/tasks/deviceconfig.py
+++ b/src/Products/ZenCollector/configcache/tasks/deviceconfig.py
@@ -90,7 +90,6 @@ def build_device_config(
 def buildDeviceConfig(
     dmd, log, monitorname, deviceid, configclassname, submitted
 ):
-    svcconfigclass = resolve(configclassname)
     svcname = configclassname.rsplit(".", 1)[0]
     store = _getStore()
     key = DeviceKey(svcname, monitorname, deviceid)
@@ -157,6 +156,13 @@ def buildDeviceConfig(
         monitorname,
         svcname,
     )
+
+    try:
+        svcconfigclass = resolve(configclassname)
+    except Exception:
+        log.warn("could not load config service  service=%s", configclassname)
+        _delete_config(key, store, log)
+        return
 
     service = svcconfigclass(dmd, monitorname)
     method = getattr(service, "remote_getDeviceConfigs", None)

--- a/src/Products/ZenCollector/configcache/tests/test_dispatcher.py
+++ b/src/Products/ZenCollector/configcache/tests/test_dispatcher.py
@@ -13,7 +13,11 @@ from unittest import TestCase
 
 from mock import call, patch
 
-from ..dispatcher import DeviceConfigTaskDispatcher, build_device_config
+from ..dispatcher import (
+    DeviceConfigTaskDispatcher,
+    build_device_config,
+    UnknownServiceError,
+)
 
 
 PATH = {"src": "Products.ZenCollector.configcache.dispatcher"}
@@ -85,5 +89,5 @@ class DeviceConfigTaskDispatcherTest(TestCase):
         device = "linux"
         submitted = 1111.0
 
-        with t.assertRaises(ValueError):
+        with t.assertRaises(UnknownServiceError):
             t.bctd.dispatch("unknown", monitor, device, timeout, submitted)


### PR DESCRIPTION
An invalid config is associated with a service config class that does not inherit from the CollectorConfigService class.

ZEN-35251