### PR TITLE
ZEN-35051: remove close_fds from subprocessjob

### DIFF
--- a/src/Products/Jobber/jobs/subprocess.py
+++ b/src/Products/Jobber/jobs/subprocess.py
@@ -66,7 +66,6 @@ class SubprocessJob(Job):
                     cmd,
                     bufsize=1,
                     env=environ,
-                    close_fds=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                 )


### PR DESCRIPTION
in RHEL-like 9.x OS versions, setting close_fds=True causes the fork/exec to hang in a loop of trying to write to closed file descriptors for 10-20 minutes before it succeeds (from processes with threads or that are busy enough to have GC happening, couldn't reproduce in zendmd)