### PR TITLE
Use writeStatistics for eventQueueLength metric updates.

### DIFF
--- a/src/Products/ZenHub/PBDaemon.py
+++ b/src/Products/ZenHub/PBDaemon.py
@@ -448,7 +448,9 @@ class PBDaemon(ZenDaemon, pb.Referenceable):
         )
         self.__eventclient.start()
         self.__eventclient.sendEvent(self.startEvent)
-        self.__recordQueuedEventsCountLoop.start(2.0, now=False)
+        self.__recordQueuedEventsCountLoop.start(
+            self.options.writeStatistics, now=False
+        )
         self.log.info("started event client")
 
     def _start_internal_metrics_task(self):

--- a/src/Products/ZenUtils/MetricReporter.py
+++ b/src/Products/ZenUtils/MetricReporter.py
@@ -94,15 +94,14 @@ class MetricReporter(Reporter):
 
 class TwistedMetricReporter(object):
     def __init__(
-        self, interval=30, metricWriter=None, tags={}, *args, **options
+        self, interval=30, metricWriter=None, tags=None, *args, **options
     ):
         super(TwistedMetricReporter, self).__init__()
         self.registry = options.get("registry", registry)
         self.prefix = options.get("prefix", "")
         self.metricWriter = metricWriter
         self.interval = interval
-        self.tags = {}
-        self.tags.update(tags)
+        self.tags = dict(tags) if tags else {}
         self._stopped = False
         self._loop = task.LoopingCall(self.postMetrics)
 
@@ -234,7 +233,8 @@ def _log_queue_gauge(name, metric, tags, prefix):
     whole_metric_name = "{}.value".format(metric_name)
     try:
         while metric.queue:
-            # each stat should be a tuple with 1 more member than metric.tagKeys
+            # Each stat should be a tuple with 1 more member
+            # than metric.tagKeys
             stat = metric.queue.pop()
             qtags = tags.copy()
             qtags.update(izip(metric.tagKeys, stat))


### PR DESCRIPTION
Changed the eventQueueLength metric post interval from 2 seconds to the value specified by the 'writeStatistics' configuration option.

ZEN-35254