### PR TITLE
Replace the 'zendb' entry point with a script.

### DIFF
--- a/bin/zendb
+++ b/bin/zendb
@@ -1,0 +1,6 @@
+#!/opt/zenoss/bin/python2
+import sys
+from Products.ZenUtils.ZenDB import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ scripts =
 	bin/zenactiond
 	bin/zenbincheck
 	bin/zencommand
+	bin/zendb
 	bin/zendisc
 	bin/zendoc_base
 	bin/zendoc_zenpack
@@ -89,7 +90,6 @@ console_scripts =
 	zenchkrels = Products.ZenUtils.CheckRelations:main
 	zenchkschema = Products.ZenRelations.checkrel:main
 	zencyberark = Products.ZenCollector.zencyberark:main
-	zendb = Products.ZenUtils.ZenDB:main
 	zendmd = Products.ZenModel.zendmd:main
 	zendump = Products.ZenRelations.ExportRM:main
 	zenjobs = Products.Jobber.bin:main


### PR DESCRIPTION
Replaces the use of Python with the mysql client to improve mariadb_healthcheck performance.

ZEN-35281